### PR TITLE
Added Drush to DrupalVM.

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -45,6 +45,7 @@ nodejs_install_npm_user: "{{ drupalvm_user }}"
 npm_config_prefix: "/home/{{ drupalvm_user }}/.npm-global"
 installed_extras:
   - adminer
+  - drush
   - mailhog
   - nodejs
   - selenium


### PR DESCRIPTION
DrupalVM 4.* no longer includes Drush by default, it needs to be specifically included.

Without this, most BLT tasks fail.

cc @geerlingguy 