### PR TITLE
Allow project.local.yml for different local environments.

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,6 +1,6 @@
 # Ignore configuration files that may contain sensitive information.
 local.*
-*.local
+*.local.*
 
 # Ignore drupal core.
 docroot/core

--- a/template/build/core/phing/tasks/properties.xml
+++ b/template/build/core/phing/tasks/properties.xml
@@ -7,6 +7,14 @@
   <!-- Load the root project.yml file for this project. -->
   <property file="${repo.root}/project.yml" override="true"/>
 
+  <!-- Load the local project.local.yml file for this project. -->
+  <if>
+    <available file="${repo.root}/project.local.yml" type="file" property="local.properties"/>
+    <then>
+      <property file="${repo.root}/project.local.yml" override="true"/>
+    </then>
+  </if>
+
   <!-- Load file directory and binary locations. -->
   <property file="${core.phing.dir}/build.yml" override="true"/>
 

--- a/template/example.project.local.yml
+++ b/template/example.project.local.yml
@@ -1,0 +1,11 @@
+# Override any settings as necessary by copying to project.local.yml
+project:
+  local:
+    protocol: http
+    hostname: mysite.dev
+
+drush:
+  # You can set custom project aliases in drush/site-aliases/aliases.drushrc.php.
+  aliases:
+    # The local environment against which all local drush commands are run.
+    local: local.mysite.dev

--- a/template/readme/onboarding.md
+++ b/template/readme/onboarding.md
@@ -74,7 +74,7 @@ Ensure that your local email address correctly matches the email address for you
 
 ## Updating you local environment
 
-The project is configured to update the local environment with a local drush alias and a remote alias as defined in `project.yml`. Given that these aliases match, those in `drush/site-aliases/`, you can update the site with BLT.
+The project is configured to update the local environment with a local drush alias and a remote alias as defined in `project.yml` or `project.local.yml`. Given that these aliases match, those in `drush/site-aliases/`, you can update the site with BLT.
 
 [Local Development Tasks](project-tasks.md#local-tasks)
 

--- a/template/readme/project-tasks.md
+++ b/template/readme/project-tasks.md
@@ -13,10 +13,10 @@
 
 Pre-requisites to installation:
 
-1. Ensure that `docroot/sites/default/settings/local.settings.php` exists by executing `./blt.sh setup:drupal:settings`. 
+1. Ensure that `docroot/sites/default/settings/local.settings.php` exists by executing `./blt.sh setup:drupal:settings`.
 1. Verify that correct local database credentials are set in `local.settings.php`.
 1. Ensure that project dependencies have already been built via `./blt.sh setup:build:all`
-   
+
 To re-install Drupal, execute: `./blt.sh setup:drupal:install`. Note that this will drop the existing database tables and install Drupal from scratch!
 
 ## <a name="update-dependency"></a>Update dependencies (core, profile, module, theme, libraries)
@@ -81,7 +81,7 @@ To build Thunder's assets, execute:
 
 ## <a name="local-tasks"></a>Updating you local environment
 
-The project is configured to update the local environment with a local drush alias and a remote alias as defined in `project.yml`. Given that these aliases match, those in `drush/site-aliases/`, you can update the site with BLT. Please see [drush/README.md](../drush/README.md) for details on how to create these aliases.
+The project is configured to update the local environment with a local drush alias and a remote alias as defined in `project.yml` or `project.local.yml`. Given that these aliases match, those in `drush/site-aliases/`, you can update the site with BLT. Please see [drush/README.md](../drush/README.md) for details on how to create these aliases.
 
 ### Refresh: Rebuild the codebase, copy the database, and run updates
 


### PR DESCRIPTION
- Ignore local files, including sites, settings, project.
- Load project.local.yml
- Example project.local.yml
- Update docs references to project.yml.local