### PR TITLE
Don't uninstall dblog locally.

### DIFF
--- a/template/project.yml
+++ b/template/project.yml
@@ -95,5 +95,4 @@ modules:
     uninstall:
       - acsf
       - acquia_connector
-      - dblog
       - shield


### PR DESCRIPTION
`dblog` is both enabled and uninstalled locally, it should be only enabled.