### PR TITLE
Support ACSF vanity domains.

### DIFF
--- a/template/drush/site-aliases/example.acsf.aliases.drushrc.php
+++ b/template/drush/site-aliases/example.acsf.aliases.drushrc.php
@@ -6,7 +6,20 @@
 // Acquia Cloud Site Factory id.
 $site_id = '[PROJECT-NAME]';
 
-// List of sites. For each site, one record should be added.
+/**
+ * List of sites. For each site, one record should be added.
+ * Optionally, you can also list vanity domains for each site.
+ *
+ * @code
+ * $sites = array(
+ *   'demo' => array(
+ *     'dev' => 'dev.demo.example.com',
+ *     'test' => 'test.demo.example.com',
+ *     'prod' => 'demo.example.com',
+ *   ),
+ * );
+ * @endcode
+ */
 $sites = array(
   'demo',
 );
@@ -18,28 +31,25 @@ $prod_web = 'web-###';
 $dev_web = 'staging-###';
 
 // =======================END OF CONFIGURATION==============================.
-
 if ($site_id !== '[PROJECT-NAME]') {
-
   // Acquia Cloud Site Factory environment settings.
-  $acsf_prod = array(
-    'remote-user' => $site_id . '.01live',
-    'root' => '/var/www/html/' . $site_id . '.01live/docroot',
-    'remote-host' => $prod_web . '.enterprise-g1.hosting.acquia.com',
+  $envs = array(
+    'prod' => array(
+      'remote-user' => $site_id . '.01live',
+      'root' => '/var/www/html/' . $site_id . '.01live/docroot',
+      'remote-host' => $prod_web . '.enterprise-g1.hosting.acquia.com',
+    ),
+    'test' => array(
+      'remote-user' => $site_id . '.01test',
+      'root' => '/var/www/html/' . $site_id . '.01test/docroot',
+      'remote-host' => $dev_web . '.enterprise-g1.hosting.acquia.com',
+    ),
+    'dev' => array(
+      'remote-user' => $site_id . '.01dev',
+      'root' => '/var/www/html/' . $site_id . '.01dev/docroot',
+      'remote-host' => $dev_web . '.enterprise-g1.hosting.acquia.com',
+    ),
   );
-
-  $acsf_stage = array(
-    'remote-user' => $site_id . '.01test',
-    'root' => '/var/www/html/' . $site_id . '.01test/docroot',
-    'remote-host' => $dev_web . '.enterprise-g1.hosting.acquia.com',
-  );
-
-  $acsf_dev = array(
-    'remote-user' => $site_id . '.01dev',
-    'root' => '/var/www/html/' . $site_id . '.01dev/docroot',
-    'remote-host' => $dev_web . '.enterprise-g1.hosting.acquia.com',
-  );
-
   // These defaults connect to the Acquia Cloud Site Factory.
   $acsf_defaults = array(
     'ssh-options' => '-p 22',
@@ -47,31 +57,26 @@ if ($site_id !== '[PROJECT-NAME]') {
       '%dump-dir' => '/mnt/tmp/'
     )
   );
-
   // Create the aliases using the defaults and the list of sites.
-  foreach ($sites as $site) {
-    $aliases[$site . '.dev'] = array_merge(
-      $acsf_defaults,
-      $acsf_dev,
-      array(
-        'uri' => $site . '.dev-' . $site_id . '.acsitefactory.com',
-      )
-    );
-
-    $aliases[$site . '.stage'] = array_merge(
-      $acsf_defaults,
-      $acsf_dev,
-      array(
-        'uri' => $site . '.test-' . $site_id . '.acsitefactory.com',
-      )
-    );
-
-    $aliases[$site . '.prod'] = array_merge(
-      $acsf_defaults,
-      $acsf_prod,
-      array(
-        'uri' => $site . '.' . $site_id . '.acsitefactory.com',
-      )
-    );
+  foreach ($sites as $site_name => $site_domains) {
+    if (!is_array($site_domains)) {
+      $site_name = $site_domains;
+    }
+    foreach ($envs as $env_name => $env_info) {
+      $uri = $site_name . '.' . $env_name . '-' . $site_id . '.acsitefactory.com';
+      if ($env_name == 'prod') {
+        $uri = $site_name . '.' . $site_id . '.acsitefactory.com';
+      }
+      if (is_array($site_domains) && isset($site_domains[$env_name])) {
+        $uri = $site_domains[$env_name];
+      }
+      $aliases[$site_name . '.' . $env_name] = array_merge(
+        $acsf_defaults,
+        $env_info,
+        array(
+          'uri' => $uri,
+        )
+      );
+    }
   }
 }


### PR DESCRIPTION
Many projects will have vanity domains for environments, such as `dev.example.com` instead of `example.dev-project.acsitefactory.com`. The current ACSF alias template doesn't support these vanity domains, which causes confusion at best and blockers/bugs at worst (if you are using trusted host patterns or have a temperamental cache).

This supports adding vanity domains, and also provides backwards compatibility when vanity domains don't exist.