### PR TITLE
Removed duplicate dependencies.

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -8,7 +8,6 @@
         }
     ],
     "require": {
-        "composer/installers":                        "^1.0.20",
         "cweagans/composer-patches":                  "dev-master#5456199acdcc16b243814aa45259f4c56272a634 as 1.5.0",
         "drupal/acquia_connector":                    "^8.1.5",
         "drupal/acsf":                                "^8.1.32",

--- a/template/composer.json
+++ b/template/composer.json
@@ -13,7 +13,6 @@
         "drupal/acquia_connector":                    "^8.1.5",
         "drupal/acsf":                                "^8.1.32",
         "drupal/cog":                                 "^8.1.0",
-        "drupal/console":                             "1.0.0-beta5",
         "drupal/core":                                "~8",
         "drupal/features":                            "^8.3.0-beta9",
         "drupal/lightning":                           "8.1.x-dev",
@@ -27,14 +26,11 @@
         "behat/behat":                                "^3.1",
         "behat/mink":                                 "~1.7",
         "behat/mink-selenium2-driver":                "^1.3.1",
-        "drupal/coder":                               "^8.2.9",
         "drupal/drupal-extension":                    "^3.2",
         "drush/drush":                                "^9.0",
         "drupal-composer/drupal-scaffold":            "^2.1.0",
         "jarnaiz/behat-junit-formatter":              "^1.3.2",
-        "phpunit/phpunit":                            "^5.4",
-        "se/selenium-server-standalone":              "^2.53",
-        "squizlabs/php_codesniffer":                  "^2.7"
+        "se/selenium-server-standalone":              "^2.53"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
The template composer.json defines a direct dependency on several packages that are already dependencies of other packages:
- Drupal Console (dependency of BLT)
- Drupal Coder (BLT)
- PHPUnit (BLT)
- PHPCS (BLT)
- Composer installers (Drupal Console and Lightning)

Because these dependencies are effectively defined twice, composer throws a warning when you run composer update on a BLT project:

> Dependency "drupal/coder" is also a root requirement, but is not explicitly whitelisted. Ignoring.

Right now I think this is a harmless warning, but it could lead to unpredictable behavior if BLT, Drupal console, or Lightning updates or patches one of these dependencies.

Seems like the best solution is to remove them from the project template composer.json, and just allow upstream projects to manage them.