### PR TITLE
BLT-802: replacing cc with cr

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -232,7 +232,7 @@
           <param>features</param>
         </drush>
         <!-- Clear drush caches to register features drush commands. -->
-        <drush command="cc" assume="yes" alias="${drush.alias}">
+        <drush command="cr" alias="${drush.alias}">
           <param>drush</param>
         </drush>
         <!-- Revert all features. -->


### PR DESCRIPTION
Fixes #802  .

Changes proposed:
- replace deprecated cc (cache clear) command with correct d8 cr (cache-rebuild)
command during features-import process 
