### PR TITLE
Don't overwrite local config files

### DIFF
--- a/template/build/core/phing/tasks/properties.xml
+++ b/template/build/core/phing/tasks/properties.xml
@@ -21,7 +21,14 @@
 
   <!-- Extract PHP variable values from local.settings.php. -->
   <property name="local.settings.file" value="${docroot}/sites/${multisite.name}/settings/local.settings.php" />
-  <copy file="${docroot}/sites/${multisite.name}/settings/default.local.settings.php" tofile="${local.settings.file}" overwrite="false" verbose="true"/>
+  <if>
+    <not>
+        <available file="${local.settings.file}" type="file" />
+    </not>
+    <then>
+      <copy file="${docroot}/sites/${multisite.name}/settings/default.local.settings.php" tofile="${local.settings.file}" verbose="true"/>
+    </then>
+  </if>
 
   <echo>Executing commands against multisite "${multisite.name}"</echo>
   <echo>Using settings file ${local.settings.file}</echo>

--- a/template/build/core/phing/tasks/setup.xml
+++ b/template/build/core/phing/tasks/setup.xml
@@ -48,11 +48,25 @@
 
     <if>
       <not>
-        <available file="${repo.root}/project.local.yml" type="file" property="localConfigFilesExist" />
+        <available file="${repo.root}/project.local.yml" type="file" />
       </not>
       <then>
         <copy file="${repo.root}/example.project.local.yml" tofile="${repo.root}/project.local.yml" />
+      </then>
+    </if>
+    <if>
+      <not>
+          <available file="${docroot}/sites/${multisite.name}/settings/local.settings.php" type="file" />
+      </not>
+      <then>
         <copy file="${docroot}/sites/${multisite.name}/settings/default.local.settings.php" tofile="${docroot}/sites/${multisite.name}/settings/local.settings.php" />
+      </then>
+    </if>
+    <if>
+      <not>
+          <available file="${docroot}/sites/${multisite.name}/local.drushrc.php" type="file" />
+      </not>
+      <then>
         <copy file="${docroot}/sites/${multisite.name}/default.local.drushrc.php" tofile="${docroot}/sites/${multisite.name}/local.drushrc.php">
           <filterchain>
             <expandproperties />

--- a/template/build/core/phing/tasks/setup.xml
+++ b/template/build/core/phing/tasks/setup.xml
@@ -45,13 +45,22 @@
 
   <target name="setup:drupal:settings" description="Create local settings files using default settings files.">
     <chmod mode="0755" file="${docroot}/sites/default" failonerror="false" verbose="true"/>
-    <copy file="${repo.root}/example.project.local.yml" tofile="${repo.root}/project.local.yml" overwrite="false"/>
-    <copy file="${docroot}/sites/${multisite.name}/settings/default.local.settings.php" tofile="${docroot}/sites/${multisite.name}/settings/local.settings.php" overwrite="false"/>
-    <copy file="${docroot}/sites/${multisite.name}/default.local.drushrc.php" tofile="${docroot}/sites/${multisite.name}/local.drushrc.php" overwrite="false">
-      <filterchain>
-        <expandproperties />
-      </filterchain>
-    </copy>
+
+    <if>
+      <not>
+        <available file="${repo.root}/project.local.yml" type="file" property="localConfigFilesExist" />
+      </not>
+      <then>
+        <copy file="${repo.root}/example.project.local.yml" tofile="${repo.root}/project.local.yml" />
+        <copy file="${docroot}/sites/${multisite.name}/settings/default.local.settings.php" tofile="${docroot}/sites/${multisite.name}/settings/local.settings.php" />
+        <copy file="${docroot}/sites/${multisite.name}/default.local.drushrc.php" tofile="${docroot}/sites/${multisite.name}/local.drushrc.php">
+          <filterchain>
+            <expandproperties />
+          </filterchain>
+        </copy>
+      </then>
+    </if>
+
     <!-- Re-extract value of $options['uri'] in case it was not yet set. -->
     <!-- @todo Add multisite support. -->
     <phpVariable file="${repo.root}/drush/drushrc.php" variable="options[uri]" outputProperty="local_url" />


### PR DESCRIPTION
The copy task `overwrite` option defaults to `false`, and means that files will be overwritten if the timestamp of the source file is newer (https://www.phing.info/docs/guide/trunk/CopyTask.html).  This results in local changes being destroyed if any changes are made upstream.

This pull request adds a conditional based on the existence of the `project.local.yml` file, so that the files are only copied the first time setup is run.