### PR TITLE
Ignore compiled theme CSS and other artifacts

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -23,8 +23,10 @@ docroot/profiles/contrib
 docroot/libraries
 drush/contrib
 
-# Ignore custom theme node_modules folders
+# Ignore custom theme build artifacts
 docroot/themes/custom/*/node_modules
+docroot/themes/custom/*/css
+docroot/themes/custom/*/styleguide
 
 # Ignore build artifacts
 /deploy


### PR DESCRIPTION
Cog is about to remove their own .gitignore, and in general it seems that it's the responsibility of the parent project to ignore compiled CSS: https://github.com/acquia-pso/cog/issues/29

Once this and the Cog issue are merged, Cog-based themes should work out of the box with any BLT project (including deployment of CSS).