### PR TITLE
Fixed multisite settings on ACE.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -88,7 +88,7 @@ $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
  * Acquia Cloud settings.
  */
 if ($is_ah_env) {
-  if (!$is_acsf && file_exists('/var/www/site-php')) {
+  if (!$is_acsf && file_exists('/var/www/site-php') && $site_dir == 'default') {
     require "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/{$_ENV['AH_SITE_GROUP']}-settings.inc";
   }
 


### PR DESCRIPTION
When doing multisite on ACE, any site other than the default site is supposed to include a custom settings file defined by ACE (reference step 4 in [Acquia Docs](https://docs.acquia.com/cloud/multi-site), also in the [BLT multisite docs](https://github.com/acquia/blt/blob/8.x/readme/multisite.md#acquia-cloud-setup))

BLT should not clobber this custom include with the default include. Among the various bad outcomes when this happens: all of your sites will share the same memcache key and corrupt your database (hopefully you didn't try setting this up on prod!)