### PR TITLE
Improve composer validation.

### DIFF
--- a/template/build/core/phing/tasks/validate.xml
+++ b/template/build/core/phing/tasks/validate.xml
@@ -6,7 +6,7 @@
 
   <!-- Verify that composer json and lock files are in sync. -->
   <target name="validate:composer" description="Validate composer files.">
-    <exec dir="${repo.root}" command="composer validate" logoutput="true" checkreturn="true"/>
+    <exec dir="${repo.root}" command="composer validate --no-check-all --ansi" logoutput="true" checkreturn="true"/>
   </target>
 
   <!-- Run linter against all php files in repository. -->


### PR DESCRIPTION
Fortunately, the new composer validation has saved us on several occasions from developers forgetting to update and commit `composer.lock`.

Unfortunately, they aren't always able to determine from the Travis logs exactly what's gone wrong or what to do to fix it. Hopefully this makes the problem more obvious (i.e. bright red).