### PR TITLE
Issue 779 Separate out composer from drush in acsf:init

### DIFF
--- a/phing/tasks/acsf.xml
+++ b/phing/tasks/acsf.xml
@@ -3,6 +3,12 @@
   <target name="acsf:init" description="Initializes ACSF support for project.">
     <echo>Adding acsf module as a dependency.</echo>
     <exec dir="${repo.root}" command="composer require drupal/acsf:^8" logoutput="true" checkreturn="true" passthru="true" level="${blt.exec_level}"/>
+    <!-- Run the acsf init commands. -->
+    <phingcall target="acsf:init:drush"/>
+  </target>
+
+  <!-- Run the acsf init commands to sync library files. -->
+  <target name="acsf:init:drush" description="Refreshes the acsf settings and hook files.">
     <echo>Executing initialization command for acsf module.</echo>
     <drush command="acsf-init">
       <option name="include">"${docroot}/modules/contrib/acsf/acsf_init"</option>


### PR DESCRIPTION
Fixes # 779

Changes proposed:
- create a new acsf:init:drush task that does the drush work

This should allow builds to be more efficient since I think that composer update will get new versions of acsf and there should be no need to run that twice if the project is already 'inited'
