### PR TITLE
Adapts #1024: Add pre-config-import hook

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -221,6 +221,9 @@
   </target>
 
   <target name="setup:config-import" description="Import configuration from the config directory.">
+    <phingcall target="target-hook:invoke">
+      <property name="hook-name" value="pre-config-import"/>
+    </phingcall>
     <!-- Sometimes drush forgets where to find its aliases. -->
     <drush command="cc" assume="yes" passthru="false">
       <param>drush</param>

--- a/template/blt/project.yml
+++ b/template/blt/project.yml
@@ -46,6 +46,10 @@ target-hooks:
     dir: ${docroot}
     # E.g., `npm run build`.
     command: echo 'No frontend-build configured.'
+  # Executed before configuration is imported.
+  pre-config-import:
+    dir: ${docroot}
+    command: echo 'No pre-config-import configured.'
   # Executed after deployment artifact is created.
   post-deploy-build:
     dir: ${docroot}


### PR DESCRIPTION
Adapts #1024: Add pre-config-import hook.

Changes proposed:
- Allow pre-config-import scripts to be run via BLT's existing hook structure.
