### PR TITLE
Toggle modules per environment.

### DIFF
--- a/phing/tasks/ci.xml
+++ b/phing/tasks/ci.xml
@@ -14,8 +14,7 @@
     <phingcall target="setup">
       <property name="drush.alias" value="${drush.aliases.ci}"/>
       <property name="create_alias" value="n"/>
-      <property name="enable_property" value="modules.ci.enable"/>
-      <property name="uninstall_property" value="modules.ci.uninstall"/>
+      <property name="environment" value="ci"/>
     </phingcall>
   </target>
 
@@ -39,8 +38,7 @@
   <target name="ci:update" description="Update current database to reflect the state of the Drupal file system; uses ci drush alias." hidden="true">
     <phingcall target="setup:update">
       <property name="drush.alias" value="${drush.aliases.ci}"/>
-      <property name="enable_property" value="modules.ci.enable"/>
-      <property name="uninstall_property" value="modules.ci.uninstall"/>
+      <property name="environment" value="ci"/>
     </phingcall>
   </target>
 </project>

--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -159,8 +159,7 @@
 
   <target name="deploy:update" description="Update current database to reflect the state of the Drupal file system; uses local drush alias.">
     <phingcall target="setup:update">
-      <param name="enable_property" value="modules.deploy.enable"/>
-      <param name="uninstall_property" value="modules.deploy.uninstall"/>
+      <param name="environment" value="deploy"/>
       <property name="drush.alias" value="self"/>
       <!-- Most sites store their version-controlled configuration in /config/default. -->
       <!-- ACE internally sets the vcs configuration directory to /config/default, so we use that. -->

--- a/phing/tasks/local-sync.xml
+++ b/phing/tasks/local-sync.xml
@@ -11,8 +11,7 @@
   <target name="local:setup" description="Install dependencies, builds docroot, installs Drupal; uses local drush alias.">
     <phingcall target="setup">
       <property name="drush.alias" value="${drush.aliases.local}" />
-      <param name="enable_property" value="modules.local.enable"/>
-      <param name="uninstall_property" value="modules.local.uninstall"/>
+      <param name="environment" value="local"/>
     </phingcall>
   </target>
 
@@ -35,8 +34,7 @@
   <target name="local:update" description="Update current database to reflect the state of the Drupal file system; uses local drush alias.">
     <phingcall target="setup:update">
       <property name="drush.alias" value="${drush.aliases.local}"/>
-      <property name="enable_property" value="modules.local.enable"/>
-      <property name="uninstall_property" value="modules.local.uninstall"/>
+      <property name="environment" value="local"/>
     </phingcall>
   </target>
 

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -164,7 +164,6 @@
       <param>"install_configure_form.update_status_module='array(FALSE,FALSE)'"</param>
     </drush>
 
-    <!-- enable_property and uninstall_property must be set at this time. -->
     <phingcall target="setup:update"/>
 
     <!-- Set sites directory file permissions. -->
@@ -274,7 +273,6 @@
   </target>
 
   <target name="setup:update" description="Update current database to reflect the state of the Drupal file system." depends="setup:config-import">
-    <!-- enable_property and uninstall_property must be set at this time. -->
     <phingcall target="setup:toggle-modules"/>
   </target>
 
@@ -286,19 +284,14 @@
 
   <target name="setup:toggle-modules" description="Enables and uninstalls specified modules.">
     <if>
-      <isset property="${enable_property}"/>
+      <isset property="${environment}"/>
       <then>
         <drush command="pm-enable" assume="yes">
-          <param>${${enable_property}}</param>
+          <param>${modules.${environment}.enable}</param>
           <option name="skip"></option>
         </drush>
-      </then>
-    </if>
-    <if>
-      <isset property="${uninstall_property}"/>
-      <then>
         <drush command="pm-uninstall" assume="yes">
-          <param>${${uninstall_property}}</param>
+          <param>${modules.${environment}.uninstall}</param>
         </drush>
       </then>
     </if>

--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -12,7 +12,7 @@ deploy_updates() {
   export PATH=$repo_root/vendor/bin:$PATH
   cd $repo_root
 
-  blt deploy:update
+  blt deploy:update -Denvironment=$target_env
   if [ $? -ne 0 ]; then
       echo "Update errored."
       status=1;

--- a/template/blt/project.yml
+++ b/template/blt/project.yml
@@ -72,7 +72,20 @@ modules:
     uninstall:
       - acquia_connector
       - shield
-  deploy:
+  dev:
+    enable:
+      - acquia_connector
+      - shield
+    uninstall: []
+  test:
+    enable:
+      - acquia_connector
+      - shield
+    uninstall:
+      - devel
+      - field_ui
+      - views_ui
+  prod:
     enable:
       - acquia_connector
       - shield


### PR DESCRIPTION
Fixes #668 .

Changes proposed:
- Modules will be toggled based on the value of an "environment" parameter.
- No functional change for the `ci:setup`, `ci:update`, `local:setup`, and `local:update` targets (we are simply consolidating variables)
- For `deploy:update`, you will now need to define modules to toggle per environment. But if you prefer the old style, simply don't pass the environment parameter and it will default to `deploy` like before.