### PR TITLE
Passes repo.root into filterFileListByFileSet target

### DIFF
--- a/phing/phingcludes/FilterFileListByFileSetTask.php
+++ b/phing/phingcludes/FilterFileListByFileSetTask.php
@@ -22,6 +22,13 @@ class FilterFileListByFileSetTask extends Task {
    */
   protected $return_property = null;
 
+  /**
+   * The project root directory.
+   *
+   * @var string
+   */
+  protected $root;
+
   public function setFileList($fileList)
   {
     $this->fileList = $fileList;
@@ -50,6 +57,16 @@ class FilterFileListByFileSetTask extends Task {
     $this->return_property = $str;
   }
 
+  /**
+   * Project root directory.
+   *
+   * @param string $root The project root.
+   * @return void
+   */
+  public function setRoot($root)
+  {
+    $this->root = $root;
+  }
 
   /**
    * The main entry point method.
@@ -80,8 +97,18 @@ class FilterFileListByFileSetTask extends Task {
     return (bool) $filteredList;
   }
 
+  /**
+   * Convert given relative paths to absolute file paths.
+   *
+   * @param string $relative_path A relative file path.
+   *
+   * @return string
+   *   Absolute file path.
+   */
   protected function prependProjectPath($relative_path) {
-    return $this->project->getBasedir()->getAbsolutePath() . DIRECTORY_SEPARATOR . $relative_path;
+    return isset($this->root)
+        ? $this->root . DIRECTORY_SEPARATOR . $relative_path
+        : $this->project->getBasedir()->getAbsolutePath() . DIRECTORY_SEPARATOR . $relative_path;
   }
 
   /**

--- a/phing/tasks/validate.xml
+++ b/phing/tasks/validate.xml
@@ -26,7 +26,7 @@
     <fail unless="files" message="Missing files parameter."/>
     <property name="phpcs.ruleset" value="${repo.root}/vendor/drupal/coder/coder_sniffer/Drupal/ruleset.xml"/>
 
-    <filterFileListByFileSet fileList="${files}" returnProperty="filteredFileList">
+    <filterFileListByFileSet fileList="${files}" root="${repo.root}" returnProperty="filteredFileList">
       <fileset refid="files.php.custom.modules"/>
       <fileset refid="files.php.custom.themes"/>
       <fileset refid="files.php.tests"/>


### PR DESCRIPTION
The git pre-commit hook builds a list of file paths relative to the git root which looks like:

```
docroot/modules/custom/test.php
```

When the `validate:phpcs:files` target builds a list of files to sniff it attempts to prepend the repository root to the relative path given by `git diff`. When run from a project the application call returns a path to the vendor directory.

``` php
$this->project->getBasedir()->getAbsolutePath(); 
```

Which produces output like:

```
array(1) {
  [0]=>
  string(87) "/Users/steven.worley/repos/blt2/vendor/acquia/blt/phing/docroot/modules/custom/test.php"
}
```

This then causes the array intersect validation to fail resulting in no files given to phpcs.
