### PR TITLE
Add tagging of remote repo.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -18,10 +18,27 @@
                     promptText="Enter a deploy branch (defaults to [current branch]-build)"
                     promptCharacter=":"
                     defaultValue="${branch.current}-build"/>
-    <propertyprompt propertyName="deploy.tag" useExistingValue="true"
-                    promptText="Enter the name of the tag to create"
-                    promptCharacter=":"
-                    defaultValue=""/>
+
+    <if>
+      <isset property="deploy.tag"/>
+      <then>
+        <property name="deploy.tag.create" value="y" />
+      </then>
+    </if>
+
+    <propertyprompt promptText="Would you like to create a tag? [y/n]"
+                    useExistingValue="true"
+                    propertyName="deploy.tag.create"
+                    defaultValue="n"/>
+    <if>
+      <equals arg1="${deploy.tag.create}" arg2="y" casesensitive="false"/>
+      <then>
+        <propertyprompt propertyName="deploy.tag" useExistingValue="true"
+                        promptText="Enter the name of the tag to create"
+                        promptCharacter=":"
+                        defaultValue=""/>
+      </then>
+    </if>
 
     <!-- Check necessary runtime parameters. -->
     <if>

--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -192,7 +192,6 @@
     <if>
       <isset property="deploy.tag"/>
       <then>
-        <exec command="echo ${deploy.remote} | openssl md5 | cut -d' ' -f 2" outputProperty="remoteName"/>
         <exec command="git push ${remoteName} ${deploy.tag}-build" dir="${deploy.dir}" outputProperty="deploy.push.output" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
         <exec command="export DEPLOY_UPTODATE=$(echo '${deploy.push.output}' | grep --quiet 'Everything up-to-date')" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
       </then>

--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -18,6 +18,10 @@
                     promptText="Enter a deploy branch (defaults to [current branch]-build)"
                     promptCharacter=":"
                     defaultValue="${branch.current}-build"/>
+    <propertyprompt propertyName="deploy.tag" useExistingValue="true"
+                    promptText="Enter the name of the tag to create"
+                    promptCharacter=":"
+                    defaultValue=""/>
 
     <!-- Check necessary runtime parameters. -->
     <if>
@@ -47,6 +51,14 @@
     <!--Commit artifact. -->
     <phingcall target="deploy:commit"/>
 
+    <!-- Commit tag if present -->
+    <if>
+      <isset property="deploy.tag"/>
+      <then>
+        <phingcall target="deploy:tag"/>
+      </then>
+    </if>
+
     <!-- Push up changes to remotes if this is not a dry run.-->
     <if>
       <not><isset property="deploy.dryRun"/></not>
@@ -54,6 +66,7 @@
         <phingcall target="deploy:push-all"/>
       </then>
     </if>
+
   </target>
 
   <target name="deploy:remote:add" description="Adds a git remote and checks out deploy branch from upstream." hidden="true">
@@ -157,6 +170,16 @@
     <exec command="echo ${deploy.remote} | openssl md5 | cut -d' ' -f 2" outputProperty="remoteName"/>
     <exec command="git push ${remoteName} ${deploy.branch}" dir="${deploy.dir}" outputProperty="deploy.push.output" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
     <exec command="export DEPLOY_UPTODATE=$(echo '${deploy.push.output}' | grep --quiet 'Everything up-to-date')" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+
+    <!-- Push tag if present -->
+    <if>
+      <isset property="deploy.tag"/>
+      <then>
+        <exec command="echo ${deploy.remote} | openssl md5 | cut -d' ' -f 2" outputProperty="remoteName"/>
+        <exec command="git push ${remoteName} ${deploy.tag}-build" dir="${deploy.dir}" outputProperty="deploy.push.output" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
+        <exec command="export DEPLOY_UPTODATE=$(echo '${deploy.push.output}' | grep --quiet 'Everything up-to-date')" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+      </then>
+    </if>
   </target>
 
   <target name="deploy:sanitize" description="Removes sensitive files from the deploy docroot." hidden="true">
@@ -178,5 +201,10 @@
       <!-- ACE internally sets the vcs configuration directory to /config/default, so we use that. -->
       <property name="cm.core.config-dir" value="vcs"/>
     </phingcall>
+  </target>
+
+  <target name="deploy:tag" description="Tag repository.">
+    <!-- Add -build to tag. -->
+    <exec command="git tag -a ${deploy.tag}-build -m '${deploy.commitMsg}'" dir="${deploy.dir}" logoutput="true" level="${blt.exec_level}" passthru="true"/>
   </target>
 </project>


### PR DESCRIPTION
Fixes #830.

Changes proposed:
Todos:

- [x] Create a new deploy:tag target, which create a tag on remotes.
- [x] Add a prompt to the deploy target which asks Would you like to create a tag?.
- [x] If yes, prompt for tag name "Enter the name of the tag to create:" and use input to set the value of deploy.tag property.
- [x] Modify deploy target. If deploy.tag is set, call deploy:tag after deploy:commit.
- [x] Modify deploy:push-remote target. If deploy.tag is set, push tags too.
- [ ] Document new feature.


Note: I incorporated this into my project's .travis.yml by adding:

```
deploy:
   - provider: script
     script: blt deploy -Ddeploy.commitMsg="Automated commit by Travis CI for Build ${TRAVIS_TAG}" -Ddeploy.branch="master-build" -Ddeploy.tag="${TRAVIS_TAG}"
     skip_cleanup: true
     on:
       tags: true
       php: 5.6
```

Using this in travisCI will force a tag on the master branch. TRAVIS_BRANCH variable is set to the same as TRAVIS_TAG when travis is building based on a tag.