### PR TITLE
Fix 'blt version'

### DIFF
--- a/phing/tasks/blt.xml
+++ b/phing/tasks/blt.xml
@@ -79,7 +79,7 @@
   </target>
 
   <target name="version" description="Display the currently installed version of BLT.">
-    <exec dir="${repo.root}" command="echo 'BLT version:' $(composer info acquia/blt | grep ^versions | awk '{print $4}')" logoutput="true" checkreturn="true" level="${blt.exec_level}" />
+    <exec dir="${repo.root}" command="echo 'BLT version:' $(composer info acquia/blt | grep versions | awk '{print $4}')" logoutput="true" checkreturn="true" level="${blt.exec_level}" />
   </target>
 
   <target name="install-alias" description="Installs the BLT alias for command line usage." hidden="true">


### PR DESCRIPTION
For some users, `blt version` doesn't work:
```bash
$ blt version
Buildfile: /Users/travis.carden/Sites/example/vendor/acquia/blt/phing/build.xml

blt > version:

     [exec] BLT version:

BUILD FINISHED

Total time: 0.6789 seconds
```
It seems to have something to do with the `grep` syntax used in the task. This fixes it without any side effects on my machine.