### PR TITLE
Added trusted host configuration.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -76,6 +76,7 @@
     <chmod mode="0644" failonerror="false" file="${docroot}/sites/default/settings.php"/>
     <echo>Ensuring that blt.settings.php is required by settings.php</echo>
     <exec dir="${docroot}/sites/default" command="grep vendor/acquia/blt/settings/blt.settings.php settings.php || echo 'require DRUPAL_ROOT . &quot;/../vendor/acquia/blt/settings/blt.settings.php&quot;;' >> settings.php" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
+    <exec dir="${docroot}/sites/default" command="grep trusted_host.settings.php settings.php || echo '// require DRUPAL_ROOT . &quot;/sites/default/settings/trusted_host.settings.php&quot;;' >> settings.php" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
 
     <echo>Generating local settings files.</echo>
 

--- a/template/docroot/sites/default/settings/trusted_host.settings.php
+++ b/template/docroot/sites/default/settings/trusted_host.settings.php
@@ -1,0 +1,19 @@
+<?php
+
+if ($is_ah_env) {
+  if ($is_ah_prod_env) {
+    $settings['trusted_host_patterns'] = array(
+      '^example\.com$',
+    );
+  }
+  elseif ($is_ah_stage_env) {
+    $settings['trusted_host_patterns'] = array(
+      '^stg\.example\.com$',
+    );
+  }
+  elseif ($is_ah_dev_env) {
+    $settings['trusted_host_patterns'] = array(
+      '^dev\.example\.com$',
+    );
+  }
+}


### PR DESCRIPTION
For now, this is mostly useful as a demonstration of how to customize settings for a project, and a reminder to set the trusted host.

Ultimately it would be nice if you could configure environments and domains in project.yml, and have the trusted domains and drush alias uris all be configured automatically. But that might be a lot of work for not a huge return, and it might be hard to accommodate multisite.