### PR TITLE
Cleaned up SimpleSAML_php integration.

### DIFF
--- a/phing/tasks/simplesamlphp.xml
+++ b/phing/tasks/simplesamlphp.xml
@@ -13,7 +13,7 @@
 
         <!-- Sets a value in project.yml to let other targets know simplesamlphp is installed -->
         <echo>Updating project.yml.</echo>
-        <exec dir="${repo.root}" command="drupal yaml:update:value project.yml simplesamlphp true" logoutput="true" checkreturn="true" passthru="true" level="${blt.exec_level}"/>
+        <exec dir="${repo.root}" command="${composer.bin}/drupal yaml:update:value project.yml simplesamlphp true" logoutput="true" checkreturn="true" passthru="true" level="${blt.exec_level}"/>
 
         <!-- Creates a symlink from the docroot to the web accessible library dir. -->
         <echo>Creating a symbolic link from ${docroot}/simplesaml to web accessible directory in the simplesamlphp library</echo>

--- a/readme/simplesamlphp-setup.md
+++ b/readme/simplesamlphp-setup.md
@@ -4,7 +4,7 @@ To configure SimpleSAMLphp, perform the following steps after initially setting 
 
 1. Execute `blt simplesamlphp:init`. This will perform the initial setup tasks including:
 	* Adds the simplesamlphp_auth module as a project dependency.
-	* Copies congigruation files to `${project.root}/simplesamlphp`
+	* Copies configuration files to `${project.root}/simplesamlphp`
 	* Adds a simplesamlphp property to project.yml
 	* Creates a symbolic link in the docroot to the web accessible directory of the simplesamlphp library.
 	* Adds a settings.php file to the project's default settings directory.


### PR DESCRIPTION
The drupal yaml update command fails because that command isn't generally available globally.

@grasmash on a tangential note, are we supposed to be submitting PRs against 8.x-dev now? Should we update the contribution guidelines to reflect that?