### PR TITLE
Fixed memcache contamination.

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -15,7 +15,7 @@
         "drupal/cog": "^1.0.0",
         "drupal/core": "^8.0",
         "drupal/features": "^3.0.0",
-        "drupal/memcache": "^2.0.0-alpha2",
+        "drupal/memcache": "2.x-dev",
         "drupal/seckit": "^1.0.0-alpha2",
         "drupal/security_review": "*",
         "drupal/shield": "^1.0.0",
@@ -51,9 +51,9 @@
         },
         "enable-patching": true,
         "patches": {
-           "acquia/lightning": {
-               "New LightningExtension subcontexts do not autoload": "https://www.drupal.org/files/issues/2836258-3-lightning-extension-autoload.patch"
-           }
+            "acquia/lightning": {
+                "New LightningExtension subcontexts do not autoload": "https://www.drupal.org/files/issues/2836258-3-lightning-extension-autoload.patch"
+            }
         },
         "installer-paths": {
             "docroot/core": [


### PR DESCRIPTION
We noticed odd behavior on our dev/stage sites (which share the same hardware) where cache keys were very clearly being shared between sites. For instance, we deployed a module to dev, and then got routing errors on stage indicating that Drupal was looking for that module.

My theory is that the memcache module is not properly prefixing keys per host. It appears that the ACE server-side includes do configure these keys correctly, and the memcache store uses them correctly about 99% of the time. But if the key is too long, the memcache module hashes it and I think this is the case where the hostname is ignored and caches can become contaminated across multiple sites on the same server.

This is fixed upstream here, so updating to dev should fix it: https://www.drupal.org/node/2701903

I also requested a new alpha release, so we can get back off of dev ASAP: https://www.drupal.org/node/2837857