### PR TITLE
Update filesystem.settings.php for ACSF

### DIFF
--- a/settings/filesystem.settings.php
+++ b/settings/filesystem.settings.php
@@ -9,6 +9,7 @@ $settings['file_public_path'] = "sites/$site_dir/files";
 
 // ACSF file paths.
 if ($is_acsf) {
+  $settings['file_public_path'] = "sites/g/files/$acsf_db_name/files";
   $settings['file_private_path'] = "/mnt/gfs/$ah_group.$ah_env/files-private/$acsf_db_name";
 }
 // Acquia cloud file paths.


### PR DESCRIPTION
I'm not 100% sure if this is the best way to address this. Previously, my project (as far as I could tell) was not setting "file_public_path", so I'm assuming it was set maybe through ACSF configuration? The latest release of BLT on L#8 sets the "file_public_path" to the default for all sites, even SF. To fix this, I had to explicitly set the file path after this file loads. Wondering if this change should be incorporated here upstream? Again, I'm not sure if this is the appropriate place for this, but this was my best guess.