### PR TITLE
Replaced require with require_once in settings.php and blt.settings.php

### DIFF
--- a/template/docroot/sites/default/settings.php
+++ b/template/docroot/sites/default/settings.php
@@ -700,4 +700,4 @@ $settings['container_yamls'][] = __DIR__ . '/services.yml';
  */
 
 // Include BLT configuration.
-require DRUPAL_ROOT . '/sites/default/settings/blt.settings.php';
+require_once DRUPAL_ROOT . '/sites/default/settings/blt.settings.php';

--- a/template/docroot/sites/default/settings/blt.settings.php
+++ b/template/docroot/sites/default/settings/blt.settings.php
@@ -1,26 +1,26 @@
 <?php
 
 // Includes required Acquia configuration and set $base_url correctly.
-require DRUPAL_ROOT . '/sites/default/settings/base.settings.php';
+require_once DRUPAL_ROOT . '/sites/default/settings/base.settings.php';
 
 // Includes caching configuration.
-require DRUPAL_ROOT . '/sites/default/settings/cache.settings.php';
+require_once DRUPAL_ROOT . '/sites/default/settings/cache.settings.php';
 
 // Includes logging configuration.
-require DRUPAL_ROOT . '/sites/default/settings/logging.settings.php';
+require_once DRUPAL_ROOT . '/sites/default/settings/logging.settings.php';
 
 
 /**
  * Acquia Cloud settings.
  */
 if ($is_ah_env && file_exists('/var/www/site-php')) {
-  require "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/{$_ENV['AH_SITE_GROUP']}-settings.inc";
+  require_once "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/{$_ENV['AH_SITE_GROUP']}-settings.inc";
 
   // Store API Keys and things outside of version control.
   // @see settings/sample-secrets.settings.php for sample code.
   $secrets_file = sprintf('/mnt/gfs/%s.%s/secrets.settings.php', $_ENV['AH_SITE_GROUP'], $_ENV['AH_SITE_ENVIRONMENT']);
   if (file_exists($secrets_file)) {
-    require $secrets_file;
+    require_once $secrets_file;
   }
 }
 
@@ -37,19 +37,19 @@ if ($is_ah_env && file_exists('/var/www/site-php')) {
 if ($is_local_env) {
   // Load Dev Desktop settings.
   if (isset($_SERVER['DEVDESKTOP_DRUPAL_SETTINGS_DIR']) && file_exists($_SERVER['DEVDESKTOP_DRUPAL_SETTINGS_DIR'] . '/loc_${project.machine_name}_dd.inc')) {
-    require $_SERVER['DEVDESKTOP_DRUPAL_SETTINGS_DIR'] . '/loc_${project.machine_name}_dd.inc';
+    require_once $_SERVER['DEVDESKTOP_DRUPAL_SETTINGS_DIR'] . '/loc_${project.machine_name}_dd.inc';
   }
   // Load local machine settings.
   elseif (file_exists(DRUPAL_ROOT . '/sites/default/settings/local.settings.php')) {
-    require DRUPAL_ROOT . '/sites/default/settings/local.settings.php';
+    require_once DRUPAL_ROOT . '/sites/default/settings/local.settings.php';
   }
 
   // Load Travis CI settings.
   if (getenv('TRAVIS') && file_exists(DRUPAL_ROOT . '/sites/default/settings/travis.settings.php')) {
-    require DRUPAL_ROOT . '/sites/default/settings/travis.settings.php';
+    require_once DRUPAL_ROOT . '/sites/default/settings/travis.settings.php';
   }
   // Load Tugboat settings.
   elseif (getenv('TUGBOAT_URL') && file_exists(DRUPAL_ROOT . '/sites/default/settings/tugboat.settings.php')) {
-    require DRUPAL_ROOT . '/sites/default/settings/tugboat.settings.php';
+    require_once DRUPAL_ROOT . '/sites/default/settings/tugboat.settings.php';
   }
 }

--- a/template/docroot/sites/default/settings/readme.md
+++ b/template/docroot/sites/default/settings/readme.md
@@ -3,6 +3,6 @@
 This directory contains modularized settings files. The are "required" into
 a Drupal installation's sites/default/settings.php in the follow manner
 
-    require '../all/settings/base.settings.php';
-    require '../all/settings/cache.settings.php';
+    require_once '../all/settings/base.settings.php';
+    require_once '../all/settings/cache.settings.php';
     // etc...


### PR DESCRIPTION
When writing some custom code that included functions the functions got redeclaration errors.  Adding a require once solved the problem.