### PR TITLE
Only deploy on a single php version.

### DIFF
--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -69,6 +69,7 @@ deploy:
      skip_cleanup: true
      on:
        branch: master
+       php: 5.6
    #  Uncomment the following section to perform deployments on more than one branch.
    #  This pattern be repeated for multiple integration branches.
 #   - provider: script
@@ -76,3 +77,4 @@ deploy:
 #     skip_cleanup: true
 #     on:
 #       branch: integration
+#       php: 5.6


### PR DESCRIPTION
Simple change to `.travis.yml` template so we don't deploy multiple times when more than one PHP version is being tested.