### PR TITLE
Fixes #712: Fix BLT's ReadTheDocs search.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ site_description: 'BLT - Acquia Build & Launch Tools'
 theme: readthedocs
 strict: true
 
+extra_javascript:
+  - readme/js/fix_search.js
+
 markdown_extensions:
   - toc:
       permalink: True

--- a/readme/js/fix_search.js
+++ b/readme/js/fix_search.js
@@ -1,0 +1,44 @@
+(function (){
+  var MutationObserver = (function () {
+    var prefixes = ['WebKit', 'Moz', 'O', 'Ms', '']
+    for (var i=0; i < prefixes.length; i++) {
+      if (prefixes[i] + 'MutationObserver' in window) {
+        return window[prefixes[i] + 'MutationObserver'];
+      }
+    }
+    return false;
+  }());
+
+  /*
+  * RTD messes up MkDocs' search feature by tinkering with the search box defined in the theme, see
+  * https://github.com/rtfd/readthedocs.org/issues/1088. This function sets up a DOM4 MutationObserver
+  * to react to changes to the search form (triggered by RTD on doc ready). It then reverts everything
+  * the RTD JS code modified.
+  *
+  * @see https://github.com/rtfd/readthedocs.org/issues/1088#issuecomment-224715045
+  */
+  $(document).ready(function () {
+    if (!MutationObserver) {
+      return;
+    }
+    var target = document.getElementById('rtd-search-form');
+    var config = {attributes: true, childList: true};
+
+    var observer = new MutationObserver(function(mutations) {
+      // if it isn't disconnected it'll loop infinitely because the observed element is modified
+      observer.disconnect();
+      var form = $('#rtd-search-form');
+      var path = window.location.pathname;
+      var branch = path.split('/')[2];
+      form.empty();
+      form.attr('action', window.location.origin + '/en/' + branch + '/search.html');
+      $('<input>').attr({
+        type: "text",
+        name: "q",
+        placeholder: "Search docs"
+      }).appendTo(form);
+    });
+
+    observer.observe(target, config);
+  });
+}());


### PR DESCRIPTION
Fixes #712

Changes proposed:
- Add a JS file to make search work.
- Make sure the JS file is on the page (path should be correct, but might need to switch it from `readme/js/fix_search.js` to `js/fix_search.js` if it's not the right path).