### PR TITLE
Don't fail on chmod.

### DIFF
--- a/template/build/core/phing/tasks/setup.xml
+++ b/template/build/core/phing/tasks/setup.xml
@@ -87,7 +87,7 @@
     </drush>
 
     <!-- Grant execution permissions. -->
-    <chmod mode="0755">
+    <chmod mode="0755" failonerror="false">
       <fileset dir="${docroot}/sites/default">
         <include name="**" />
       </fileset>


### PR DESCRIPTION
See #128... this command will almost always fail if `sites/default/files` is not empty.