### PR TITLE
Moves drush back [Do not merge until ACE 1.91 release]

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -10,6 +10,7 @@
   ],
   "require": {
     "composer/installers": "^1.0.20",
+    "drush/drush":"dev-master",
     "drupal/acquia_connector": "8.1.*",
     "drupal/acsf": "~8.1",
     "drupal/core": "~8",
@@ -27,7 +28,6 @@
     "behat/mink-goutte-driver":     "*",
     "behat/mink-selenium2-driver":  "*",
     "behat/mink-browserkit-driver": "*",
-    "drush/drush":                  "dev-master",
     "drupal/drupal-extension":      "~3.0",
     "drupal/coder":                 "~8.2",
     "phpunit/phpunit":              "4.6.*",


### PR DESCRIPTION
The issue here is that ACE has a block on using a vendor'ed drush. 

Once ACE 1.91 goes out we can move this back for best practices.

(Unless its not a best practice anymore)