### PR TITLE
Fixed munged YAML indentation.

### DIFF
--- a/src/Console/Command/YamlMungeCommand.php
+++ b/src/Console/Command/YamlMungeCommand.php
@@ -51,7 +51,7 @@ class YamlMungeCommand extends Command
 
     $munged_contents = array_replace_recursive((array) $file1_contents, (array) $file2_contents);
 
-    return Yaml::dump($munged_contents, 3);
+    return Yaml::dump($munged_contents, 3, 2);
   }
 
   protected function parseFile($file) {


### PR DESCRIPTION
We use an indentation of two spaces for YAML files, namely project.yml: https://github.com/acquia/blt/blob/8.x/template/blt/project.yml

However, when we munge YAML files, they are output with the Symfony default of 4 spaces:
- https://github.com/acquia/blt/blob/8.x/src/Console/Command/YamlMungeCommand.php#L54 
- https://github.com/symfony/yaml/blob/master/Yaml.php#L95

This munges to two spaces for consistency.