### PR TITLE
Modify blt alias and bin/blt to allow for nested repo scenarios.

### DIFF
--- a/bin/blt
+++ b/bin/blt
@@ -5,7 +5,7 @@ set -o pipefail
 # set -o xtrace
 
 function run_blt() {
-  # If we are in a git repository, find the repo root.
+  # If we are in a git repository, go to the repo root.
   if [ "`git rev-parse --show-toplevel 2> /dev/null`" != "" ]; then
     GIT_ROOT=$(git rev-parse --show-toplevel)
     cd $GIT_ROOT
@@ -14,8 +14,8 @@ function run_blt() {
       ./vendor/acquia/blt/blt.sh "$@"
       exit 0
     else
-      # Go up one directory, 
-      # which will either take us into a parent repo or out of any Git repo.
+      # Go up one directory, which will either take us
+      # into a parent repo or out of any Git repo.
       cd ../
       # Recurse.
       run_blt "$@"
@@ -27,5 +27,5 @@ function run_blt() {
   fi
 }
 
-# Invoke the function
+# Invoke the function.
 run_blt "$@"

--- a/bin/blt
+++ b/bin/blt
@@ -1,14 +1,31 @@
 #!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace
 
-if [ "`git rev-parse --show-cdup 2> /dev/null`" != "" ]; then
-  GIT_ROOT=$(git rev-parse --show-cdup)
-else
-  GIT_ROOT="."
-fi
+function run_blt() {
+  # If we are in a git repository, find the repo root.
+  if [ "`git rev-parse --show-toplevel 2> /dev/null`" != "" ]; then
+    GIT_ROOT=$(git rev-parse --show-toplevel)
+    cd $GIT_ROOT
+    # If blt.sh exists relative to here, run it.
+    if [ -f "$GIT_ROOT/vendor/acquia/blt/blt.sh" ]; then
+      ./vendor/acquia/blt/blt.sh "$@"
+      exit 0
+    else
+      # Go up one directory, 
+      # which will either take us into a parent repo or out of any Git repo.
+      cd ../
+      # Recurse.
+      run_blt "$@"
+    fi
+  else
+    # We are not in a recognizable git repo. 
+    echo "Error: you are not in a BLT project. Exiting."
+    exit 1
+  fi
+}
 
-if [ -f "$GIT_ROOT/vendor/acquia/blt/blt.sh" ]; then
-  cd $GIT_ROOT
-  ./vendor/acquia/blt/blt.sh "$@"
-else
-  echo "Error: You must run this command from within a BLT-generated project repository!"
-fi
+# Invoke the function
+run_blt "$@"

--- a/scripts/blt/alias
+++ b/scripts/blt/alias
@@ -1,19 +1,24 @@
 function blt() {
+  # Save our current directory.
   local STORED_DIR=$(pwd)
+  # If we are in a git repository, go to the repo root.
   if [ "`git rev-parse --show-toplevel 2> /dev/null`" != "" ]; then
     GIT_ROOT=$(git rev-parse --show-toplevel)
     cd $GIT_ROOT
-    # If blt.sh exists relative to here, run it.
+    # If blt exists relative to here, run it.
     if [ -f "$GIT_ROOT/vendor/bin/blt" ]; then
       ./vendor/bin/blt "$@"
     else
-      # Go up one directory, which will either take us into a parent repo or out of any Git repo.
+      # Go up one directory, which will either take us
+      # into a parent repo or out of any Git repo.
       cd ../
-      # Recurse
+      # Recurse.
       blt "$@"
     fi
   else
+    # We are not in a recognizable git repo. 
     echo "Error: you are not in a BLT project. Exiting."
   fi
+  # Restore the saved directory.
   cd $STORED_DIR
 }

--- a/scripts/blt/alias
+++ b/scripts/blt/alias
@@ -1,15 +1,19 @@
-
 function blt() {
-  if [ "`git rev-parse --show-cdup 2> /dev/null`" != "" ]; then
-    GIT_ROOT=$(git rev-parse --show-cdup)
+  local STORED_DIR=$(pwd)
+  if [ "`git rev-parse --show-toplevel 2> /dev/null`" != "" ]; then
+    GIT_ROOT=$(git rev-parse --show-toplevel)
+    cd $GIT_ROOT
+    # If blt.sh exists relative to here, run it.
+    if [ -f "$GIT_ROOT/vendor/bin/blt" ]; then
+      ./vendor/bin/blt "$@"
+    else
+      # Go up one directory, which will either take us into a parent repo or out of any Git repo.
+      cd ../
+      # Recurse
+      blt "$@"
+    fi
   else
-    GIT_ROOT="."
+    echo "Error: you are not in a BLT project. Exiting."
   fi
-
-  if [ -f "$GIT_ROOT/vendor/bin/blt" ]; then
-    $GIT_ROOT/vendor/bin/blt "$@"
-  else
-    echo "You must run this command from within a BLT-generated project repository."
-    return 1
-  fi
+  cd $STORED_DIR
 }


### PR DESCRIPTION
This is more of a proposal. Stating up front that the BLT core contributors may have thought of this scenario and there may be good reasons to not do this.

One thing that is causing my particular build a fair amount of pain is that BLT's alias and vendor/bin commands rely on being in the same repo as BLT's vendor directory. This precludes submodule scenarios and Drupal-specific VCS package scenarios where we want a package-in-progress (say, a custom profile that is shared among multiple builds) to exist within a BLT project. 

In our particular case, we use a VCS package in our BLT-based project's composer.json to include a profile. We store the profile in a separate repository. When composer installs this, it puts it in docroot/profiles/contrib, and the profile contains its .git directory. We .gitignore the profile. This allows us to work in a single codebase (from an IDE perspective at any rate) but to keep the code bases separate.

BLT currently cannot work properly inside our profile directory because it is its own git repo, and therefore the BLT alias cannot find the appropriate vendor directory. We've been working around this, but https://github.com/acquia/blt/pull/922 has thrown a wrench into this.

The proposal is to make the blt alias and bin/blt both recursive functions that look for acquia/blt in the vendor directory, as before, but if it is not found, go up one directory, and try again. This continues until BLT is found or we are no longer in a  git repo.

Appreciate any feedback. Thank you!
