### PR TITLE
Fixed composer errors on ACE.

### DIFF
--- a/phing/tasks/properties.xml
+++ b/phing/tasks/properties.xml
@@ -33,7 +33,8 @@
     </then>
   </if>
   <exec dir="${repo.root}" command="cat ${blt.config-files.schema-version}" outputProperty="blt.schema-version" checkreturn="true" logoutput="false" level="${blt.exec_level}"/>
-  <exec dir="${repo.root}" command="composer info acquia/blt | grep versions | awk '{print $4}'" outputProperty="blt.version" logoutput="false" checkreturn="true" level="${blt.exec_level}" />
+  <!-- Send errors to /dev/null, for environments like ACE without composer. -->
+  <exec dir="${repo.root}" command="composer info acquia/blt 2> /dev/null | grep versions | awk '{print $4}'" outputProperty="blt.version" logoutput="false" checkreturn="true" level="${blt.exec_level}" />
 
   <!--verbosityTask is used to set the verbosity level of Phing via a property. It is necessary because the -verbose, -debug, -silent, and -quiet command line options are not available as properties and cannot be utilized in task conditionals. -->
   <verbosityTask level="${blt.level}"/>


### PR DESCRIPTION
Turns out #733 wasn't a complete fix... I think because of the way the commands are piped together, errors from the first command (`composer`) aren't caught by Phing.

