### PR TITLE
Fixes #809: Add mailhog to Drupal VM installed_extras.

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -45,6 +45,7 @@ nodejs_install_npm_user: "{{ drupalvm_user }}"
 npm_config_prefix: "/home/{{ drupalvm_user }}/.npm-global"
 installed_extras:
   - adminer
+  - mailhog
   - nodejs
   - selenium
 


### PR DESCRIPTION
Fixes #809.

Changes proposed:
- Install `mailhog` in Drupal VM by default, so email is caught locally (regardless of Drupal site configuration).