### PR TITLE
Modify deploy phing to enable multiple environment deployments.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -59,7 +59,7 @@
     <exec command="git fetch ${remoteName} ${deploy.branch}" dir="${deploy.dir}" logoutput="true" level="info" passthru="true"/>
 
     <!-- Create the new branch, "[source-branch-name]-build". -->
-    <exec command="git checkout -b ${deploy.branch}" dir="${deploy.dir}" logoutput="true" checkreturn="true" level="info" passthru="true"/>
+    <exec command="git checkout -B ${deploy.branch}" dir="${deploy.dir}" logoutput="true" checkreturn="true" level="info" passthru="true"/>
 
     <!-- Pull the latest updates (if available). -->
     <exec command="git merge ${remoteName}/${deploy.branch}" dir="${deploy.dir}" logoutput="true" passthru="true"/>


### PR DESCRIPTION
While attempting to deploy to multiple environments with travis I was blocked by:

[exec] Executing command: git checkout -b master-build
fatal: A branch named 'master-build' already exists.
[phingcall] /vendor/acquia/blt/phing/tasks/deploy.xml:62:59: Task exited with code 128

changing this to a -B checkout argument should create or switch the the correct branch. 