### PR TITLE
Update Drupal VM to latest stable release.

### DIFF
--- a/phing/tasks/vm.xml
+++ b/phing/tasks/vm.xml
@@ -64,7 +64,7 @@
     <copy file="${blt.root}/scripts/drupal-vm/Vagrantfile" todir="${repo.root}" verbose="true"/>
 
     <echo>Adding geerlingguy/drupal-vm to composer dev dependencies.</echo>
-    <exec dir="${repo.root}" command="composer require --dev geerlingguy/drupal-vm:~3.4" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+    <exec dir="${repo.root}" command="composer require --dev geerlingguy/drupal-vm:~3.5" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
 
     <echo></echo>
     <echo>A new "box" directory and a Vagrantfile have been added to ${repo.root}</echo>

--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -64,7 +64,6 @@ php_packages:
   - php5.6-sqlite3
   - php5.6-xml
   - php5.6-mbstring
-  - php-pear
   - libpcre3-dev
 php_conf_paths:
   - /etc/php/5.6/fpm


### PR DESCRIPTION
The 3.4.x release of Drupal VM should work in most cases, but one of the underlying PPAs that was providing PHP 5.6 has recently gone offline and was deprecated.

So there needs to be a default variable change as well as a minor version bump so the PPA can be updated and used correctly. See here for more details on the reason the `php-pear` package should be dropped from the base install: https://github.com/oerdnj/deb.sury.org/wiki/PPA-migration-to-ppa:ondrej-php#explaining-php-pear-dependency