### PR TITLE
Support for multisite deploys

### DIFF
--- a/phing/build.yml
+++ b/phing/build.yml
@@ -67,9 +67,9 @@ drupal:
 
 drush:
   bin: ${composer.bin}/drush
-  cmd: ${drush.bin} @${drush.alias} -l ${multisite.name}
+  cmd: ${drush.bin} @${drush.alias} -l default
   dir: ${docroot}
-  uri: ${multisite.name}
+  uri: default
   assume: yes
   passthru: yes
   logoutput: yes

--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -235,8 +235,8 @@
       <property name="drush.bin" value="${drush.bin} --include=../drush" override="true" />
       <!-- Environment parameter is used to determine which modules to toggle. On ACE, will be overridden by one of dev/stage/prod. -->
       <param name="environment" value="deploy"/>
-      <!-- Drush alias should be set to self, but can be overridden for multisite. -->
-      <property name="drush.alias" value="self"/>
+      <!-- Drush alias should be set to sites to update all sites. -->
+      <property name="drush.alias" value="sites"/>
       <!-- Most sites store their version-controlled configuration in /config/default. -->
       <!-- ACE internally sets the vcs configuration directory to /config/default, so we use that. -->
       <property name="cm.config-dir.key" value="${cm.config-dir.deploy-key}"/>

--- a/phing/tasks/tests.xml
+++ b/phing/tasks/tests.xml
@@ -273,7 +273,7 @@
         <echo message="Running server at ${behat.server-url}"/>
         <exec command="pkill -f runserver" logoutput="true" level="${blt.exec_level}" passthru="true"/>
         <exec executable="${drush.bin}" dir="${docroot}" spawn="true" level="${blt.exec_level}">
-          <arg line="runserver ${behat.server-url} -l ${multisite.name}"/>
+          <arg line="runserver ${behat.server-url}"/>
         </exec>
         <echo message="Waiting 10 seconds for ${behat.server-url} to become available."/>
         <waitfor maxwait="10" maxwaitunit="second" checkevery="1" checkeveryunit="second">

--- a/readme/multisite.md
+++ b/readme/multisite.md
@@ -14,7 +14,7 @@ Start by following the [Acquia Cloud multisite instructions](https://docs.acquia
         if (file_exists('/var/www/site-php')) {
           require '/var/www/site-php/mysite/multisitename-settings.inc';
         }
-        
+
         require DRUPAL_ROOT . "/../vendor/acquia/blt/settings/blt.settings.php";
 
 ## BLT setup
@@ -22,6 +22,13 @@ Start by following the [Acquia Cloud multisite instructions](https://docs.acquia
 Start by setting `$site_dir` in each site's settings.php, prior to the `blt.settings.php` include. This is necessary for BLT to set a number of configurations correctly, such as your public and private file paths:
 
     $site_dir = 'example.com';
+
+You will also need to define your multisites in `blt/project.yml` by creating a `multisite.name` variable. This allows BLT to run setup and deployment tasks for each site in the codebase.
+
+    multisite:
+      name:
+        - default
+        - example.com
 
 Ensure that your new project has `$settings['install_profile']` set, or Drupal core will attempt (unsuccessfully) to write it to disk!
 


### PR DESCRIPTION
This makes two significant changes:

1. The deploy site alias is changed from "self" to "sites". This will cause Drush to run the deploy:update commands against _all_ sites, not just the default site.
2. The `multisite.name` variable is currently overloaded. Sometimes it is used as an array, and sometimes as a single-value string. The only reason it works at all is because the output is identical in both cases for single-install sites. But for multisite projects, we need to decouple this in some places.