### PR TITLE
Fixed installation of packages with commit refs.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -104,7 +104,7 @@
             <include name="composer.lock"/>
           </fileset>
         </copy>
-        <exec dir="${deploy.dir}" command="export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+        <exec dir="${deploy.dir}" command="export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --no-dev --no-interaction --optimize-autoloader" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
       </then>
       <else>
         <echo>Dependencies will not be built because deploy.build-dependencies is not enabled.</echo>

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -53,7 +53,7 @@
 
   <target name="setup:composer:install" description="Installs project dependencies, including drupal core and contrib.">
     <!-- Prefer distributions locally so that the downloaded archives are cached. -->
-    <exec dir="${repo.root}" command="export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --ansi --no-interaction --prefer-dist" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true" />
+    <exec dir="${repo.root}" command="export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --ansi --no-interaction" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true" />
   </target>
 
   <!-- We intentionally do not run setup:behat because we'd like to delay setting values in local.yml until just before they are run. -->


### PR DESCRIPTION
It seems that `--prefer-dist` is bugged: https://github.com/composer/composer/issues/5823

Basically, if you specify a commit ref for a package version, `--prefer-dist` will sometimes cause composer to ignore that. This is a rather insidious bug because of the sticky nature of how composer chooses source and dist packages... it can cause some really unexpected behavior.

Simply removing `--prefer-dist` should fix this. Composer will still use dist versions of stable packages. Newer composer versions cache Git clones locally, so there shouldn't be much of a performance impact.
