### PR TITLE
Consistent settings.php permissions.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -104,7 +104,7 @@
       </then>
     </if>
     <echo>Making ${docroot}/sites/default/settings.php writable.</echo>
-    <chmod mode="0755" failonerror="false" file="${docroot}/sites/default/settings.php"/>
+    <chmod mode="0644" failonerror="false" file="${docroot}/sites/default/settings.php"/>
     <echo>Ensuring that blt.settings.php is required by settings.php</echo>
     <exec dir="${docroot}/sites/default" command="grep vendor/acquia/blt/settings/blt.settings.php settings.php || echo 'require DRUPAL_ROOT . &quot;/../vendor/acquia/blt/settings/blt.settings.php&quot;;' >> settings.php" logoutput="true" checkreturn="true" level="info"/>
 


### PR DESCRIPTION
General consensus is that settings.php should be mode 644, which is what we use elsewhere in BLT. For some reason we were using 755 in `setup:drupal:settings`, which causes the file mode to flip flop when you run different commands.

git blame doesn't reveal anything about why 755 was chosen for `setup:drupal:settings` in the first place.