### PR TITLE
Chmod settings.php to 644 instead of 755

### DIFF
--- a/phing/tasks/blt.xml
+++ b/phing/tasks/blt.xml
@@ -62,7 +62,7 @@
   <target name="configure">
     <!-- @todo add multisite support. -->
     <echo>Making ${docroot}/sites/default/settings.php writable.</echo>
-    <chmod mode="0755" failonerror="false" file="${docroot}/sites/default/settings.php"/>
+    <chmod mode="0644" failonerror="false" file="${docroot}/sites/default/settings.php"/>
 
     <echo>Expanding Phing properties in BLT files.</echo>
     <!-- Reflexively expand properties in specified dirs/files. -->


### PR DESCRIPTION
the blt:configure task chmods the settings.php file to 755 but it should be 644, since this file does not need execute permissions.