### PR TITLE
Add inclusion of optional site settings file.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -101,6 +101,16 @@ if ($is_ah_env) {
 }
 
 /**
+ * Include optional site specific includes file.
+ *
+ * This is being included before the local file so all available settings are
+ * able to be overridden in the local.settings.php file below.
+ */
+if (file_exists(DRUPAL_ROOT . "/sites/$site_dir/settings/includes.settings.php")) {
+  require DRUPAL_ROOT . "/sites/$site_dir/settings/includes.settings.php";
+}
+
+/**
  * Load local development override configuration, if available.
  *
  * Use local.settings.php to override variables on secondary (staging,


### PR DESCRIPTION
Fixes #926.

See description in the issue queue for more details.

Changes proposed:
- Have BLT settings file look for a site specific includes file, and when available, include that.
