### PR TITLE
Documented setup:update task.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -220,6 +220,8 @@
       <param>${cm.core.config-dir}</param>
     </drush>
     <!-- Execute db updates. -->
+    <!-- This must happen before features are imported or configuration is imported. -->
+    <!-- For instance, if you add a dependency on a new extension to an existing configuration file, you must enable that extension via an update hook before attempting to import the configuration. -->
     <drush command="updb" assume="yes" alias="${drush.alias}">
       <option name="entity-updates"></option>
     </drush>


### PR DESCRIPTION
In trying to solve #842, I thought I was being very clever by trying to run features-imports before database updates. But then I realized that this will cause nasty problems. I just thought I should document the reason here in case someone tries to get "smart" like me again in the future.

Basically, you should _always_ run database updates before feature reverts or config imports. For instance, you might add a dependency on a new module to an existing config file. If that module isn't already installed before you try to import the config file, the import will fail. The only way to prevent this is to enable the module first via an update hook.