### PR TITLE
Fix 'ore' typo fix in Behat fail message.

### DIFF
--- a/phing/tasks/tests.xml
+++ b/phing/tasks/tests.xml
@@ -89,7 +89,7 @@
           <not><equals arg1="${behatPass}" arg2="0"/></not>
           <then>
             <phingcall target="tests:selenium:kill"/>
-            <fail message="One ore more Behat tests failed." />
+            <fail message="One or more Behat tests failed." />
           </then>
           <else>
             <echo>All Behat tests in ${behat.path} have passed.</echo>


### PR DESCRIPTION
Changes proposed:
- Fix a typo.

Suggestions for award:
- Trivial patch of the day.
