### PR TITLE
Change drush.wrapper to not run 'composer install' automatically

### DIFF
--- a/template/drush.wrapper
+++ b/template/drush.wrapper
@@ -32,9 +32,9 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd "`dirname $0`"
 
 if [ ! -f ${DIR}/vendor/drush/drush/drush.launcher ]; then
-  echo "Drush was not found in this project's vendor directory."
-  echo "Attempting to run composer install. This takes a few minutes."
-  composer install
+  echo >&2 "Drush was not found in this project's vendor directory. You can install it by typing:"
+  echo >&2 "composer install"
+  exit 1
 fi
 
 vendor/drush/drush/drush.launcher --config=${DIR}/drush/drushrc.php --alias-path=${DIR}/drush/site-aliases "$@"


### PR DESCRIPTION
`drush-wrapper` shouldn't run `composer install` automatically. Something that significant should require user intervention. This changes the behavior to simply emit a message to stderr and exit.