### PR TITLE
Removing Icon from gitignore

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -27,7 +27,6 @@ reports
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
This line in gitignore was causing local `deploy:build` commits to not include real icons, such as `docroot/core/themes/stable/images/core/icons/e29700/warning.svg`.