### PR TITLE
Allow specification of multiple Features bundles

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -248,13 +248,17 @@
           <param>drush</param>
         </drush>
         <!-- Revert all features. -->
-        <drush command="fra" assume="yes" alias="${drush.alias}">
-          <option name="bundle">${cm.features.bundle}</option>
-        </drush>
+        <foreach list="${cm.features.bundle}" param="bundle" target="setup:update:features-import" />
       </then>
     </if>
     <!-- Rebuild caches. -->
     <drush command="cr" alias="${drush.alias}"/>
+  </target>
+
+  <target name="setup:update:features-import" description="Perform a features import on the specified bundle.">
+    <drush command="fra" assume="yes" alias="${drush.alias}">
+      <option name="bundle">${bundle}</option>
+    </drush>
   </target>
 
 </project>


### PR DESCRIPTION
https://github.com/acquia/blt/issues/626

We would like to be able to specify multiple Features bundles.

I would have liked to change the property name to cm.features.bundles but left it as-is for backwards compatibility sake. I've confirmed that the ForEachTask is perfectly happy with a single item.