### PR TITLE
[BUGFIX] Failed Behat tests keeps pahntomJS running

### DIFF
--- a/phing/tasks/tests.xml
+++ b/phing/tasks/tests.xml
@@ -38,6 +38,7 @@
           <!-- A non-zero returns status indicates failure. -->
           <not><equals arg1="${behatPass}" arg2="0"/></not>
           <then>
+            <phingcall target="tests:phantomjs:kill"/>
             <fail message="One ore more Behat tests failed." />
           </then>
           <else>


### PR DESCRIPTION
- PB: when a Behat test fails, phing exits through the fail statement. The task            tests:phantomjs:kill is not called.
- FIX: call tests:phantomjs:kill before exiting with fail.