### PR TITLE
Change/remove drupal scaffold

### DIFF
--- a/phing/files/deploy-exclude.txt
+++ b/phing/files/deploy-exclude.txt
@@ -14,6 +14,7 @@
 /docroot/sites/*/files
 /docroot/sites/*/private
 /docroot/themes/contrib
+/docroot/.gitignore
 /drush/contrib
 /drush.wrapper
 /project.yml

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -44,6 +44,7 @@
 
   <target name="setup:composer:install" description="Installs project dependencies, including drupal core and contrib.">
     <exec dir="${repo.root}" command="export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --ansi --no-interaction" logoutput="true" checkreturn="true" level="info" passthru="true" />
+    <exec dir="${repo.root}" command="composer drupal-scaffold --ansi --no-interaction" logoutput="true" checkreturn="true" level="info" passthru="true" />
   </target>
 
   <target name="setup:drupal:settings" description="Create local settings files using default settings files.">

--- a/scripts/blt/ignore-existing.txt
+++ b/scripts/blt/ignore-existing.txt
@@ -5,6 +5,7 @@ project.yml
 composer.json
 README.md
 drush/site-aliases/aliases.drushrc.php
+docroot/.gitignore
 docroot/sites/default/services.yml
 factory-hooks/pre-settings-php/includes.php
 tests/behat/behat.yml

--- a/template/composer.json
+++ b/template/composer.json
@@ -59,8 +59,9 @@
     }
   },
   "scripts": {
-    "install-phantomjs": "PhantomInstaller\\Installer::installPhantomJS",
     "blt-alias": "blt install-alias -Dcreate_alias=true",
+    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+    "install-phantomjs": "PhantomInstaller\\Installer::installPhantomJS",
     "post-install-cmd": [
       "PhantomInstaller\\Installer::installPhantomJS"
     ],

--- a/template/docroot/.gitignore
+++ b/template/docroot/.gitignore
@@ -1,0 +1,21 @@
+# Ignore drupal-scaffold files.
+# This file mirrors the default list of packages at:
+# ~ https://github.com/drupal-composer/drupal-scaffold#configuration
+#
+# If you want to make changes to a Drupal Core scaffold file, remove it from
+# this list, and commit it to your repository.
+/.csslintrc
+/.editorconfig
+/.eslintignore
+/.eslintrc
+/.gitattributes
+/.htaccess
+/index.php
+/robots.txt
+/sites/default/default.settings.php
+/sites/default/default.services.yml
+/sites/development.services.yml
+/sites/example.settings.local.php
+/sites/example.sites.php
+/update.php
+/web.config


### PR DESCRIPTION
Ok, this is a total shot in the dark... I'm guessing this has maybe already been thought of, but was working on this today and wanted to see if there are any thoughts on this approach.

Ultimately, if we don't keep drupal/core or any contrib modules in our repo, I don't see any reason to keep drupal-scaffold files either (unless you have changes to these, which I do for `docroot/.htaccess` for example). This also seems to me to be an approach that @grasmash slightly agrees with given the changes in PR #391. I will note, this goes against the suggested approach of the [drupal-composer/drupal-scaffold](https://github.com/drupal-composer/drupal-scaffold) project:

> It is assumed that the scaffold files will be committed to the repository, to ensure that the correct files are used on the CI server (see Limitation, above). After running composer install for the first time commit the scaffold files to your repository.

So here is what I'm doing... 

First, with this approach, users will not have the drupal scaffold files in their local installs, as they only get placed by the drupal-scaffold project on updates of drupal/core module. We can get around this by calling the library's functionality manually. Composer has a new command added to it, `$ composer drupal-scaffold`, which downloads and places the scaffold files on every run. This command gets added as a 2nd step to BLT's `setup:composer:install` command, which users will run, and CI would run. This, IMO, takes care of the drupal-scaffold warning around CI, quoted above.
(Side note: it feels like we are running this more than we have to though)

Next, I wanted to, by default, `.gitignore` the scaffold files. Since I also want users to be able to place a scaffold file in their repo (to modify/extend), and not have BLT overwrite it, I also place this .gitignore file in the `scripts/blt/ignore-existing.txt` file.

Now, if as a BLT end user, I want to include `docroot/.htaccess` file in my repo to add changes, I would remove that file's corresponding line from `docroot/.gitignore`, and commit that file to my repo. 
I could probably use some documentation on this approach as well, because by _now having_ this file in my repo, everytime `$ composer update` gets run with an update to drupal/core, it will try to revert my custom changes to `docroot/.htaccess`. However, I can [add a section to `composer.json` "extra/drupal-scaffold/excludes"](https://github.com/drupal-composer/drupal-scaffold#configuration) to tell drupal-scaffold to not overwrite my changes. In this case, you will not necessarily know about upstream changes to these files, but that seems like a choice we can leave to the end user: a) manually ignore upstream changes to drupal-scaffold files, b) have drupal-scaffold leave your file alone, but not easily find out about upstream changes.

Possible ToDo's Here:
1. Should there be an upgrade path for this that deletes or suggests to delete these files if they exist for a user?
2. Additional documentation?

All feedback is welcome. Thanks!
