### PR TITLE
Follow-up to #502: Remove bz2 requirement after switch to Selenium2.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,9 +7,6 @@ You must have the following tools on the command line of your *host operating sy
 * [Git](https://git-scm.com/)
 * [Composer](https://getcomposer.org/download/)
 * [PHP 5.6+](http://php.net/manual/en/install.php)
-    * PHP BZ2 extension is required (included by default in many cases).
-        * Install with PECL `pecl install bz2`
-        * Install with apt `apt-get install php5.6-bz2`
 
 ## Installing requirements
 

--- a/readme/windows-install.md
+++ b/readme/windows-install.md
@@ -12,7 +12,7 @@ Follow Microsoft's official instructions to install [Bash on Ubuntu on Windows](
 
   1. `sudo add-apt-repository ppa:ondrej/php` (hit 'Enter' when prompted)
   2. `sudo apt-get update`
-  3. `sudo apt-get install -y php5.6-cli php5.6-curl php5.6-xml php5.6-mbstring php5.6-bz2 php5.6-gd`
+  3. `sudo apt-get install -y php5.6-cli php5.6-curl php5.6-xml php5.6-mbstring php5.6-gd`
   4. `sudo apt-get install -y git nodejs npm unzip`
   4. `php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"`
   5. `php composer-setup.php`

--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -80,11 +80,5 @@ php_memcached_package: php5-memcached
 xhprof_download_url: https://github.com/phacility/xhprof/archive/master.tar.gz
 xhprof_download_folder_name: xhprof-master
 
-extra_packages:
-  # This is required for PhantomJS Installer.
-  - php-bz2
-  - subversion
-  - php-bcmath
-
 post_provision_scripts:
   - "../../../acquia/blt/scripts/drupal-vm/post-provision.sh"


### PR DESCRIPTION
Bz2 isn't required if we're not using PhantomJS... and it's harder to get it installed cleanly for PHP 5.6 anyways. Therefore I recommend we drop it once #500 gets merged.