### PR TITLE
Setup and deploy should install frontend dependencies.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -70,7 +70,7 @@
   </target>
 
   <target name="deploy:build" description="Generates a deploy-ready build in deploy.dir."
-          depends="frontend:build, deploy:copy, deploy:composer:install, deploy:sanitize">
+          depends="frontend, deploy:copy, deploy:composer:install, deploy:sanitize">
     <!-- If we are using ACSF, run the ACSF Deploy command. -->
     <if>
       <equals arg1="${hosting}" arg2="acsf"/>

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -18,7 +18,7 @@
 
   <!-- This is run when a project is cloned to a new environment. -->
   <target name="setup:build" description="Generates all required files for a full build. E.g., (re)builds docroot, etc."
-          depends="setup:git-hooks, setup:drupal:settings, setup:behat, setup:composer:install, frontend:build">
+          depends="setup:git-hooks, setup:drupal:settings, setup:behat, setup:composer:install, frontend">
 
     <phingcall target="target-hook:invoke">
       <property name="hook-name" value="post-setup-build"/>


### PR DESCRIPTION
Is there a reason that the setup and deploy tasks only call frontend:build but not frontend:setup? That seems pretty pointless to me, since you can't very well build without dependencies in place :smile: 