### PR TITLE
Add .theme files to validation patternset

### DIFF
--- a/phing/tasks/filesets.xml
+++ b/phing/tasks/filesets.xml
@@ -7,6 +7,7 @@
     <include name="**/*.php"/>
     <include name="**/*.profile"/>
     <include name="**/*.test"/>
+    <include name="**/*.theme"/>
     <exclude name="**/vendor/**/*"/>
     <!-- Behat php files are ignored because method names and comments do not conform to Drupal coding standards by default. -->
     <exclude name="**/behat/**/*"/>


### PR DESCRIPTION
Includes `.theme` files as a `php` pattern so that they may be validated.