### PR TITLE
Minor update scaffold cleanup.

### DIFF
--- a/template/build/core/phing/tasks/blt.xml
+++ b/template/build/core/phing/tasks/blt.xml
@@ -6,7 +6,7 @@
 
     <input message="Press any key to continue" propertyName="continue" />
 
-    <exec dir="${repo.root}" command="./scripts/blt/update-scaffold" logoutput="true" passthru="true"/>
+    <exec dir="${repo.root}" command="./scripts/blt/update-scaffold" logoutput="true" passthru="true" checkreturn="true"/>
   </target>
 
   <target name="blt:alias" description="Installs the BLT alias for command line usage.">

--- a/template/scripts/blt/update-scaffold
+++ b/template/scripts/blt/update-scaffold
@@ -3,14 +3,16 @@
 GIT_ROOT=$(git rev-parse --show-toplevel)
 BLT_BRANCH=8.x
 
+command -v svn >/dev/null 2>&1 || { echo "The svn command could not be found. Please install subversion." >&2; exit 1; }
+
 # Upstream directories to pull. These will be prefixed with "template/".
 BLT_DIRS=(
   "blt.sh"
   "build/core"
   "factory-hooks/post-settings-php/protect_env.php.example"
-  "factory-hooks/pre-settings-php/includes.php.example"
   "hooks/samples"
   "hooks/templates"
+  "readme"
   "scripts/blt"
   "scripts/drupal"
   "scripts/git-hooks/pre-commit"
@@ -33,5 +35,6 @@ done
 
 # Restore execute permissions.
 chmod 755 blt.sh
+chmod 755 scripts/git-hooks/pre-commit
 
 echo "Changes have been pulled down. Please review and commit desired changes."


### PR DESCRIPTION
This fixes various things related to the update scaffold:

1. Check if the SVN command exists before running and fail if it does not.
1. Remove non-existent includes.php.example.
1. Added readme directory to updates.
1. Keep pre-commit script executable.