### PR TITLE
Subversion needed for ./blt.sh blt:update in VM

### DIFF
--- a/template/scripts/drupal-vm/config.yml
+++ b/template/scripts/drupal-vm/config.yml
@@ -36,3 +36,4 @@ configure_drush_aliases: false
 extra_packages:
   # This is required for PhantomJS Installer.
   - php-bz2
+  - subversion


### PR DESCRIPTION
I'm not sure if there is a good reason to not include subversion in the config but seems that it would be useful for anyone wanting to run `./blt.sh blt:update` from within the VM