### PR TITLE
Slack notifications for deployments

### DIFF
--- a/readme/deploy.md
+++ b/readme/deploy.md
@@ -69,3 +69,9 @@ Instead of performing these deployments manually, you can enlist the help of a C
 On Acquia Cloud, [Cloud Hooks](https://docs.acquia.com/cloud/manage/cloud-hooks) are the preferred method to run database updates and configuration imports on each deploy. BLT provides a post-code-deploy hook that will conveniently run these updates automatically and fail the deployment task in Insight if anything goes wrong.
 
 For consistency and reliability, you should run the same updates on deployment as you would run locally or in CI testing. BLT provides aliases for the `setup:update` task to support this, such as `local:update` and `deploy:update`. These aliases all run the same updates, but with the appropriate aliases and configuration directories for each environment.
+
+If your team uses Slack, you can also be notified of each successful or failed deployment. Simply set up an incoming webhook in your Slack team to receive the notification (see the API documentation at https://api.slack.com/), and then store the webhook URL in a `$HOME/slack_settings` file on your Acquia Cloud servers:
+
+    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
+
+For more information, see the [Acquia Cloud Hooks Slack example](https://github.com/acquia/cloud-hooks/tree/master/samples/slack).

--- a/template/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/template/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -21,5 +21,6 @@ acsf_file="/mnt/files/$AH_SITE_GROUP.$AH_SITE_ENVIRONMENT/files-private/sites.js
 if [ ! -f $acsf_file ]; then
   . /var/www/html/$site.$target_env/vendor/acquia/blt/scripts/cloud-hooks/functions.sh
   deploy_updates
+  . `dirname $0`/../slack.sh
   exit $status
 fi

--- a/template/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/template/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -21,6 +21,7 @@ acsf_file="/mnt/files/$AH_SITE_GROUP.$AH_SITE_ENVIRONMENT/files-private/sites.js
 if [ ! -f $acsf_file ]; then
   . /var/www/html/$site.$target_env/vendor/acquia/blt/scripts/cloud-hooks/functions.sh
   deploy_updates
+  # Send notifications to Slack, if configured. See readme/deploy.md for setup instructions.
   . `dirname $0`/../slack.sh
   exit $status
 fi

--- a/template/hooks/common/post-code-update/post-code-update.sh
+++ b/template/hooks/common/post-code-update/post-code-update.sh
@@ -24,5 +24,6 @@ acsf_file="/mnt/files/$AH_SITE_GROUP.$AH_SITE_ENVIRONMENT/files-private/sites.js
 if [ ! -f $acsf_file ]; then
   . /var/www/html/$site.$target_env/vendor/acquia/blt/scripts/cloud-hooks/functions.sh
   deploy_updates
+  . `dirname $0`/../slack.sh
   exit $status
 fi

--- a/template/hooks/common/slack.sh
+++ b/template/hooks/common/slack.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+FILE=$HOME/slack_settings
+
+if [ -f $FILE ]; then
+  # Load the Slack webhook URL (which is not stored in this repo).
+  . $HOME/slack_settings
+
+  if [ $status -ne 0 ]; then
+    # Failed deploy.
+    curl -X POST --data-urlencode "payload={\"username\": \"Acquia Cloud\", \"text\": \"Deployment has FAILED for environment *$site.$target_env*.\", \"icon_emoji\": \":rain_cloud:\"}" $SLACK_WEBHOOK_URL
+  else
+    # Successful deploy.
+    if [ "$source_branch" != "$deployed_tag" ]; then
+      curl -X POST --data-urlencode "payload={\"username\": \"Acquia Cloud\", \"text\": \"An updated deployment has been made to *$site.$target_env* using branch *$source_branch* as *$deployed_tag*.\", \"icon_emoji\": \":mostly_sunny:\"}" $SLACK_WEBHOOK_URL
+    else
+      curl -X POST --data-urlencode "payload={\"username\": \"Acquia Cloud\", \"text\": \"An updated deployment has been made to *$site.$target_env* using tag *$deployed_tag*.\", \"icon_emoji\": \":mostly_sunny:\"}" $SLACK_WEBHOOK_URL
+    fi
+  fi
+else
+  echo "File $FILE does not exist."
+fi


### PR DESCRIPTION
Many project teams use Slack to coordinate with customers and partners. It's very useful to have a #deployments channel to track successful and failed deployments for QA and UAT.

With this patch, all a project has to do is define a Slack Webhook URL following the steps here: https://github.com/acquia/cloud-hooks/pull/43/files

If a webhook URL isn't defined, the script does nothing.