### PR TITLE
Ignore local.aliases.drush.php

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,6 +1,7 @@
 # Ignore configuration files that may contain sensitive information.
 local.settings.php
 local.drushrc.php
+local.aliases.drushrc.php
 local.services.yml
 tests/behat/local.yml
 box/local.config.yml


### PR DESCRIPTION
As a result of https://github.com/acquia/blt/pull/797 local.aliases.drushrc.php is no longer git-ignored. Similar PR to https://github.com/acquia/blt/pull/905.