### PR TITLE
Added features bundle argument.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -272,7 +272,9 @@
       <param>drush</param>
     </drush>
     <!-- Revert all features. -->
-    <drush command="fra" assume="yes" alias="${drush.alias}"/>
+    <drush command="fra" assume="yes" alias="${drush.alias}">
+      <option name="bundle">${cm.features.bundle}</option>
+    </drush>
     <!-- Rebuild caches. -->
     <drush command="cr" alias="${drush.alias}"/>
   </target>

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -263,18 +263,23 @@
     <drush command="config-import" assume="yes" alias="${drush.alias}">
       <option name="partial"></option>
     </drush>
-    <!-- Enable features module. -->
-    <drush command="en" assume="yes" alias="${drush.alias}">
-      <param>features</param>
-    </drush>
-    <!-- Clear drush caches to register features drush commands. -->
-    <drush command="cc" assume="yes" alias="${drush.alias}">
-      <param>drush</param>
-    </drush>
-    <!-- Revert all features. -->
-    <drush command="fra" assume="yes" alias="${drush.alias}">
-      <option name="bundle">${cm.features.bundle}</option>
-    </drush>
+    <if>
+      <isset property="cm.features.bundle"/>
+      <then>
+        <!-- Enable features module. -->
+        <drush command="en" assume="yes" alias="${drush.alias}">
+          <param>features</param>
+        </drush>
+        <!-- Clear drush caches to register features drush commands. -->
+        <drush command="cc" assume="yes" alias="${drush.alias}">
+          <param>drush</param>
+        </drush>
+        <!-- Revert all features. -->
+        <drush command="fra" assume="yes" alias="${drush.alias}">
+          <option name="bundle">${cm.features.bundle}</option>
+        </drush>
+      </then>
+    </if>
     <!-- Rebuild caches. -->
     <drush command="cr" alias="${drush.alias}"/>
   </target>

--- a/template/composer.json
+++ b/template/composer.json
@@ -15,6 +15,7 @@
     "drupal/cog":                                 "~8",
     "drupal/console":                             "1.0.0-beta5",
     "drupal/core":                                "~8",
+    "drupal/features":                            "~8.3.0-beta9",
     "drupal/lightning":                           "~8",
     "drupal/memcache" :                           "8.*",
     "drupal/search_api":                          "8.1.0-alpha14",
@@ -56,6 +57,9 @@
     "patches": {
       "drupal/core": {
         "Ignore front end vendor folders to improve directory search performance": "https://www.drupal.org/files/issues/ignore_front_end_vendor-2329453-116.patch"
+      },
+      "drupal/features": {
+        "Bundle support": "https://www.drupal.org/files/issues/features-2808303-2.patch"
       }
     }
   },

--- a/template/project.yml
+++ b/template/project.yml
@@ -59,9 +59,9 @@ target-hooks:
     command: npm run install-libraries
 
 # Configuration management options, such as core CM or features.
-cm:
-  features:
-    bundle: blted8
+# cm:
+#   features:
+#     bundle: blted8
 
 # Define any custom Phing files that you'd like to import. E.g., ${repo.root}/blt/phing/build.xml
 import: ~

--- a/template/project.yml
+++ b/template/project.yml
@@ -58,6 +58,11 @@ target-hooks:
     dir: ${docroot}/profiles/contrib/lightning
     command: npm run install-libraries
 
+# Configuration management options, such as core CM or features.
+cm:
+  features:
+    bundle: blted8
+
 # Define any custom Phing files that you'd like to import. E.g., ${repo.root}/blt/phing/build.xml
 import: ~
 


### PR DESCRIPTION
Currently, if you run fra (features-import-all) on a Lightning-based install, you'll get all of Lightning's default config, which (a) is annoying, because it clobbers your own config if you've overridden Lightning, and (b) goes against the Lightning pattern of profile inheritance, which is to push configuration updates via hook_update_n rather than relying on features reverts.

I organized the bundle argument into a separate `cm` root-level configuration option, because I think we might want to start being a little more flexible about CM options for projects. For instance, a lot of projects might not use features or core CM at all and might want options to enable them individually. In the future, we could read config values such as `cm.features` or `cm.core` to decide whether to run `fra` or `config-import`, respectively.