### PR TITLE
Auto start VM.

### DIFF
--- a/phing/tasks/local-sync.xml
+++ b/phing/tasks/local-sync.xml
@@ -6,9 +6,9 @@
     </phingcall>
   </target>
 
-  <target name="local:refresh" description="Refreshes local environment from upstream testing database." depends="setup:build, local:sync, local:update"/>
+  <target name="local:refresh" description="Refreshes local environment from upstream testing database." depends="local:check-lamp, setup:build, local:sync, local:update"/>
 
-  <target name="local:setup" description="Install dependencies, builds docroot, installs Drupal; uses local drush alias.">
+  <target name="local:setup" description="Install dependencies, builds docroot, installs Drupal; uses local drush alias." depends="local:check-lamp">
     <phingcall target="setup">
       <property name="drush.alias" value="${drush.aliases.local}" />
       <param name="environment" value="local"/>
@@ -51,6 +51,17 @@
       <property name="drush.alias" value="${drush.aliases.local}"/>
       <property name="environment" value="local"/>
     </phingcall>
+  </target>
+
+  <target name="local:check-lamp" description="Ensures LAMP stack is available.">
+    <property name="output.IS_FILE_EXISTS" value="false" />
+    <exec command="if [ -f '${repo.root}/Vagrantfile' ]; then echo 'true'; else echo 'false'; fi;" outputProperty="output.IS_FILE_EXISTS" />
+    <if>
+      <equals arg1="${output.IS_FILE_EXISTS}" arg2="true" />
+      <then>
+        <phingcall target="vm"/>
+      </then>
+    </if>
   </target>
 
 </project>


### PR DESCRIPTION
About twice a day I run `local:refresh` while forgetting to spin up the DrupalVM first. Kind of annoying because it takes a while to fail hard and you end up losing 5-10 minutes if you're not paying attention.

This simply runs the VM at the start of the refresh target if a Vagrantfile is detected.

If you like this idea, there would be ways to improve it... such as actually checking for the presence of the stack (whether VM or not), and also putting a property into project.yml so that we can look for the "right" stack a little more intelligently and also allow people to override it locally if they can't use the project default for whatever reason.