### PR TITLE
Generating a subtheme in project set-up. Adding default front-end tasks.

### DIFF
--- a/phing/tasks/frontend.xml
+++ b/phing/tasks/frontend.xml
@@ -2,18 +2,37 @@
 
   <target name="frontend" description="Runs all frontend targets"
           depends="frontend:setup, frontend:build">
+    <echo>Running main frontend task.</echo>
   </target>
 
-  <target name="frontend:setup" description="Uses project.yml hooks to run custom defined commands to setup front end dependencies for frontend:build." hidden="true">
-    <phingcall target="target-hook:invoke">
-      <property name="hook-name" value="frontend-setup"/>
-    </phingcall>
+  <target name="frontend:setup" description="Uses project.yml hooks to run custom defined commands to setup front end dependencies for frontend:build.">
+    <if>
+      <available file='${target-hooks.frontend-setup.dir}' type='dir' />
+      <then>
+        <phingcall target="target-hook:invoke">
+          <property name="hook-name" value="frontend-setup"/>
+        </phingcall>
+        <echo>Front-end setup task run.</echo>
+      </then>
+      <else>
+        <echo>Subtheme not yet created.</echo>
+      </else>
+    </if>
   </target>
 
-  <target name="frontend:build" description="Uses project.yml hooks to run custom defined commands to build front end dependencies for custom themes." hidden="true">
-    <phingcall target="target-hook:invoke">
-      <property name="hook-name" value="frontend-build"/>
-    </phingcall>
+  <target name="frontend:build" description="Uses project.yml hooks to run custom defined commands to build front end dependencies for custom themes.">
+    <if>
+      <available file='${target-hooks.frontend-setup.dir}' type='dir' />
+      <then>
+        <phingcall target="target-hook:invoke">
+          <property name="hook-name" value="frontend-build"/>
+        </phingcall>
+        <echo>Front-end build task run.</echo>
+      </then>
+      <else>
+        <echo>Subtheme not yet created.</echo>
+      </else>
+    </if>
   </target>
 
 </project>

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -1,7 +1,7 @@
 <project name="setup" default="setup">
 
   <target name="setup" description="Install dependencies, builds docroot, installs Drupal."
-          depends="setup:build, setup:drupal:install, install-alias">
+          depends="setup:build, setup:drupal:install, setup:subtheme, install-alias, setup:enable-subtheme">
     <echo>For a full list of available Phing targets, run:</echo>
     <echo>blt -l</echo>
     <echo></echo>
@@ -287,6 +287,19 @@
         </drush>
       </then>
     </if>
+  </target>
+
+  <!-- Create a subtheme and set it as the site default -->
+  <target name="setup:subtheme" description="Creates a new subtheme of Cog.">
+    <drush command="en cog -y" verbose="false" logoutput="true" />
+    <drush command="cog ${project.subtheme.machine_name} ${project.subtheme.human_name} --description=${project.subtheme.description}" verbose="false" dir="${docroot}/themes/contrib/cog" logoutput="true" />
+    <echo>Created ${project.subtheme.machine_name} subtheme</echo>
+  </target>
+
+  <target name="setup:enable-subtheme" description="Enables subtheme">
+    <drush command="en ${project.subtheme.machine_name} -y" verbose="false" logoutput="true" />
+    <drush command="config-set system.theme default ${project.subtheme.machine_name}" verbose="false" logoutput="true" />
+    <phingcall target="frontend" />
   </target>
 
 </project>

--- a/template/blt/project.yml
+++ b/template/blt/project.yml
@@ -12,6 +12,11 @@ project:
   local:
     protocol: http
     hostname: local.${project.machine_name}.com
+  # These values will be used to generate the theme for this project.
+  subtheme:
+    machine_name: cogsub
+    human_name: 'Cog Subtheme'
+    description: 'A subtheme of Cog.'
 
 # Configuration settings for new git repository.
 git:
@@ -39,15 +44,15 @@ target-hooks:
   # Executed when front end dependencies should be installed.
   frontend-setup:
     # E.g., ${docroot}/sites/all/themes/custom/mytheme.
-    dir: ${docroot}
+    dir: '${docroot}/themes/custom/${project.subtheme.machine_name}'
     # E.g., `npm install` or `bower install`.
-    command: echo 'No frontend-setup configured.'
+    command: 'npm install'
   # Executed when front end assets should be generated.
   frontend-build:
     # E.g., ${docroot}/sites/all/themes/custom/mytheme.
-    dir: ${docroot}
+    dir: '${docroot}/themes/custom/${project.subtheme.machine_name}'
     # E.g., `npm run build`.
-    command: echo 'No frontend-build configured.'
+    command: 'gulp'
   # Executed after deployment artifact is created.
   post-deploy-build:
     dir: ${docroot}


### PR DESCRIPTION
Changes proposed:
- Generate a Cog subtheme when setting up a new project.
- Add default front-end tasks to build the theme on install.

