### PR TITLE
Rebuild caches before running updates.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -240,6 +240,10 @@
     <!-- enable_property and uninstall_property must be set at this time. -->
     <phingcall target="setup:toggle-modules"/>
 
+    <!-- Rebuild caches in case service definitions have changed. -->
+    <!-- @see https://www.drupal.org/node/2826466 -->
+    <drush command="cr" alias="${drush.alias}"/>
+
     <!-- Import configuration before executing updates, in case any db updates are dependent on new configs to be imported. -->
     <drush command="config-import" assume="yes" alias="${drush.alias}">
       <option name="partial"></option>


### PR DESCRIPTION
Apparently, Drupal core caches service definitions (in *.services.yml). If a module updates its definitions, the caches need to be manually rebuilt. Fortunately, we already rebuild caches as the last update step, but if the offending module is called as part of the update process itself (i.e. Features), the whole update fails.

See https://www.drupal.org/node/2826466

Simply rebuilding caches as the first step should fix this.