### PR TITLE
Minor Typo fix and updating default selenium port

### DIFF
--- a/template/tests/behat/example.local.yml
+++ b/template/tests/behat/example.local.yml
@@ -30,10 +30,10 @@ local:
       # set default command for "Show last response" step.
       show_cmd: "open %s"
       # ADDITIONAL OPTIONS FOR WEB DRIVERS
-      # use the following 3 lines to user phantomjs
+      # use the following 3 lines to use phantomjs
       # browser_name: phantomjs
       # selenium2:
-      #   wd_host: "http://localhost:8643/wd/hub"
+      #   wd_host: "http://localhost:4444/wd/hub"
       #   browser: chrome
       #
       # use the following lines to disable SSL authentication for goutte.
@@ -48,7 +48,6 @@ local:
       #       CURLOPT_TIMEOUT: 120
       selenium2:
         wd_host: http://127.0.0.1:4444/wd/hub
-        browser: chrome
     Drupal\DrupalExtension:
       drupal:
         # This must be an absolute path.

--- a/template/tests/behat/example.local.yml
+++ b/template/tests/behat/example.local.yml
@@ -48,6 +48,7 @@ local:
       #       CURLOPT_TIMEOUT: 120
       selenium2:
         wd_host: http://127.0.0.1:4444/wd/hub
+        browser: chrome
     Drupal\DrupalExtension:
       drupal:
         # This must be an absolute path.


### PR DESCRIPTION
Setting the default selenium port to 4444. This is the default port that Drupal-VM ships with so it gets the tests running a bit faster