### PR TITLE
Update bash console with new blt command

### DIFF
--- a/readme/creating-new-project.md
+++ b/readme/creating-new-project.md
@@ -12,6 +12,7 @@
 1. Install the `blt` alias and follow on-screen instructions:
 
         composer blt-alias
+        source ~/.bash_profile
 
 1. Customize `blt/project.yml`.
 


### PR DESCRIPTION
You need to run source ~/.bash_profile on OSX to update you console to use the blt command

Fixes # .

Changes proposed:
-
-
