### PR TITLE
Connects to #965: Add --config-dir option to Drush site-install command.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -179,6 +179,7 @@
       <option name="account-name">"${drupal.account.name}"</option>
       <option name="account-pass">"${drupal.account.password}"</option>
       <option name="account-mail">"${drupal.account.mail}"</option>
+      <option name="config-dir">../config/default</option>
       <param>"${project.profile.name}"</param>
       <param>"install_configure_form.update_status_module='array(FALSE,FALSE)'"</param>
     </drush>


### PR DESCRIPTION
Relates to Issue #965.

Changes proposed:
- Add `--config-dir` option to Drush `site-install` command.
- Empower sites using full CMI exports (either via core CMI or with Config Split) to be installed in CI or other environments (otherwise the install fails on UUID issues).

Note: This should be tested on sites that are currently _not_ using full CMI export/import to make sure nothing is broken in the build in that situation.
