### PR TITLE
Adds gotchas to the INSTALL documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,6 +32,8 @@ If you'd like to create a VM with BLT, you will require the following additional
         brew install ansible
         brew cask install virtualbox vagrant
 
+The minimum required versions are VirtualBox 5.1.x and Vagrant 1.8.6. The local PHP environment should also have a memory limit of at least 2G for BLT to initialise.
+
 If you'd like to execute Behat tests from the host machine, you will need Java:
 
         brew cask install java


### PR DESCRIPTION
I ran into a couple of issues while installing BLT for the first time on my Mac. I already had vagrant and virtualbox installed but neglected to update. I also had a low memory limit for PHP which caused BLT to fail on first install. After going through various issues in both BLT and DrupalVM, I learned of these issues and have added explicit documentation to call them out for others.
