### PR TITLE
Add php5.6-yaml package

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -52,6 +52,8 @@ installed_extras:
 
 # Use PHP 5.6.
 php_version: "5.6"
-
+php_packages:
+  - php5.6-yaml
+  
 post_provision_scripts:
   - "../../../acquia/blt/scripts/drupal-vm/post-provision.sh"


### PR DESCRIPTION
Changes proposed:
- Add php5.6-yaml package (which is now enabled on many Acquia environments) to Vagrant box.
