### PR TITLE
Automated SimpleSAMLphp htaccess patch.

### DIFF
--- a/phing/tasks/simplesamlphp.xml
+++ b/phing/tasks/simplesamlphp.xml
@@ -32,6 +32,9 @@
   <target name="simplesamlphp:lib:init" hidden="true" unless="simplesamlphp">
     <echo>Adding SimpleSAMLphp Auth module as a dependency.</echo>
     <exec dir="${repo.root}" command="composer require drupal/simplesamlphp_auth:8.3.x-dev#283994f" logoutput="true" checkreturn="true" passthru="true" level="${blt.exec_level}"/>
+    <exec dir="${repo.root}" command="${repo.root}/vendor/bin/blt-console composer:munge ${blt.root}/scripts/simplesamlphp/htaccess-saml.json ${repo.root}/composer.json > ${repo.root}/composer.json.tmp" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
+    <!--@todo Find out why can't we just redirect output directly back to composer.json. -->
+    <exec dir="${repo.root}" command="mv ${repo.root}/composer.json.tmp ${repo.root}/composer.json" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
   </target>
 
   <!-- Copies the configuration templates from the library to a simplesamlphp directory located in the project root. -->
@@ -73,7 +76,6 @@
       To complete the setup you must manually modify several files.
     ============================================================================
 
-      * ${docroot}/.htaccess
       * ${repo.root}/simplesamlphp/config/acquia_config.php
       * ${repo.root}/simplesamlphp/config/authsources.php
       * ${repo.root}/simplesamlphp/metadata/saml20-idp-remote.php

--- a/readme/simplesamlphp-setup.md
+++ b/readme/simplesamlphp-setup.md
@@ -4,21 +4,12 @@ To configure SimpleSAMLphp, perform the following steps after initially setting 
 
 1. Execute `blt simplesamlphp:init`. This will perform the initial setup tasks including:
 	* Adds the simplesamlphp_auth module as a project dependency.
+  * Patches your .htaccess file to allow access to the simplesaml path.
 	* Copies configuration files to `${project.root}/simplesamlphp`
 	* Adds a simplesamlphp property to project.yml
 	* Creates a symbolic link in the docroot to the web accessible directory of the simplesamlphp library.
 	* Adds a settings.php file to the project's default settings directory.
-	
-1. Edit `docroot/.htaccess` to include the following 2 lines. Note: the only 2 lines that need to be added are the lines marked with "+" signs. 
-		
-		  # Copy and adapt this rule to directly execute PHP files in contributed or  
-    	  # custom modules or to run another PHP application in the same directory.  
-    	  RewriteCond %{REQUEST_URI} !/core/modules/statistics/statistics.php$  
-  		+ # Allow access to simplesaml paths  
-  		+ RewriteCond %{REQUEST_URI} !^/simplesaml  
-    	  # Deny access to any other PHP files that do not match the rules above.  
-    	  RewriteRule "^.+/.*\.php$" - [F]
-    
+
 1. Edit `${project.root}/simplesamlphp/config/config.php`
 	* This file has been pre-populated with a code snippet recommended for Acquia Cloud Environments. You will need to edit the `$config` array for your local environment. 
 	* Update your database name in `$ah_options`

--- a/scripts/simplesamlphp/htaccess-saml.json
+++ b/scripts/simplesamlphp/htaccess-saml.json
@@ -1,0 +1,9 @@
+{
+  "extra": {
+    "patches": {
+      "drupal/core": {
+        "SimpleSAML htaccess": "./patches/drupal/htacess-simplesaml.patch"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Following up on #602, I'd like for the SimpleSAML setup command to be as automated as possible, including patching htaccess. This _should_ work, but the composer:munge command doesn't seem to be working properly. In my tests, it's clobbering all of the array keys other than extra:patches.