### PR TITLE
Fixed features override test.

### DIFF
--- a/phing/build.yml
+++ b/phing/build.yml
@@ -59,7 +59,7 @@ drupal:
 
 drush:
   bin: ${composer.bin}/drush
-  cmd: ${drush.bin} @${drush.alias} -r ${docroot} -l ${multisite.name}
+  cmd: ${drush.bin} @${drush.alias} -l ${multisite.name}
   dir: ${docroot}
   uri: ${multisite.name}
   assume: yes

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -292,7 +292,8 @@
     <if>
       <equals arg1="${cm.features.no-overrides}" arg2="true"/>
       <then>
-        <exec command="${drush.bin} @${drush.alias} fl --bundle=${bundle} | grep -Ei '(changed|conflicts|added)( *)$'" outputProperty="features.overrides"/>
+        <echo>Checking for features overrides...</echo>
+        <exec dir="${docroot}" command="${drush.cmd} fl --bundle=${bundle} | grep -Ei '(changed|conflicts|added)( *)$'" outputProperty="features.overrides"/>
         <if>
           <istrue value="${features.overrides}"/>
           <then>


### PR DESCRIPTION
The features override test doesn't work reliably, depending on how the Drupal site is installed. This brings it in line with the security-update test, which works by running `${drush.cmd}` within the `${docroot}`.

Although I'm wondering if we want to adjust both of these to use a more generic drush wrapper.