### PR TITLE
Check date.timezone in doctor.

### DIFF
--- a/src/Drush/Command/BltDoctorCommand.php
+++ b/src/Drush/Command/BltDoctorCommand.php
@@ -208,6 +208,7 @@ class BltDoctor {
     $this->checkDrushAliases();
     $this->checkDrupalVmConfig();
     $this->checkSimpleSamlPhp();
+    $this->checkPhpDateTimezone();
 
     //$this->checkDatabaseUpdates();
     // @todo Check error_level.
@@ -914,6 +915,22 @@ class BltDoctor {
         $this->logErrorDetail("Add the snippet in simplesamlphp-setup.md readme to your .htaccess file.");
         $this->logNewLine();
       }
+    }
+  }
+
+  /**
+   * Checks the php date.timezone setting is correctly set.
+   */
+  protected function checkPhpDateTimezone() {
+    $dateTimezone = ini_get('date.timezone');
+    $php_ini_file = php_ini_loaded_file();
+    if (!$dateTimezone) {
+      $this->logError("PHP setting for date.timezone is not set.");
+      $this->logErrorDetail("Define date.timezone in $php_ini_file");
+      $this->logErrorDetail();
+    }
+    else {
+      drush_log("PHP setting for date.timezone is correctly set", 'notice');
     }
   }
 }


### PR DESCRIPTION
 * If date.timezone is not set git commit-msg hook can silently let through bad commit messages.

`php.ini` does not set a date.timezone by default, which would give a bad `$regex` value:
```
^BLT // check The configuration "date.timezone" was missing and overwritten with "America/Tijuana". -[0-9]+(: )[^ ].{15,}\.
```

This silently lets bad commit messages through. Setting a date.timezone results in the correct behaviour.
```
Invalid commit message. Commit messages must:
* Contain the project prefix followed by a hyphen
* Contain a ticket number followed by a colon and a space
* Be at least 15 characters long and end with a period.
Valid example: BLT-135: Added the new picture field to the article feature.
```
