### PR TITLE
Added search modules

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -12,34 +12,34 @@
     "cweagans/composer-patches":                  "^1.5.0",
     "drupal/acquia_connector":                    "8.1.*",
     "drupal/acsf":                                "~8.1",
-    "drupal/core":                                "~8",
     "drupal/console":                             "~1",
+    "drupal/core":                                "~8",
+    "drupal/lightning":                           "8.1.03",
     "drupal/memcache" :                           "8.*",
+    "drupal/metatag":                             "8.1.0-beta9"
     "drupal/search_api":                          "8.1.0-alpha14",
     "drupal/search_api_solr":                     "8.1.0-alpha3",
     "drupal/security_review" :                    "8.*",
-    "roave/security-advisories":                  "dev-master",
-    "drupal-composer/drupal-security-advisories": "8.0.x-dev",
     "drupal-composer/drupal-scaffold":            "^2.0.0",
-    "drupal/lightning":                           "8.1.03",
-    "drupal/metatag":                             "8.1.0-beta9"
+    "drupal-composer/drupal-security-advisories": "8.0.x-dev",
+    "roave/security-advisories":                  "dev-master",
     "solarium/solarium":                          "3.6.*"
   },
   "require-dev": {
     "behat/behat":                  "3.0.*",
     "behat/mink":                   "1.6@stable",
+    "behat/mink-browserkit-driver": "*",
     "behat/mink-extension":         "*",
     "behat/mink-goutte-driver":     "*",
     "behat/mink-selenium2-driver":  "*",
-    "behat/mink-browserkit-driver": "*",
-    "drush/drush":                  "^9.0",
-    "drupal/drupal-extension":      "~3.0",
     "drupal/coder":                 "~8.2",
-    "phpunit/phpunit":             "~5.4",
-    "squizlabs/php_codesniffer":    "2.*",
-    "phing/phing":                  "dev-master#0ef30e55bb5871cb38903cc0ee9d76074118a22c",
+    "drupal/drupal-extension":      "~3.0",
+    "drush/drush":                  "^9.0",
     "jakoch/phantomjs-installer":   "dev-master as 1.9.8",
-    "jarnaiz/behat-junit-formatter": "^1.2"
+    "jarnaiz/behat-junit-formatter": "^1.2",
+    "phing/phing":                  "dev-master#0ef30e55bb5871cb38903cc0ee9d76074118a22c",
+    "phpunit/phpunit":             "~5.4",
+    "squizlabs/php_codesniffer":    "2.*"
   },
   "autoload-dev": {
     "psr-4": {

--- a/template/composer.json
+++ b/template/composer.json
@@ -15,12 +15,15 @@
     "drupal/core":                                "~8",
     "drupal/console":                             "~1",
     "drupal/memcache" :                           "8.*",
+    "drupal/search_api":                          "8.1.0-alpha14",
+    "drupal/search_api_solr":                     "8.1.0-alpha3",
     "drupal/security_review" :                    "8.*",
     "roave/security-advisories":                  "dev-master",
     "drupal-composer/drupal-security-advisories": "8.0.x-dev",
     "drupal-composer/drupal-scaffold":            "^2.0.0",
     "drupal/lightning":                           "8.1.03",
     "drupal/metatag":                             "8.1.0-beta9"
+    "solarium/solarium":                          "3.6.*"
   },
   "require-dev": {
     "behat/behat":                  "3.0.*",

--- a/template/composer.json
+++ b/template/composer.json
@@ -16,14 +16,13 @@
     "drupal/core":                                "~8",
     "drupal/lightning":                           "8.1.03",
     "drupal/memcache" :                           "8.*",
-    "drupal/metatag":                             "8.1.0-beta9"
+    "drupal/metatag":                             "8.1.0-beta9",
     "drupal/search_api":                          "8.1.0-alpha14",
     "drupal/search_api_solr":                     "8.1.0-alpha3",
-    "drupal/security_review" :                    "8.*",
+    "drupal/security_review":                     "8.*",
     "drupal-composer/drupal-scaffold":            "^2.0.0",
     "drupal-composer/drupal-security-advisories": "8.0.x-dev",
-    "roave/security-advisories":                  "dev-master",
-    "solarium/solarium":                          "3.6.*"
+    "roave/security-advisories":                  "dev-master"
   },
   "require-dev": {
     "behat/behat":                  "3.0.*",


### PR DESCRIPTION
Search in D8 is a finicky thing... at the moment you have to have a very specific combination of module versions (it's [documented](https://docs.acquia.com/acquia-search/modules) if you know to look for it, but not obvious). Since Search is a nearly universal requirement I figured it should just be in BLT. I'm trying to coordinate with various parties to break up this weird version dependency, but even so I think this is useful to have.

Also as a minor OCD nitpick, I alphabetized the packages in composer.json so we can find them more easily as the list grows. Only look at the first commit if you just want to see the search packages I added.