### PR TITLE
Update to Drupal VM 3.4.x with Selenium and Chromedriver.

### DIFF
--- a/phing/tasks/vm.xml
+++ b/phing/tasks/vm.xml
@@ -66,7 +66,7 @@
     <copy file="${blt.root}/scripts/drupal-vm/Vagrantfile" todir="${repo.root}" verbose="true"/>
 
     <echo>Adding geerlingguy/drupal-vm to composer dev dependencies.</echo>
-    <exec dir="${repo.root}" command="composer require --dev geerlingguy/drupal-vm:~3.3" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+    <exec dir="${repo.root}" command="composer require --dev geerlingguy/drupal-vm:~3.4" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
 
     <echo></echo>
     <echo>A new "box" directory and a Vagrantfile have been added to ${repo.root}</echo>

--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -50,33 +50,36 @@ installed_extras:
 
 # Use PHP 5.6 and change package names to work with 5.6.
 php_version: "5.6"
+php_install_recommends: no
 php_packages:
-  - php5
-  - php5-apcu
-  - php5-mcrypt
-  - php5-cli
-  - php5-common
-  - php5-curl
-  - php5-dev
-  - php5-fpm
-  - php5-gd
-  - php5-sqlite
+  - php5.6
+  - php5.6-apcu
+  - php5.6-mcrypt
+  - php5.6-cli
+  - php5.6-common
+  - php5.6-curl
+  - php5.6-dev
+  - php5.6-fpm
+  - php5.6-gd
+  - php5.6-sqlite3
+  - php5.6-xml
+  - php5.6-mbstring
   - php-pear
   - libpcre3-dev
 php_conf_paths:
-  - /etc/php5/fpm
-  - /etc/php5/apache2
-  - /etc/php5/cli
+  - /etc/php/5.6/fpm
+  - /etc/php/5.6/apache2
+  - /etc/php/5.6/cli
 php_extension_conf_paths:
-  - /etc/php5/fpm/conf.d
-  - /etc/php5/apache2/conf.d
-  - /etc/php5/cli/conf.d
-php_fpm_daemon: php5-fpm
-php_fpm_conf_path: "/etc/php5/fpm"
-php_fpm_pool_conf_path: "/etc/php5/fpm/pool.d/www.conf"
-php_mysql_package: php5-mysql
-php_redis_package: php5-redis
-php_memcached_package: php5-memcached
+  - /etc/php/5.6/fpm/conf.d
+  - /etc/php/5.6/apache2/conf.d
+  - /etc/php/5.6/cli/conf.d
+php_fpm_daemon: php5.6-fpm
+php_fpm_conf_path: "/etc/php/5.6/fpm"
+php_fpm_pool_conf_path: "/etc/php/5.6/fpm/pool.d/www.conf"
+php_mysql_package: php5.6-mysql
+php_redis_package: php5.6-redis
+php_memcached_package: php5.6-memcached
 
 # Use PHP 5.6-compatible version of XHProf.
 xhprof_download_url: https://github.com/phacility/xhprof/archive/master.tar.gz


### PR DESCRIPTION
Drupal VM had to do a minor version bump since some of the PHP 5.6-related variables needed updating (so the 5.6.x branch is not using a deprecated/insecure release), and also since Alex Knoll's Selenium role changed some defaults (using Selenium + Chrome + chromedriver instead of Selenium + Firefox).