### PR TITLE
build:validate:test is deprecated.

### DIFF
--- a/template/build/README.md
+++ b/template/build/README.md
@@ -43,12 +43,12 @@ Automated testing of live content is easy to set up with two simple steps:
      ssh_known_hosts:
        - staging-12345.prod.hosting.acquia.com
      ```
-2. Override the default `build:validate:test` target by adding the following to `build/custom/phing/build.xml`:
+2. Override the default `ci:build:validate:test` target by adding the following to `build/custom/phing/build.xml`:
 
      ```
-     <!-- Override the core build:validate:test target to include a local refresh-->
-     <target name="build:validate:test" description="Builds, validates, tests, and deploys an artifact."
-       depends="validate:all, setup, tests:security-updates, tests:phpunit, local:sync, local:update, tests:behat" />
+     <!-- Override the core ci:build:validate:test target to include a local refresh-->
+     <target name="ci:build:validate:test" description="Builds, validates, tests, and deploys an artifact."
+       depends="validate:all, ci:setup, tests:security-updates, tests:phpunit, local:sync, local:update, tests:behat" />
      ```
 
 ### Setting Up Travis CI for automated deployments

--- a/template/build/core/phing/build.xml
+++ b/template/build/core/phing/build.xml
@@ -50,20 +50,6 @@
   <!-- Contains acsf tasks. -->
   <import file="${core.phing.dir}/tasks/acsf.xml"/>
 
-  <!--
-    The follow targets are intended to be wrapper targets that bundle
-    multiple targets from other includes.
-  -->
-  <target name="build:test"
-          description="Builds, tests, and deploys an artifact."
-          depends="setup, tests:all">
-  </target>
-
-  <target name="build:validate:test"
-          description="Builds, validates, tests, and deploys an artifact."
-          depends="validate:all, setup, tests:all">
-  </target>
-
   <target name="list" hidden="true">
     <exec dir="${repo.root}" command="./blt.sh -q -l" passthru="true"/>
   </target>


### PR DESCRIPTION
#84 essentially converted `build:validate:test` to `ci:build:validate:test`, but never deleted `build:validate:test` or updated references to it in the documentation. This caused us some confusion because we had overridden `build:validate:test` in a custom Phing task and couldn't figure out why our tests were broken.