### PR TITLE
Fixes #866: Remove default git.remotes url from project.yml on project create.

### DIFF
--- a/phing/tasks/blt.xml
+++ b/phing/tasks/blt.xml
@@ -9,6 +9,9 @@
     <exec dir="${repo.root}" command="result=${PWD##*/}; printf '%s\n' &quot;${PWD##*/}&quot;" logoutput="false" checkreturn="true" level="${blt.exec_level}" passthru="false" outputProperty="dirname"/>
     <exec dir="${repo.root}" command="${composer.bin}/drupal yaml:update:value ${blt.config-files.project} project.machine_name '${dirname}'" logoutput="true" checkreturn="false" level="${blt.exec_level}" passthru="true"/>
 
+    <!-- Remove default git remote -->
+    <exec dir="${repo.root}" command="${composer.bin}/drupal yaml:update:value ${blt.config-files.project} git.remotes.0 ''"  logoutput="true" checkreturn="false" level="${blt.exec_level}" passthru="true"/>
+
     <exec dir="${repo.root}" command="git add -A" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
     <exec dir="${repo.root}" command="git commit -m 'Initial commit.'" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
     <exec dir="${repo.root}" command="cat ${blt.root}/scripts/blt/ascii-art.txt" logoutput="true" passthru="true" checkreturn="false"/>

--- a/readme/next-steps.md
+++ b/readme/next-steps.md
@@ -19,7 +19,6 @@ Here are tasks that are typically performed at this stage:
 
 * Create and deploy an artifact. See [Deployment workflow](deploy.md).
 
-        # Ensure git.remotes are set in blt/project.yml. You should replace the default Bolt Acquia Cloud repository with your Acquia      Cloud repository and you should add your Github repository
         blt deploy
 
 Other commonly used commands:


### PR DESCRIPTION
Fixes #866

I wanted to set the value as any empty array, like: 
```
git:
    default_branch: master
    remotes: { }
```
but `drupal yaml:update:value` can only work with basic values. So I have set it to empty value, like:
```
git:
    default_branch: master
    remotes:
        - ''
```