### PR TITLE
Make git commit-msg hook configurable.

### DIFF
--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -8,12 +8,9 @@
 
 ROOT_DIR="$(pwd)/"
 PREFIX=$($ROOT_DIR/vendor/bin/drupal yaml:get:value $ROOT_DIR/project.yml project.prefix)
-regex="^${PREFIX}-[0-9]+(: )[^ ].{15,}\."
-if ! grep -iqE "$regex" "$1"; then
-  echo "Invalid commit message. Commit messages must:"
-  echo "* Contain the project prefix followed by a hyphen"
-  echo "* Contain a ticket number followed by a colon and a space"
-  echo "* Be at least 15 characters long and end with a period."
-  echo "Valid example: $PREFIX-135: Added the new picture field to the article feature."
+REGEX=$($ROOT_DIR/vendor/bin/drupal yaml:get:value $ROOT_DIR/project.yml git.commit_message.regex)
+MESSAGE=$($ROOT_DIR/vendor/bin/drupal yaml:get:value $ROOT_DIR/project.yml git.commit_message.instructions)
+if ! grep -iqE "$REGEX" "$1"; then
+  echo -e "$MESSAGE";
   exit 1;
 fi

--- a/template/project.yml
+++ b/template/project.yml
@@ -20,6 +20,16 @@ git:
     # Defining git remotes allows builds deployed via CI.
     - bolt8@svn-5223.devcloud.hosting.acquia.com:bolt8.git
     # - radass4@svn-11692.prod.hosting.acquia.com:radass4.git
+    commit_message:
+      regex: "^$BLT-[0-9]+(: )[^ ].{15,}\."
+      instructions: |
+        Invalid commit message. Commit messages must:
+
+        * Contain the project prefix followed by a hyphen
+        * Contain a ticket number followed by a colon and a space
+        * Be at least 15 characters long and end with a period.
+
+        Valid example: BLT-135: Added the new picture field to the article feature.
 
 drush:
   # You can set custom project aliases in drush/site-aliases/aliases.drushrc.php.

--- a/template/project.yml
+++ b/template/project.yml
@@ -21,7 +21,7 @@ git:
     - bolt8@svn-5223.devcloud.hosting.acquia.com:bolt8.git
     # - radass4@svn-11692.prod.hosting.acquia.com:radass4.git
     commit_message:
-      regex: "^$BLT-[0-9]+(: )[^ ].{15,}\."
+      regex: '^$BLT-[0-9]+(: )[^ ].{15,}\.'
       instructions: |
         Invalid commit message. Commit messages must:
 


### PR DESCRIPTION
As a developer, I would like to make the commit-msg git hook configurable so that I don't have to provide my own git hook setup process that is specific to my project. In particular, I want to configure the regex used to check the commit message format, and provide an alternative instructional response upon failure.

I think this will require some discussion and work to get a solution that doesn't break current installations.
