### PR TITLE
Fixing PHPCS filset reference.

### DIFF
--- a/phing/build.yml
+++ b/phing/build.yml
@@ -92,6 +92,7 @@ phpcs:
     - files.php.custom.modules
     - files.php.tests
     - files.php.custom.themes
+    - files.frontend.custom.theme
   haltonerror: true
   haltonwarning: true
 

--- a/phing/build.yml
+++ b/phing/build.yml
@@ -92,7 +92,7 @@ phpcs:
     - files.php.custom.modules
     - files.php.tests
     - files.php.custom.themes
-    - files.frontend.custom.theme
+    - files.frontend.custom.themes
   haltonerror: true
   haltonwarning: true
 

--- a/phing/build.yml
+++ b/phing/build.yml
@@ -91,7 +91,7 @@ phpcs:
   filesets:
     - files.php.custom.modules
     - files.php.tests
-    - files.frontend.custom.themes
+    - files.php.custom.themes
   haltonerror: true
   haltonwarning: true
 


### PR DESCRIPTION
I'm not sure if this is correct, but it seems like build.yml has a mistake referencing a fileset for code sniffing. The `files.frontend.custom.themes` fileset contains javascript, bower, npm, etc. files, not PHP code. Seems odd to send that through code sniffing. Should this be the `files.php.custom.themes` fileset instead?
