### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,12 +30,10 @@ You should be able to use the following tools on the command line of your native
 From the BLT repository’s root directory, run `./blt.sh configure`. This will create your project-specific configuration files. After running, the following files should exist in the BLT root directory:
 
 * project.yml
-* local.drushrc.php
 * local.settings.php
 
 You will need to open these files and modify their values with settings for your project. At a minimum, you must set the following configuration items:
 
-* Local site URL: `$options['uri']` in local.drushrc.php
 * Local site DB credentials: `$databases` in local.settings.php
 
 At this point, you likely have not configured your local *AMP stack for your new site. That’s ok. Simply enter the local URL and local DB credentials that you intend to use when your *AMP stack is up and running.
@@ -73,7 +71,6 @@ Please see [Local Development](template/readme/local-development.md) for more in
 
 When you have completed setting up your local \*AMP stack, double check that the following pieces of information are still correct:
 
-* Local site URL: `$options[‘uri’]` in docroot/sites/default/local.drushrc.php
 * Local site DB credentials: `$databases` in docroot/sites/default/settings/local.settings.php
 
 ## Build your project’s dependencies and install Drupal


### PR DESCRIPTION
local.drushrc.php is no longer being generated from the configure command. These lines should be removed from the install.md reflecting that. To add, it looks like the drushrc file is being generated along the way, so you may not want the last line removed and leave it as a sanity check. But, none the less its not really needed to verify since you control that file in an automated fashion.