### PR TITLE
Correctly detect environments on ACSF.

### DIFF
--- a/template/docroot/sites/default/settings/base.settings.php
+++ b/template/docroot/sites/default/settings/base.settings.php
@@ -24,8 +24,8 @@ $forwarded_protocol = !empty($_ENV['HTTP_X_FORWARDED_PROTO']) ? $_ENV['HTTP_X_FO
  */
 $ah_env = isset($_ENV['AH_SITE_ENVIRONMENT']) ? $_ENV['AH_SITE_ENVIRONMENT'] : NULL;
 $is_ah_env = (bool) $ah_env;
-$is_ah_prod_env = ($ah_env == 'prod');
-$is_ah_stage_env = ($ah_env == 'test');
+$is_ah_prod_env = ($ah_env == 'prod' || $ah_env == '01live');
+$is_ah_stage_env = ($ah_env == 'test' || $ah_env == '01test');
 $is_ah_dev_cloud = (!empty($_SERVER['HTTP_HOST']) && strstr($_SERVER['HTTP_HOST'], 'devcloud'));
 $is_ah_dev_env = (preg_match('/^dev[0-9]*$/', $ah_env) == TRUE);
 $is_acsf = (isset($_ENV['AH_SITE_GROUP']) && file_exists("/mnt/files/{$_ENV['AH_SITE_GROUP']}.$ah_env/files-private/sites.json"));


### PR DESCRIPTION
AH_SITE_ENVIRONMENT follows a different pattern on ACSF... for instance the prod environment is `01live` instead of `prod`.