### PR TITLE
Fixes #796: Don't exclude local.* files from build artifact.

### DIFF
--- a/phing/files/deploy-exclude.txt
+++ b/phing/files/deploy-exclude.txt
@@ -25,7 +25,7 @@
 /.gitignore
 .git
 example.*
-local.*
-*.local.*
+local.settings.php
+local.drushrc.php
 node_modules
 /vendor

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,5 +1,6 @@
 # Ignore configuration files that may contain sensitive information.
-local.*
+local.settings.php
+local.drushrc.php
 *.local
 project.local.yml
 


### PR DESCRIPTION
Fixes #796 .

Changes proposed:
- Don't exclude `local.*` from default gitignore template for build artifacts.
- Don't exclude `local.*` files from default `deploy-exclude.txt` file.

