### PR TITLE
Deploy build tweak.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -32,11 +32,6 @@
     <!-- Build artifact and commit locally. -->
     <phingcall target="deploy:build"/>
 
-    <!--Allow custom commands to be run before commit.-->
-    <phingcall target="target-hook:invoke">
-      <property name="hook-name" value="post-deploy-build"/>
-    </phingcall>
-
     <!--Commit artifact. -->
     <phingcall target="deploy:commit"/>
 
@@ -84,6 +79,11 @@
         <phingcall target="deploy:acsf:init"/>
       </then>
     </if>
+
+    <!--Allow custom commands to be run before commit.-->
+    <phingcall target="target-hook:invoke">
+      <property name="hook-name" value="post-deploy-build"/>
+    </phingcall>
   </target>
 
   <target name="deploy:commit" hidden="true">


### PR DESCRIPTION
On our projects, the post-deploy-build hook is used to install frontend libraries that need to be deployed with the build artifact. I'm not sure how many other projects use this hook, but I suspect they use it for the same general purpose: to modify the build artifact before it's committed.

In this case, it makes more sense for the hook to run as the final part of the build step. This way if you need to build the deploy artifact manually, you only have to run a single step (`deploy:build`), instead of having to remember to run `deploy:build` followed by the post-deploy-build hook.