### PR TITLE
Run Cloud aliases in Cloud environments.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -228,9 +228,14 @@
     </delete>
   </target>
 
+  <!-- Wrapper for setup:update that sets some environment-specific variables first. -->
   <target name="deploy:update" description="Update current database to reflect the state of the Drupal file system; uses local drush alias.">
     <phingcall target="setup:update">
+      <!-- Drush fails to include some files. @see https://github.com/drush-ops/drush/issues/2497#issuecomment-279049111 -->
+      <property name="drush.bin" value="${drush.bin} --include=../drush" override="true" />
+      <!-- Environment parameter is used to determine which modules to toggle. On ACE, will be overridden by one of dev/stage/prod. -->
       <param name="environment" value="deploy"/>
+      <!-- Drush alias should be set to self, but can be overridden for multisite. -->
       <property name="drush.alias" value="self"/>
       <!-- Most sites store their version-controlled configuration in /config/default. -->
       <!-- ACE internally sets the vcs configuration directory to /config/default, so we use that. -->

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -204,6 +204,10 @@
   </target>
 
   <target name="setup:config-import" description="Import configuration from the config directory.">
+    <!-- Sometimes drush forgets where to find its aliases. -->
+    <drush command="cc" assume="yes" passthru="false">
+      <param>drush</param>
+    </drush>
     <echo>Importing configuration...</echo>
     <drush command="pm-enable" assume="yes" alias="${drush.alias}" passthru="false">
       <param>config</param>

--- a/template/drush/policy.drush.inc
+++ b/template/drush/policy.drush.inc
@@ -6,11 +6,23 @@
  * Alter alias record data in code.
  */
 function policy_drush_sitealias_alter(&$alias_record) {
+  // Set Drush version correctly on Acquia Cloud.
   if (!empty($alias_record['uri'])
     && strstr($alias_record['remote-host'], 'acquia') !== FALSE
     && !empty($alias_record['path-aliases']['%drush-script'])
     && $alias_record['path-aliases']['%drush-script'] == 'drush9') {
     // Acquia Cloud does not currently support drush9.
     $alias_record['path-aliases']['%drush-script'] = 'drush8';
+  }
+
+  // If the alias is "remote", but the remote site is
+  // the system this command is running on, convert the
+  // alias record to a local alias.
+  if (isset($alias_record['remote-host'])) {
+    $uname = php_uname('n');
+    if ($alias_record['remote-host'] == $uname) {
+      unset($alias_record['remote-host']);
+      unset($alias_record['remote-user']);
+    }
   }
 }


### PR DESCRIPTION
Call me crazy, but I believe the Acquia Cloud aliases (defined _by_ Acquia Cloud) should in fact be able to run on... Acquia Cloud.

Currently this isn't possible, because the aliases define remote hosts, and Cloud can't SSH across servers or even into its own server.

This makes it possible by stripping the server when running an alias on its native host.

This is necessary to support multisite integration (coming soon).