### PR TITLE
Issue #38: Test for features overrides.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -293,6 +293,18 @@
     <drush command="fra" assume="yes" alias="${drush.alias}">
       <option name="bundle">${bundle}</option>
     </drush>
+    <if>
+      <equals arg1="${cm.features.no-overrides}" arg2="true"/>
+      <then>
+        <exec command="${drush.bin} @${drush.alias} fl --bundle=${bundle} | grep -Ei '(changed|conflicts|added)( *)$'" outputProperty="features.overrides"/>
+        <if>
+          <istrue value="${features.overrides}"/>
+          <then>
+            <fail>A feature in the ${bundle} bundle is overridden. You must re-export this feature to incorporate the changes.</fail>
+          </then>
+        </if>
+      </then>
+    </if>
   </target>
 
   <target name="setup:toggle-modules" description="Enables and uninstalls specified modules.">

--- a/template/blt/project.yml
+++ b/template/blt/project.yml
@@ -61,6 +61,7 @@ target-hooks:
 # cm:
 #   features:
 #     bundle: blted8
+#     no-overrides: 'true'
 
 # Define any custom Phing files that you'd like to import. E.g., ${repo.root}/blt/phing/build.xml
 import: ~


### PR DESCRIPTION
Fixes #38

Changes proposed:
- Adds a cm.features.no-overrides property. If this property is true, BLT will check for any overridden features immediately after importing all features on updates.
