### PR TITLE
Issue #509: Adjust drush wrapper bin path so it works on Windows with bad symlinks.

### DIFF
--- a/template/drush.wrapper
+++ b/template/drush.wrapper
@@ -31,10 +31,10 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd "`dirname $0`"
 
-if [ ! -f ${DIR}/vendor/bin/drush ]; then
-  echo "Drush was not found in this project's vendor/bin directory."
+if [ ! -f ${DIR}/vendor/drush/drush/drush.launcher ]; then
+  echo "Drush was not found in this project's vendor directory."
   echo "Attempting to run composer install. This takes a few minutes."
   composer install
 fi
 
-vendor/bin/drush.launcher --config=${DIR}/drush/drushrc.php --alias-path=${DIR}/drush/site-aliases "$@"
+vendor/drush/drush/drush.launcher --config=${DIR}/drush/drushrc.php --alias-path=${DIR}/drush/site-aliases "$@"


### PR DESCRIPTION
See: https://github.com/acquia/blt/issues/509#issuecomment-252329047

Basically, it's _really hard_ to guarantee symlinks set up in a Windows environment will work as expected in myriad situations (in Drupal VM synced via SMB, synced native, etc., in Dev Desktop, native PowerShell, Cygwin, Ubuntu Bash, etc.).

Therefore, ditch the symlinked copy in `vendor/bin` and point to the direct executable instead.

This is tested to work on Mac and Windows 10 at least.