### PR TITLE
The URL in template README.md is malformed

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -4,7 +4,7 @@ Replace this with a brief description of the ${project.human_name} project.
 
 ## BLT
 
-Please see the [BLT documentation](blt.readthedocs.io/en/latest) for information on build, testing, and deployment processes.
+Please see the [BLT documentation](http://blt.readthedocs.io/en/latest/) for information on build, testing, and deployment processes.
 
 ## Resources
 


### PR DESCRIPTION
This PR just simply makes the URL into a fully qualified URL that points directly to the docs.  The current bug is that it points to a relative path in the file structure.