### PR TITLE
Update ci.md

### DIFF
--- a/readme/ci.md
+++ b/readme/ci.md
@@ -97,7 +97,7 @@ To set up the [workflow described earlier](#workflow), you must configure Acquia
 
          blt ci:travis:init
 
-1. Generate an SSH key locally for Travis / Build use. (e.g.)
+1. Generate an SSH key locally that will allow Travis to authenticate to Acquia Cloud:
 
          cd ~/.ssh
          ssh-keygen -t rsa -b 4096
@@ -105,7 +105,8 @@ To set up the [workflow described earlier](#workflow), you must configure Acquia
     Do not use a passphrase!
     Name this key something different than your normal Acquia Cloud key (e.g. travis)
 
-1. Login to your Acquia Cloud account and add the public SSH key from the key pair that was generated in step 1 by visiting `https://accounts.acquia.com/account/[uid]/security`.
+1. Create a new Acquia Cloud account to be used exclusively as a container for the SSH keys that will grant Travis push access to Acquia Cloud. This can be done by inviting a new team member on the "Teams" tab in Acquia Cloud. You can use an email address like `<email>+<project>.travis@acquia.com`. The team member must have SSH push access (i.e. Team Lead role). It's not recommended to use a personal account or re-use the shell account across projects, since this poses a security risk, and will also cause deployments to fail if your account is removed from the project.
+1. Login to the new Acquia Cloud account and add the public SSH key from the key pair that was generated in step 1 by editing the profile and choosing the "credentials" tab.
 1. Add the same public SSH key to the "Deployment Keys" section on your project's GitHub settings page, located at `https://github.com/acquia-pso/[project-name]/settings/keys`. **Note: You may not have direct access to these settings if you do not have administrative control over your repository.**
 1. Add the _private SSH key_ to your project's Travis CI settings located at `https://magnum.travis-ci.com/acquia-pso/[project-name]/settings`.
 1. Add your cloud git repository to the remotes section of your project.yml file:
@@ -113,18 +114,15 @@ To set up the [workflow described earlier](#workflow), you must configure Acquia
         remotes:
            - example@svn-14671.prod.hosting.acquia.com:example.git`
 
-    Note: if planning on executing any drush sql-syncs/rsyncs between the cloud and your environment, also add the test/stage server host here and ensure that your account has the senior developer or team lead role (or appropriate custom access in the Acquia Cloud).
-
 1. Add your cloud git repository's server host name to `ssh_known_hosts` in your .travis.yml file. Take care to remove the user name and file name (example.git) and use only the hostname.
 
         addons:
           ssh_known_hosts:
           - svn-14671.prod.hosting.acquia.com
    
-    Note: if planning on executing any drush sql-syncs/rsyncs between the cloud and your environment, also add the test/stage server host here and ensure that your account has the senior developer or team lead role (or appropriate custom access in the Acquia Cloud).
+    Note: if planning on executing any drush sql-syncs/rsyncs between the cloud and your environment, also add the test/stage server host here.
 
 1. Commits or merges to the develop branch on GitHub should now trigger a fully built artifact to be deployed to your specified remotes.
-1. **If the build account is removed from the project, the Travis Builds for that project will begin to fail.**
 
 For information on manually deploying your project, read [deploy.md](deploy.md)
 


### PR DESCRIPTION
This was last touched by @mikemadison13 in #794 / #795, which recommended using a personal account because Cloud no longer allowed plus signs. However, using a personal account is not very secure since it would allow anyone on a project to bypass access control and access any subscription associated with your account. It also means that deployments will begin to fail unexpectedly if you are removed from the project.

I just verified that you can create new Cloud accounts using emails with plus signs, as well as invite these accounts to any team, so I think we should go back to recommending the use of a dedicated account.

Note that we have internal tickets to track improvements to this process (NN-12088, CSPF-191).