### PR TITLE
Fixes #885: Local & CI Tests Fail with Git Hooks Disabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,8 @@ script:
   - cat blt/project.yml
   # Call targets in the new 'blt-project' project.
   - blt ci:build:validate:test -Dcreate_alias=false -Dbehat.run-server=true -Dbehat.launch-phantom=true -Dblt.verbose=true
+  # Run 'blt-project' tests.
+  - phpunit tests/phpunit --group blt-project
   # Initialize ACSF config.
   - blt acsf:init
   # Ensure that the doctor doesn't report any problems at this point.

--- a/phing/tasks/tests.xml
+++ b/phing/tasks/tests.xml
@@ -247,7 +247,6 @@
         <fileset dir="${repo.root}/tests/phpunit">
           <include name="**/*Test*.php"/>
         </fileset>
-        <fileset dir="${blt.root}/tests/phpunit/BltProject"/>
       </batchtest>
     </phpunit>
     <phpunitreport infile="${reports.localDir}/phpunit/testsuites.xml" format="noframes" todir="${reports.localDir}/phpunit" />


### PR DESCRIPTION
Fixes #885 

Changes:
- Run phpunit tests for blt only and not on generated project.
