### PR TITLE
Change private files path.

### DIFF
--- a/phing/files/.gitignore
+++ b/phing/files/.gitignore
@@ -5,6 +5,7 @@ local.*
 # Ignore paths that contain user-generated content.
 docroot/sites/*/files
 docroot/sites/*/files-private
+docroot/sites/*/private
 
 # OS X
 .DS_Store

--- a/phing/files/.gitignore
+++ b/phing/files/.gitignore
@@ -4,7 +4,7 @@ local.*
 
 # Ignore paths that contain user-generated content.
 docroot/sites/*/files
-docroot/sites/*/private
+docroot/sites/*/files-private
 
 # OS X
 .DS_Store

--- a/phing/files/deploy-exclude.txt
+++ b/phing/files/deploy-exclude.txt
@@ -12,7 +12,7 @@
 /docroot/libraries/contrib
 /docroot/modules/contrib
 /docroot/sites/*/files
-/docroot/sites/*/private
+/docroot/sites/*/files-private
 /docroot/themes/contrib
 /drush/contrib
 /drush.wrapper

--- a/phing/files/deploy-exclude.txt
+++ b/phing/files/deploy-exclude.txt
@@ -13,6 +13,7 @@
 /docroot/modules/contrib
 /docroot/sites/*/files
 /docroot/sites/*/files-private
+/docroot/sites/*/private
 /docroot/themes/contrib
 /drush/contrib
 /drush.wrapper

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -9,6 +9,7 @@ docroot/core
 # Ignore paths that contain user-generated content.
 docroot/sites/*/files
 docroot/sites/*/files-private
+docroot/sites/*/private
 
 # Ignore contrib modules. These should be created during build process.
 docroot/modules/contrib

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -8,7 +8,7 @@ docroot/core
 
 # Ignore paths that contain user-generated content.
 docroot/sites/*/files
-docroot/sites/*/private
+docroot/sites/*/files-private
 
 # Ignore contrib modules. These should be created during build process.
 docroot/modules/contrib


### PR DESCRIPTION
This is a proposed change for the private files path in BLT. Acquia hosting puts private files in a `files-private` directory. BLT uses `private` directory (inside the `sites/*/` directory) for the same files. This PR just proposes to align the naming conventions. I know not everyone using BLT uses Acquia, but even within BLT you have `files-private` [mentions](https://github.com/acquia/blt/search?utf8=%E2%9C%93&q=files-private) throughout the code (namely [blt/default.local.settings.php](https://github.com/acquia/blt/blob/8.x/settings/default.local.settings.php#L126))

Changes proposed:
- Change `.gitignore` files
- Exclude folder on creation of artifact

Consideration: do we need some kind of upgrade task for this type of thing? I'm thinking maybe not b/c of the above mentioned default file.

