### PR TITLE
Issue #704: Fixed update hooks.

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -38,11 +38,11 @@ class Updates {
 
   /**
    * @Update(
-   *   version = "8.5.2",
+   *   version = "8.6.0-beta1",
    *   description = "Moves configuration files to blt subdirectory. Removes .git/hooks symlink."
    * )
    */
-  public function update_852() {
+  public function update_860() {
     // Move files to blt subdir.
     $this->updater->moveFile('project.yml', 'blt/project.yml', TRUE);
     $this->updater->moveFile('project.local.yml', 'blt/project.local.yml', TRUE);

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -29,12 +29,20 @@ class Updates {
   /**
    * @Update(
    *   version = "8.5.1",
-   *   description = "Removes deprecated features patch. Moves configuration files to blt subdirectory. Removes .git/hooks symlink."
+   *   description = "Removes deprecated features patch."
    * )
    */
   public function update_851() {
     $this->updater->removePatch("drupal/features", "https://www.drupal.org/files/issues/features-2808303-2.patch");
+  }
 
+  /**
+   * @Update(
+   *   version = "8.5.2",
+   *   description = "Moves configuration files to blt subdirectory. Removes .git/hooks symlink."
+   * )
+   */
+  public function update_852() {
     // Move files to blt subdir.
     $this->updater->moveFile('project.yml', 'blt/project.yml', TRUE);
     $this->updater->moveFile('project.local.yml', 'blt/project.local.yml', TRUE);
@@ -44,5 +52,6 @@ class Updates {
     $this->updater->deleteFile('.git/hooks');
     $this->updater->getOutput()->writeln('.git/hooks was deleted. Please re-run setup:git-hooks to install git hooks locally.');
   }
+
 
 }


### PR DESCRIPTION
Fixes (partly) #704 

`project.yml` was moved to the `blt` subdirectory as part of 8.6.0-beta1, not 8.5.1, which is why I think this update hook wasn't running.

I'm not sure if this is the correct version syntax to apply, still testing locally.