### PR TITLE
Ignore private files.

### DIFF
--- a/phing/files/.gitignore
+++ b/phing/files/.gitignore
@@ -5,7 +5,7 @@ project.local.yml
 
 # Ignore paths that contain user-generated content.
 docroot/sites/*/files
-docroot/sites/*/files-private
+/files-private
 docroot/sites/*/private
 
 # Ignore build artifacts

--- a/phing/files/deploy-exclude.txt
+++ b/phing/files/deploy-exclude.txt
@@ -12,7 +12,7 @@
 /docroot/libraries/contrib
 /docroot/modules/contrib
 /docroot/sites/*/files
-/docroot/sites/*/files-private
+/files-private
 /docroot/sites/*/private
 /docroot/themes/contrib
 /drush/contrib

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -13,7 +13,7 @@ docroot/core
 
 # Ignore paths that contain user-generated content.
 docroot/sites/*/files
-docroot/sites/*/files-private
+/files-private
 docroot/sites/*/private
 
 # Ignore contrib modules. These should be created during build process.


### PR DESCRIPTION
When creating a new project with BLT following [these instructions](https://github.com/acquia/blt/blob/8.x/readme/creating-new-project.md), after the `local:setup` step I get a /files-private directory in the repo root that should be gitignored.

I'm not quite sure _why_ this directory is created in the repo root instead of in the Drupal docroot. This PR seems like it would put it into the docroot: #322 :man_shrugging: 

Regardless, I'm definitely not seeing it at docroot/sites/*/files-private, which is where BLT apparently expects it to be following #732, so I figure we should change to the gitignore to match reality.

@dpagini under what circumstances were you seeing files show up at docroot/sites/*/files-private? I'm guessing it was for an older version of BLT?