### PR TITLE
Fixed errors on ACE deploys.

### DIFF
--- a/phing/tasks/properties.xml
+++ b/phing/tasks/properties.xml
@@ -33,7 +33,7 @@
     </then>
   </if>
   <exec dir="${repo.root}" command="cat ${blt.config-files.schema-version}" outputProperty="blt.schema-version" checkreturn="true" logoutput="false" level="${blt.exec_level}"/>
-  <exec dir="${repo.root}" command="composer info acquia/blt | grep versions | awk '{print $4}'" outputProperty="blt.version" logoutput="false " checkreturn="true" level="${blt.exec_level}" error="/dev/null" />
+  <exec dir="${repo.root}" command="composer info acquia/blt | grep versions | awk '{print $4}'" outputProperty="blt.version" logoutput="false" checkreturn="true" level="${blt.exec_level}" />
 
   <!--verbosityTask is used to set the verbosity level of Phing via a property. It is necessary because the -verbose, -debug, -silent, and -quiet command line options are not available as properties and cannot be utilized in task conditionals. -->
   <verbosityTask level="${blt.level}"/>

--- a/phing/tasks/properties.xml
+++ b/phing/tasks/properties.xml
@@ -33,7 +33,7 @@
     </then>
   </if>
   <exec dir="${repo.root}" command="cat ${blt.config-files.schema-version}" outputProperty="blt.schema-version" checkreturn="true" logoutput="false" level="${blt.exec_level}"/>
-  <exec dir="${repo.root}" command="composer info acquia/blt | grep versions | awk '{print $4}'" outputProperty="blt.version" logoutput="false " checkreturn="true" level="${blt.exec_level}" />
+  <exec dir="${repo.root}" command="composer info acquia/blt | grep versions | awk '{print $4}'" outputProperty="blt.version" logoutput="false " checkreturn="true" level="${blt.exec_level}" error="/dev/null" />
 
   <!--verbosityTask is used to set the verbosity level of Phing via a property. It is necessary because the -verbose, -debug, -silent, and -quiet command line options are not available as properties and cannot be utilized in task conditionals. -->
   <verbosityTask level="${blt.level}"/>


### PR DESCRIPTION
After updating to 8.6.0-beta1, deployments to ACE throw this error:

> sh: 1: 
> composer: not found

I'm assuming this is due to the addition of this version check, which uses composer: https://github.com/acquia/blt/blob/8.x/phing/tasks/properties.xml#L36

This may not be the most elegant solution, but it eliminates the errors. Another (more performant) solution might be to make the version check a dedicated function that runs only as a dependency of Phing targets that need it (i.e. `update-delta` and `version`)

Still testing this.