### PR TITLE
Fixes #840: Git commit messages are not being validated.

### DIFF
--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -4,11 +4,26 @@
 #
 # You may adapt the message length check. Currently checking it's longer than
 # 15 characters.
-ROOT_DIR="$(pwd)/"
-PREFIX=$($ROOT_DIR/vendor/bin/drupal yaml:get:value $ROOT_DIR/blt/project.yml project.prefix)
-regex="^${PREFIX}-[0-9]+(: )[^ ].{15,}\."
+
+ROOT_DIR="$(pwd)"
+COMMAND="$ROOT_DIR/vendor/bin/drupal yaml:get:value $ROOT_DIR/blt/project.yml project.prefix"
+ERROR=$($COMMAND 2>&1 > /dev/null)
+PREFIX=$($COMMAND)
 RED='\033[0;31m'
 NO_COLOR='\033[0m'
+
+# Make sure there are no errors while running drupal console command
+# todo: It would have be easy, just by discarding the std error, but for some
+# reason the error message is repeated on std out - which messes up everything.
+if [ -n "$ERROR" ]; then
+  printf "${RED}Error: could not get project prefix!${NO_COLOR} Please check:\n"
+  echo "* Project prefix is set properly in project.yml."
+  echo "* Drupal console is configured properly, to configure run \"drupal init\"."
+  exit 1;
+fi
+
+# Validate the commit message.
+regex="^${PREFIX}-[0-9]+(: )[^ ].{15,}\."
 if ! grep -iqE "$regex" "$1"; then
   printf "${RED}Error: invalid commit message!${NO_COLOR} Commit messages must:\n"
   echo "* Contain the project prefix followed by a hyphen"
@@ -17,4 +32,3 @@ if ! grep -iqE "$regex" "$1"; then
   echo "Valid example: $PREFIX-135: Added the new picture field to the article feature."
   exit 1;
 fi
-


### PR DESCRIPTION
Fixes #840

Changes:
Shows an error message, when there is an error while running console command to get the project prefix. Or if for some reason project prefix is not set in `project.yml`.

@grasmash I do not see any error/warning for `date.timezone` even though I do not have `date.time` set in php.ini. Looks like when `date.time` is set correctly in console config i.e `phpcheck.yml` - everything works perfectly. checkPhpDateTimezone is already there, so skipping that.