### PR TITLE
Fixes #924: Remove nonexistent --db option from db-scrub script.

### DIFF
--- a/template/hooks/common/post-db-copy/db-scrub.sh
+++ b/template/hooks/common/post-db-copy/db-scrub.sh
@@ -12,5 +12,5 @@ db_name="$3"
 source_env="$4"
 
 echo "$site.$target_env: Scrubbing database $db_name"
-drush @$site.$target_env sql-sanitize --db=$db_name
-drush @$site.$target_env cache-rebuild --db=$db_name
+drush @$site.$target_env sql-sanitize
+drush @$site.$target_env cache-rebuild


### PR DESCRIPTION
Fixes #924 

Changes proposed:
- Remove `--db` option. It doesn't exist.
