### PR TITLE
Change default local settings for visibility of test projects and rebuild access

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -95,7 +95,7 @@ $config['system.performance']['js']['preprocess'] = FALSE;
  * During development it can be useful to install test extensions for debugging
  * purposes.
  */
-$settings['extension_discovery_scan_tests'] = TRUE;
+$settings['extension_discovery_scan_tests'] = FALSE;
 
 /**
  * Enable access to rebuild.php.
@@ -105,7 +105,7 @@ $settings['extension_discovery_scan_tests'] = TRUE;
  * be gained by generating a query string from rebuild_token_calculator.sh and
  * using these parameters in a request to rebuild.php.
  */
-$settings['rebuild_access'] = TRUE;
+$settings['rebuild_access'] = FALSE;
 
 /**
  * Temporary file path:


### PR DESCRIPTION
Given the local development workflow BLT encourages, I'd argue that we should change the default value in local settings for `extension_discovery_scan_tests` and `rebuild_access` to be false. 

This will:
- Assure that test themes and modules are not shown in theme and module lists.
- Prevent the status report warning regarding rebuild.php being accessible.

These settings could be changed again locally, and should prevent some developer confusion after they start a new project.