### PR TITLE
Ensure correct exit status on pre-commit

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -13,4 +13,8 @@ if [ ! -f $PHPCS_BIN ];
 fi
 
 ${ROOT_DIR}/vendor/bin/blt validate:phpcs:files -Dfiles="$LIST" -q
-exit 0;
+
+# Return the status of the phing task. Any target executed should throw a build exception to prevent
+# code from being committed during the precommit. The hooks can be skipped by adding `--no-verify` to
+# a commit.
+exit $?


### PR DESCRIPTION
Pre-commit should return the status of the executed phing target, this will prevent code from being committed that doesn't meet the minimum requirements for the project.

These checks can be skipped by specifying the `--no-verify` option when comitting.