### PR TITLE
Add script to install BLT alias to template composer.json script, upd…

### DIFF
--- a/readme/onboarding.md
+++ b/readme/onboarding.md
@@ -49,8 +49,8 @@ If you need to make requests via a proxy server, please [configure git to use a 
 
 1. Checkout the `develop` branch. `git checkout develop`
 1. Run `composer install` (you must already have Composer installed).
-1. Install `blt` alias `./vendor/bin/blt install-alias`
 1. Run `blt setup:drupal:settings` This will generate `docroot/sites/default/settings/local.settings.php` and `docroot/sites/default/local.drushrc.php`. Update these with your local database credentials and your local site URL.
+1. Set up your local development environment. Please see [Configure Local Environment](#configure-local-environment) for detailed information on setting up a local \*AMP stack.
 1. Run `blt local:setup`. This will build all project dependencies and install drupal.
 1. Create and edit your local drush alias file. Copy `drush/site-aliases/example.local.aliases.drushrc.php` to `drush/site-aliases/local.aliases.drushrc.php`. Edit the new alias file with your local path.
 
@@ -67,7 +67,7 @@ For readability of commit history, set your name and email address properly:
 
 Ensure that your local email address correctly matches the email address for your Jira account.
 
-## Updating you local environment
+## Updating your local environment
 
 The project is configured to update the local environment with a local drush alias and a remote alias as defined in `project.yml` or `project.local.yml`. Given that these aliases match, those in `drush/site-aliases/`, you can update the site with BLT.
 

--- a/scripts/blt/install-alias.sh
+++ b/scripts/blt/install-alias.sh
@@ -23,11 +23,22 @@ if [ ! -z "$DETECTED_PROFILE" ]; then
     exit
   fi
 
+  while getopts ":y" arg; do
+  case $arg in
+    y)
+      REPLY=y
+      ;;
+    esac
+  done
+
   echo "BLT can automatically create a Bash alias to make it easier to run BLT tasks."
   echo "This alias may be created in .bash_profile or .bashrc depending on your system architecture."
   echo ""
-  read -p "Install alias? (y/n)" -n 1 -r
-  echo ""
+
+  if [ -z $REPLY ]; then
+    read -p "Install alias? (y/n)" -n 1 -r
+    echo ""
+  fi
 
   if [[ $REPLY =~ ^[Yy]$ ]]; then
     DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/template/composer.json
+++ b/template/composer.json
@@ -57,11 +57,14 @@
   },
   "scripts": {
     "install-phantomjs": "PhantomInstaller\\Installer::installPhantomJS",
+    "install-blt-alias": "./vendor/acquia/blt/scripts/blt/install-alias.sh -y",
     "post-install-cmd": [
-      "PhantomInstaller\\Installer::installPhantomJS"
+      "PhantomInstaller\\Installer::installPhantomJS",
+      "@composer install-blt-alias"
     ],
     "post-update-cmd": [
-      "PhantomInstaller\\Installer::installPhantomJS"
+      "PhantomInstaller\\Installer::installPhantomJS",
+      "@composer install-blt-alias"
     ]
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
…ate setup instructions in onboarding.md. (#284).

The simplest solution seemed to be to add the script to the template composer.json. I modified the script itself to accept a "-y" flag to automatically install the alias since composer does not support interactive scripts. This does not add the script to existing projects, but I think that is not necessary since it is really only a one-time thing.