### PR TITLE
Allow overrides of blt phing targets: fixes #316.

### DIFF
--- a/phing/build.xml
+++ b/phing/build.xml
@@ -19,6 +19,18 @@
   <!-- Defines a list of default properties, available to all targets. -->
   <import file="${phing.dir}/tasks/properties.xml"/>
 
+  <!-- Allow custom file to be imported. -->
+  <if>
+    <isset property="import" />
+    <then>
+      <echo>Importing custom Phing file ${import}.</echo>
+      <import file="${import}"/>
+    </then>
+    <else>
+      <echo>No custom Phing file specified.</echo>
+    </else>
+  </if>
+
   <!-- Contains BLT tasks. -->
   <import file="${phing.dir}/tasks/blt.xml"/>
 
@@ -51,18 +63,6 @@
 
   <!-- Contains Drupal VM tasks. -->
   <import file="${phing.dir}/tasks/vm.xml"/>
-
-  <!-- Allow custom file to be imported. -->
-  <if>
-    <isset property="import" />
-    <then>
-      <echo>Importing custom Phing file ${import}.</echo>
-      <import file="${import}"/>
-    </then>
-    <else>
-      <echo>No custom Phing file specified.</echo>
-    </else>
-  </if>
 
   <target name="list" hidden="true">
     <exec dir="${blt.root}" command="${repo.root}/vendor/bin/phing -f ${phing.dir}/build.xml -q -l" passthru="true"/>


### PR DESCRIPTION
See acquia/blt#316 for the long-winded explanation. Essentially, the goal of this PR is to make **BLT** more extensible by allowing custom overrides of BLT phing targets.

By moving the import file declaration up in the `build.xml` file, we are allowing a custom definition of each BLT target to be defined before the BLT library's version.