### PR TITLE
Exit gracefully when `blt` command cannot be run

### DIFF
--- a/scripts/blt/alias
+++ b/scripts/blt/alias
@@ -10,6 +10,6 @@ function blt() {
     $GIT_ROOT/vendor/bin/blt "$@"
   else
     echo "You must run this command from within a BLT-generated project repository."
-    exit 1
+    return 1
   fi
 }


### PR DESCRIPTION
Fixes #708.

Changes proposed:
- Return instead of exiting when the `blt` command is run outside a BLT-generated project repository. It still passes the exit code correctly to bash but doesn't kill the session.