### PR TITLE
DX improvement by adding composer install to blt.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,12 @@ script:
   # Generate a new 'blted' project.
   - ./blt.sh configure
   - ./blt.sh create
+  # Move to the target directory.
+  - cd ../blted8
   # Call targets in the new 'blted' project.
-  - ../blted8/blt.sh ci:build:validate:test -Dcreate_alias=false -Dbehat.run-server=true -Dbehat.launch-phantom=true
+  - ./blt.sh ci:build:validate:test -Dcreate_alias=false -Dbehat.run-server=true -Dbehat.launch-phantom=true
   # Deploy build artifact.
-  - ../blted8/blt.sh deploy:artifact:build -Ddeploy.commitMsg="Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" -Ddeploy.branch="8.x-build"
+  - ./blt.sh deploy:artifact:build -Ddeploy.commitMsg="Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" -Ddeploy.branch="8.x-build"
   # Validate and run 'blt' phpunit tests.
   - phpcs --standard=../blted8/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml tests
   - phpunit tests/phpunit --exclude-group deploy-push

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ script:
   - ./blt.sh deploy:artifact:build -Ddeploy.commitMsg="Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" -Ddeploy.branch="8.x-build"
   # Validate and run 'blt' phpunit tests.
   - phpcs --standard=../blted8/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml tests
+  # Switch back to 'blt' directory
+  - cd ../blt
   - phpunit tests/phpunit --exclude-group deploy-push
 
 deploy:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,8 +23,7 @@ You should be able to use the following tools on the command line of your native
 ## Prepare BLT installer
 
 * Clone BLT to your local machine on your native OS: 
-  `git clone https://github.com/acquia/blt.git`
-* From the BLT repository’s root directory, run `composer install`. This will build the dependencies required for BLT’s “installer”. 
+  `git clone https://github.com/acquia/blt.git` 
 
 # Generate and modify configuration files
 

--- a/blt.sh
+++ b/blt.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 
+# Test if Composer is installed
+composer -v > /dev/null 2>&1
+COMPOSER_IS_INSTALLED=$?
+
+# True, if composer is not installed
+if [[ $COMPOSER_IS_INSTALLED -ne 0 ]]; then
+  echo "Composer is required but not found."
+  echo "Please install composer from the composer website:"
+  echo "  https://getcomposer.org/doc/00-intro.md"
+  exit 1
+fi
+
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 if [ ! -f ${DIR}/vendor/bin/phing ]; then
-   echo "Phing was not found in this project's bin directory."
-   echo "Please run composer install."
-   echo "You may need to remove the vendor directory first."
-   exit 1
+  echo "Phing was not found in this project's bin directory."
+  echo "Attempting to run composer install. This takes a few minutes."
+  composer install
 fi
 
 # This script simply passes all arguments to Phing.

--- a/build/phing/build.xml
+++ b/build/phing/build.xml
@@ -146,9 +146,6 @@
     <exec command="git add -A" dir="${blt.new.dir}" logoutput="false" passthru="false" />
     <exec command="git commit -m 'Initial commit of default files from BLT.'" dir="${blt.new.dir}" logoutput="false" passthru="false" />
 
-    <!-- Build composer dependencies. -->
-    <exec dir="${blt.new.dir}" command="composer install" logoutput="true" passthru="true" checkreturn="true" />
-
     <echo></echo>
     <echo>New project was created in ${blt.new.dir}</echo>
     <echo>Please change to the new project directory and run the setup task:</echo>

--- a/template/blt.sh
+++ b/template/blt.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 
+# Test if Composer is installed
+composer -v > /dev/null 2>&1
+COMPOSER_IS_INSTALLED=$?
+
+# True, if composer is not installed
+if [[ $COMPOSER_IS_INSTALLED -ne 0 ]]; then
+  echo "Composer is required but not found."
+  echo "Please install composer from the composer website:"
+  echo "  https://getcomposer.org/doc/00-intro.md"
+  exit 1
+fi
+
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 if [ ! -f ${DIR}/vendor/bin/phing ]; then
-   echo "Phing was not found in this project's bin directory."
-   echo "Please run composer install."
-   echo "You may need to remove the vendor directory first."
-   exit 1
+  echo "Phing was not found in this project's bin directory."
+  echo "Attempting to run composer install. This takes a few minutes."
+  composer install
 fi
 
 # This script simply passes all arguments to Phing.


### PR DESCRIPTION
This moves composer install to the blt.sh wrapper.

This allows an easier initial setup (don't have to run composer install after clone), and removes it from the inital `create` task. This makes `create` much faster by delaying composer install to the first run of blt.sh within the target directory.