### PR TITLE
Issue 1084: add 'type:' to drupal-custom-module installer path.

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -59,7 +59,7 @@
                 "type:drupal-module"
             ],
             "docroot/modules/custom/{$name}": [
-                "drupal-custom-module"
+                "type:drupal-custom-module"
             ],
             "docroot/profiles/contrib/{$name}": [
                 "type:drupal-profile"


### PR DESCRIPTION
Fixes #1084.

Changes proposed:
- add 'type:' to drupal-custom-module installer path:
`"docroot/modules/custom/{$name}": [ "type:drupal-custom-module" ],`
