### PR TITLE
[BUGFIX] Tests may fail due to PhantomJs not ready

### DIFF
--- a/phing/tasks/tests.xml
+++ b/phing/tasks/tests.xml
@@ -63,6 +63,14 @@
               passthru="true"
               spawn="true"
               checkreturn="true" />
+        <exec command="which curl &gt; /dev/null &amp;&amp; echo $?" checkreturn="false" outputProperty="hasCurl" />
+        <if>
+          <equals arg1="${hasCurl}" arg2="0"/>
+          <then>
+            <echo message="Waiting for PhantomJS to start..." />
+            <exec command="while ! curl -v -L http://127.0.0.1:4444/wd/hub/session; do sleep 1; done" checkreturn="false" />
+          </then>
+        </if>
       </then>
     </if>
   </target>

--- a/phing/tasks/tests.xml
+++ b/phing/tasks/tests.xml
@@ -63,14 +63,10 @@
               passthru="true"
               spawn="true"
               checkreturn="true" />
-        <exec command="which curl &gt; /dev/null &amp;&amp; echo $?" checkreturn="false" outputProperty="hasCurl" />
-        <if>
-          <equals arg1="${hasCurl}" arg2="0"/>
-          <then>
-            <echo message="Waiting for PhantomJS to start..." />
-            <exec command="while ! curl -v -L http://127.0.0.1:4444/wd/hub/session; do sleep 1; done" checkreturn="false" />
-          </then>
-        </if>
+        <echo message="Waiting 10 seconds for ${behat.server-url} to become available."/>
+        <waitfor maxwait="10" maxwaitunit="second" checkevery="1" checkeveryunit="second">
+          <http url="${behat.server-url}"/>
+        </waitfor>
       </then>
     </if>
   </target>

--- a/phing/tasks/tests.xml
+++ b/phing/tasks/tests.xml
@@ -63,9 +63,9 @@
               passthru="true"
               spawn="true"
               checkreturn="true" />
-        <echo message="Waiting 10 seconds for ${behat.server-url} to become available."/>
+        <echo message="Waiting 10 seconds for PhantomJS (http://127.0.0.1:4444) to become available."/>
         <waitfor maxwait="10" maxwaitunit="second" checkevery="1" checkeveryunit="second">
-          <http url="${behat.server-url}"/>
+          <http url="http://127.0.0.1:4444"/>
         </waitfor>
       </then>
     </if>


### PR DESCRIPTION
- PB: Under some systems, Behat tests fails due to the fact the PhantomJS server is not ready to handle connections.
- FIX: ensure server is running before continuing.
- NOTE: currently use curl to test, if curl is not available, it doesn't wait