### PR TITLE
Connected #262: Attempt to set drush.root from project.local.yml if it exists.

### DIFF
--- a/template/drush.wrapper
+++ b/template/drush.wrapper
@@ -29,6 +29,15 @@
 # composer-managed Drupal sites.
 #
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DRUSH_ROOT=''
+
+if [ -f ${DIR}/project.local.yml ]; then
+  DRUSH_ROOT=`${DIR}/vendor/bin/drupal yaml:get:value ${DIR}/project.local.yml drush.root`
+  if [[ ${DRUSH_ROOT} =~ Could\ not\ find.* ]]; then
+    DRUSH_ROOT=''
+  fi
+fi
+
 cd "`dirname $0`"
 
 if [ ! -f ${DIR}/vendor/bin/drush ]; then
@@ -37,4 +46,4 @@ if [ ! -f ${DIR}/vendor/bin/drush ]; then
   composer install
 fi
 
-vendor/bin/drush.launcher --alias-path=${DIR}/drush/site-aliases "$@" -r ${DIR}/docroot
+vendor/bin/drush.launcher --alias-path=${DIR}/drush/site-aliases "$@" -r ${DRUSH_ROOT}


### PR DESCRIPTION
@grasmash - I've changed this so it attempts to set the drush root from project.local.yml if the file exists. The check for the return value is the error message i received when the specified key was not found in the YAML file. The default value is just an empty string.