### PR TITLE
Catch PHP messages with Behat.

### DIFF
--- a/template/tests/behat/features/bootstrap/Drupal/FeatureContext.php
+++ b/template/tests/behat/features/bootstrap/Drupal/FeatureContext.php
@@ -21,4 +21,38 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
 
   }
 
+  /**
+   * The BeforeSuite hook is run before any feature in the suite runs.
+   *
+   * @BeforeSuite
+   */
+  public static function prepare($event) {
+    if (db_table_exists('watchdog')) {
+      db_truncate('watchdog')->execute();
+    }
+  }
+
+  /**
+   * The AfterScenario hook is run after executing a scenario.
+   *
+   * @AfterScenario
+   */
+  public function afterScenario($event) {
+    if (db_table_exists('watchdog')) {
+      $log = db_select('watchdog', 'w')
+        ->fields('w')
+        ->condition('w.type', 'php', '=')
+        ->execute()
+        ->fetchAll();
+      if (!empty($log)) {
+        foreach ($log as $error) {
+          // Make the substitutions easier to read in the log.
+          $error->variables = unserialize($error->variables);
+          print_r($error);
+        }
+        throw new \Exception('PHP errors logged to watchdog in this scenario.');
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
This will cause Behat to fail on PHP errors, warnings, and notices as long as watchdog is enabled.
