### PR TITLE
Fixes #214: Fix default Drupal VM synced_folder path doc.

### DIFF
--- a/template/scripts/drupal-vm/config.yml
+++ b/template/scripts/drupal-vm/config.yml
@@ -7,7 +7,7 @@ drupal_site_name: "${project.human_name}"
 
 # Provide the path to the project root to Vagrant.
 vagrant_synced_folders:
-  # Set the local_path for the first synced folder to `../`.
+  # Set the local_path for the first synced folder to `.`.
   - local_path: .
     # Set the destination to the Acquia Cloud subscription machine name.
     destination: /var/www/${project.machine_name}


### PR DESCRIPTION
The actual default configuration is correct... but the documentation line above it is outdated.