### PR TITLE
Remove root detection to allow drush to run remotely

### DIFF
--- a/template/drush.wrapper
+++ b/template/drush.wrapper
@@ -37,15 +37,4 @@ if [ ! -f ${DIR}/vendor/bin/drush ]; then
   composer install
 fi
 
-if [ ! -f ${DIR}/vendor/bin/blt ]; then
-  echo "BLT was not found in this project's vendor/bin directory."
-  echo "Attempting to run composer install. This takes a few minutes."
-  composer install
-fi
-
-DOCROOT=$(${DIR}/vendor/bin/blt echo-property -Dproperty.name=drush.root -S -e | tail -1)
-if [ -z "$DOCROOT" ]; then
-  vendor/bin/drush.launcher --config=${DIR}/drush/drushrc.php --alias-path=${DIR}/drush/site-aliases "$@"
-else
-  vendor/bin/drush.launcher -r $DOCROOT --config=${DIR}/drush/drushrc.php --alias-path=${DIR}/drush/site-aliases "$@"
-fi
+vendor/bin/drush.launcher --config=${DIR}/drush/drushrc.php --alias-path=${DIR}/drush/site-aliases "$@"


### PR DESCRIPTION
This fixes #426.

By removing the directory detection and passthrough we remove the ability to run `drush` commands from the BLT project root and this will now need to be run from the `docroot` directory. However this allows Drush to correctly infer the `root` from defined aliases so if you set up a local drush alias you can still run `drush @local` from the BLT project root.

This fixed issues I was having with running remote drush commands and I don't think it's necessary to detect and pass in the root directory with the `-r` option.

This is working with global and local drush installs, ie.

```
./drush.wrapper @local status
./drush.wrapper @dev status
```

and

```
drush @local status
drush @dev status
```