### PR TITLE
Bugfix for ACSF db name.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -83,7 +83,7 @@ $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
 /**
  * Acquia Cloud settings.
  */
-if ($is_ah_env && file_exists('/var/www/site-php')) {
+if ($is_ah_env && file_exists('/var/www/site-php' && !$is_acsf)) {
   require "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/{$_ENV['AH_SITE_GROUP']}-settings.inc";
 
   // Store API Keys and things outside of version control.


### PR DESCRIPTION
This fixes a very major ACSF issue where site-specific ACSF settings.inc template provided by the ACSF module files are overridden in BLT - this caused ACSF sites in each environment to share a single, incorrect database and prevented the creation of new sites in some instances. 