### PR TITLE
Fixes #898: Upgrade to Drupal VM 4.1.0.

### DIFF
--- a/phing/tasks/vm.xml
+++ b/phing/tasks/vm.xml
@@ -64,7 +64,7 @@
     <copy file="${blt.root}/scripts/drupal-vm/Vagrantfile" todir="${repo.root}" verbose="true"/>
 
     <echo>Adding geerlingguy/drupal-vm to composer dev dependencies.</echo>
-    <exec dir="${repo.root}" command="composer require --dev geerlingguy/drupal-vm:~4.0" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+    <exec dir="${repo.root}" command="composer require --dev geerlingguy/drupal-vm:~4.1" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
 
     <echo></echo>
     <echo>A new "box" directory and a Vagrantfile have been added to ${repo.root}</echo>


### PR DESCRIPTION
Fixes #898.

Changes proposed:
- Bump Drupal VM version requirement to `~4.1`.