### PR TITLE
Remove scripts/drupal directory from blt/update-scaffold

### DIFF
--- a/template/scripts/blt/update-scaffold
+++ b/template/scripts/blt/update-scaffold
@@ -16,7 +16,6 @@ BLT_DIRS=(
   "hooks/templates"
   "readme"
   "scripts/blt"
-  "scripts/drupal"
   "scripts/git-hooks/pre-commit"
   "scripts/release-notes"
   "tests/behat/behat.yml"


### PR DESCRIPTION
Running the "blt:update" command fails because the "scripts/drupal" directory was removed in #230. This won't fix the problem the first time one tries to update a BLT project, but it should prevent future failures.