### PR TITLE
Resolve typo in install docs.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@ You should be able to use the following tools on the command line of your native
 
 1. Create a new project using the [blt-project](https://github.com/acquia/blt-project) template:
 
-        composer cache-clear
+        composer clear-cache
         export COMPOSER_PROCESS_TIMEOUT=2000
         composer create-project acquia/blt-project MY_PROJECT --no-interaction
         cd MY_PROJECT


### PR DESCRIPTION
Tiny fix to documentation, `composer cache-clear` should actually be `composer clear-cache`

.. and the trivial PR of the year award goes to ..