### PR TITLE
DB updates should always be run before config imports.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -215,6 +215,7 @@
     <!-- Execute db updates. -->
     <!-- This must happen before features are imported or configuration is imported. -->
     <!-- For instance, if you add a dependency on a new extension to an existing configuration file, you must enable that extension via an update hook before attempting to import the configuration. -->
+    <!-- If a db update relies on updated configuration, you should import the necessary configuration file(s) as part of the db update. -->
     <drush command="updb" assume="yes" alias="${drush.alias}">
       <option name="entity-updates"></option>
     </drush>

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -212,11 +212,6 @@
     <!-- @see https://www.drupal.org/node/2826466 -->
     <drush command="cr" alias="${drush.alias}"/>
 
-    <!-- Import configuration before executing updates, in case any db updates are dependent on new configs to be imported. -->
-    <drush command="config-import" assume="yes" alias="${drush.alias}">
-      <option name="partial"></option>
-      <param>${cm.core.config-dir}</param>
-    </drush>
     <!-- Execute db updates. -->
     <!-- This must happen before features are imported or configuration is imported. -->
     <!-- For instance, if you add a dependency on a new extension to an existing configuration file, you must enable that extension via an update hook before attempting to import the configuration. -->


### PR DESCRIPTION
This is sort of a follow-up to #911, since I just saw an example of it failing in the wild.

As I mentioned in that ticket, db updates _must_ be run before configuration imports so that any dependent modules can be enabled. Otherwise there's no way to add a configuration with a dependency on a new module.

Of course it's possible that something in your update hook might depend on a configuration change, in this case you should manually import just the necessary configuration as part of your update hook. This was the best practice with Features in D7 and I don't see any alternative in D8.