### PR TITLE
Fix drush.wrapper script to use only last line of output of phing ech…

### DIFF
--- a/template/drush.wrapper
+++ b/template/drush.wrapper
@@ -43,7 +43,15 @@ if [ ! -f ${DIR}/vendor/bin/blt ]; then
   composer install
 fi
 
-DOCROOT=$(${DIR}/vendor/bin/blt echo-property -Dproperty.name=drush.root -S -e)
+# Get the value defined for drush.root by the project. Split the command output
+# into an array and use the last element of the array in case there is other
+# command output, for instance, when the user has xdebug enabled.
+OLDIFS=$IFS
+IFS=$'\n'
+PROPERTY=( $(${DIR}/vendor/bin/blt echo-property -Dproperty.name=drush.root -S -e) )
+DOCROOT=${PROPERTY[${#PROPERTY[@]}]}
+IFS=$OLDIFS
+
 if [ -z "$DOCROOT" ]; then
   vendor/bin/drush.launcher --config=${DIR}/drush/drushrc.php --alias-path=${DIR}/drush/site-aliases "$@"
 else


### PR DESCRIPTION
…o-property task when discovering the drush root. (#315)

@grasmash - I altered the command a bit so the value returned is saved into an array, and assign drush.root to be the last value in the array. I tested this locally with xdebug enabled and disabled, and it appears to work correctly in both cases.