### PR TITLE
Set PHP memory limit for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ before_install:
   - echo 'variables_order = "EGPCS"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # Ensure that always_populate_raw_post_data PHP setting: Not set to -1 does not happen.
   - echo "always_populate_raw_post_data = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  # Increase PHP memory limit.
-  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  # Set PHP memory limit to something more realistic.
+  - echo "memory_limit=256M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - git config --global user.name "Travis-CI"
   - git config --global user.email "noreply@travis-ci.org"
   - mysql -u root -e "CREATE DATABASE drupal; CREATE USER 'drupal'@'localhost' IDENTIFIED BY 'drupal'; GRANT ALL ON drupal.* TO 'drupal'@'localhost';"

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -44,6 +44,8 @@ before_install:
   - echo 'variables_order = "EGPCS"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # Ensure that always_populate_raw_post_data PHP setting: Not set to -1 does not happen.
   - echo "always_populate_raw_post_data = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  # Set PHP memory limit to something more realistic.
+  - echo "memory_limit=256M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - git config --global user.name "Travis-CI"
   - git config --global user.email "noreply@travis-ci.org"
   - mysql -u root -e "CREATE DATABASE drupal; CREATE USER 'drupal'@'localhost' IDENTIFIED BY 'drupal'; GRANT ALL ON drupal.* TO 'drupal'@'localhost';"


### PR DESCRIPTION
We just had a deploy fail because update hooks that passed on Travis failed on ACE, due to memory exhaustion.

Right now Travis is using some default PHP memory limit, I think either 512M or 1024M. This sets it to 256M, which is what DrupalVM uses by default and is the upper limit of what you'd see on ACE.