### PR TITLE
Issue #509: Use default hostname that works more universally.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ This document outlines the process for creating a new BLT release.
 In order to use these testing instructions:
 
 * The `blt` alias must be installed.
-* Your LAMP stack must have host entry for `http://blted8.localhost` pointing to `./blted8/docroot`.
+* Your LAMP stack must have host entry for `http://local.blted8.com` pointing to `./blted8/docroot`.
 * MySQL must use `mysql://drupal:drupal@localhost/drupal:3306`. If this is not the case, modify the instructions below for your credentials.
 * In order to test Drupal VM, you must install VirtualBox and Vagrant. See [Drupal VM](https://github.com/geerlingguy/drupal-vm#quick-start-guide) for more information.
 

--- a/template/project.yml
+++ b/template/project.yml
@@ -11,7 +11,7 @@ project:
   # This will be used as the local uri for all developers.
   local:
     protocol: http
-    hostname: ${project.machine_name}.localhost
+    hostname: local.${project.machine_name}.com
 
 # Configuration settings for new git repository.
 git:


### PR DESCRIPTION
It looks like `*.localhost` domains don't work on Windows. Under Chrome and IE, with all the default settings, I would get "CONNECTION_REFUSED".

If I switch to anything without `.local` in the domain, things just work. So I figure why not use the pattern `local.[machine-name].com`.

This has two advantages:

  1. It _works_ (I've had issues with .local and .localhost in myriad environments—not just Windows).
  2. If you have a domain like "www.example.com", with a stage env of "stage.example.com", now your local environment would be "local.example.com". So much simpler to reason about and program around if automating anything (e.g. settings.php, build scripts, etc.) since it's just `[environment].example.com`.