### PR TITLE
Fix permission changes to default sites directory contents

### DIFF
--- a/template/build/core/phing/tasks/setup.xml
+++ b/template/build/core/phing/tasks/setup.xml
@@ -77,10 +77,17 @@
       <param>sync</param>
     </drush>
 
-    <!-- Grant execution permissions. -->
+    <!-- Set sites directory file permissions. -->
     <chmod mode="0755" failonerror="false">
       <fileset dir="${docroot}/sites/default">
-        <include name="**" />
+        <type type="dir" />
+        <exclude name="files/**" />
+      </fileset>
+    </chmod>
+    <chmod mode="0644" failonerror="false">
+      <fileset dir="${docroot}/sites/default">
+        <type type="file" />
+        <exclude name="files/**" />
       </fileset>
     </chmod>
 


### PR DESCRIPTION
Should address the issues in #128 
 - Ignore the files directory, since files that are owned by the webserver user will throw warnings
 - Change directories to `755` and files to `644`