### PR TITLE
Connects to  #1028: Add drush and drupal settings tests

### DIFF
--- a/tests/phpunit/BltProject/DrupalSettingsTest.php
+++ b/tests/phpunit/BltProject/DrupalSettingsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Acquia\Blt\Tests\BltProject;
+
+use Acquia\Blt\Tests\BltProjectTestBase;
+
+/**
+ * Class DrupalSettingsTest.
+ *
+ * Verifies $settings.php configuration.
+ */
+class DrupalSettingsTest extends BltProjectTestBase {
+
+  /**
+   * Tests Phing setup:drupal:settings target.
+   *
+   * Ensures each site has a default.local.settings.php file.
+   *
+   * @group blt-project
+   */
+  public function testSetupDefaultLocalSettings() {
+    foreach ($this->sites as $site) {
+      $this->assertFileExists("$this->projectDirectory/docroot/sites/$site/settings/default.local.settings.php");
+    }
+  }
+
+  /**
+   * Tests Phing setup:drupal:settings target.
+   *
+   * Ensures each site has a local.settings.php file.
+   *
+   * @group blt-project
+   */
+  public function testSetupLocalSettings() {
+    foreach ($this->sites as $site) {
+      $this->assertFileExists("$this->projectDirectory/docroot/sites/$site/settings/local.settings.php");
+    }
+  }
+
+  /**
+   * Tests Phing setup:drupal:settings target.
+   *
+   * Ensures the default site has a default.settings.php file, which is used
+   * as the basis for new settings.php files.
+   *
+   * @group blt-project
+   */
+  public function testSetupDefaultSettings() {
+    $this->assertFileExists("$this->projectDirectory/docroot/sites/default/default.settings.php");
+  }
+
+  /**
+   * Tests Phing setup:drupal:settings target.
+   *
+   * Ensures each site has a settings.php file.
+   *
+   * @group blt-project
+   */
+  public function testSetupSettings() {
+    foreach ($this->sites as $site) {
+      $this->assertFileExists("$this->projectDirectory/docroot/sites/$site/settings.php");
+    }
+  }
+
+  /**
+   * Tests Phing setup:drupal:settings target.
+   *
+   * Ensures BLT's settings are included in each site's settings.php file.
+   *
+   * @group blt-project
+   */
+  public function testSetupBltSettings() {
+    foreach ($this->sites as $site) {
+      $file = "$this->projectDirectory/docroot/sites/$site/settings.php";
+      if (file_exists($file)) {
+        $this->assertContains(
+          'require DRUPAL_ROOT . "/../vendor/acquia/blt/settings/blt.settings.php"',
+          file_get_contents($file)
+        );
+      }
+    }
+  }
+
+}

--- a/tests/phpunit/BltProject/DrushSettingsTest.php
+++ b/tests/phpunit/BltProject/DrushSettingsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Acquia\Blt\Tests\BltProject;
+
+use Acquia\Blt\Tests\BltProjectTestBase;
+
+/**
+ * Class DrushSettingsTest.
+ *
+ * Verifies Drush configuration.
+ */
+class DrushSettingsTest extends BltProjectTestBase {
+
+  /**
+   * Tests Phing setup:drush:settings target.
+   *
+   * Ensures each site has a local.drushrc.php file.
+   *
+   * @group blt-project
+   */
+  public function testSetupLocalSettings() {
+    foreach ($this->sites as $site) {
+      $this->assertFileExists("$this->projectDirectory/docroot/sites/$site/local.drushrc.php");
+    }
+  }
+
+  /**
+   * Tests Phing setup:drush:settings target.
+   *
+   * Ensures each site has a default.local.drushrc.php.
+   *
+   * @group blt-project
+   */
+  public function testSetupDefaultSettings() {
+    foreach ($this->sites as $site) {
+      $this->assertFileExists("$this->projectDirectory/docroot/sites/$site/default.local.drushrc.php");
+    }
+  }
+
+}

--- a/tests/phpunit/src/BltProjectTestBase.php
+++ b/tests/phpunit/src/BltProjectTestBase.php
@@ -13,6 +13,7 @@ abstract class BltProjectTestBase extends \PHPUnit_Framework_TestCase {
 
   protected $projectDirectory;
   protected $drupalRoot;
+  protected $sites = [];
   protected $config = [];
 
   /**
@@ -56,6 +57,9 @@ abstract class BltProjectTestBase extends \PHPUnit_Framework_TestCase {
     if (file_exists("{$this->projectDirectory}/blt/project.local.yml")) {
       $this->config = array_replace_recursive($this->config, (array) Yaml::parse(file_get_contents("{$this->projectDirectory}/blt/project.local.yml")));
     }
+
+    // Build sites list.
+    $this->sites = !empty($this->config['multisite']['name']) ? $this->config['multisite']['name'] : ['default'];
   }
 
 }


### PR DESCRIPTION
Connects to  #1028.

I saw #1028 opened by @danepowell and thought some tests I've written as part of #1023 could benefit any work in this area, at least as a place to start.

Changes proposed:
- Add additional tests for Drush and Drupal settings.
