### PR TITLE
Fixed broken git commit msg hook.

### DIFF
--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -46,6 +46,7 @@ install:
   - composer validate --no-check-all --ansi
   - composer install
   - export PATH=$TRAVIS_BUILD_DIR/vendor/bin:$PATH
+  - drupal init --quiet
   # Install proper version of node for front end tasks.
   - nvm install 4.4.1
   - nvm use 4.4.1


### PR DESCRIPTION
The Git commit msg validation hook calls Drupal Console, which will throw an error if Console has not been initialized yet. This was happening to us in Travis on a newly-created project.