### PR TITLE
Fixes #1113: Add support for multisite sync.

### DIFF
--- a/phing/build.yml
+++ b/phing/build.yml
@@ -32,6 +32,7 @@ blt:
     local: ${repo.root}/blt/project.local.yml
     example-local: ${repo.root}/blt/example.project.local.yml
     schema-version: ${repo.root}/blt/.schema_version
+    multisite: ${docroot}/sites/${multisite.name}/site.yml
 
 composer:
   bin: ${repo.root}/${bin.path}

--- a/phing/tasks/local-sync.xml
+++ b/phing/tasks/local-sync.xml
@@ -17,26 +17,6 @@
 
   <target name="local:sync" description="Synchronize local environment from remote (remote --> local)."
           depends="setup:drupal:settings">
-    <if>
-      <!-- There is multisite config. Allow it to override values for local:sync:site. -->
-      <available file="${blt.config-files.multisite}" />
-      <then>
-        <phingcall target="local:sync:site">
-          <property file="${blt.config-files.multisite}" logoutput="false"/>
-          <!--
-            We need to override drush.uri, which defaults to 'default'
-            in order to run commands against ${multisite.name}.
-          -->
-          <property name="drush.uri" value="${multisite.name}"/>
-        </phingcall>
-      </then>
-      <else>
-        <phingcall target="local:sync:site"/>
-      </else>
-    </if>
-  </target>
-
-  <target name="local:sync:site" hidden="true">
     <drush command="cc drush"/>
     <drush command="sql-drop"/>
     <if>
@@ -67,27 +47,10 @@
   </target>
 
   <target name="local:update" description="Update current database to reflect the state of the Drupal file system; uses local drush alias.">
-    <if>
-      <!-- There is multisite config. -->
-      <available file="${blt.config-files.multisite}" />
-      <then>
-        <phingcall target="setup:update">
-          <property name="drush.alias" value="${drush.aliases.local}"/>
-          <property name="environment" value="local"/>
-          <!--
-            We need to override drush.uri, which defaults to 'default'
-            in order to run commands against ${multisite.name}.
-           -->
-          <property name="drush.uri" value="${multisite.name}" />
-        </phingcall>
-      </then>
-      <else>
-        <phingcall target="setup:update">
-          <property name="drush.alias" value="${drush.aliases.local}"/>
-          <property name="environment" value="local"/>
-        </phingcall>
-      </else>
-    </if>
+    <phingcall target="setup:update">
+      <property name="drush.alias" value="${drush.aliases.local}"/>
+      <property name="environment" value="local"/>
+    </phingcall>
   </target>
 
 </project>

--- a/phing/tasks/local-sync.xml
+++ b/phing/tasks/local-sync.xml
@@ -17,6 +17,26 @@
 
   <target name="local:sync" description="Synchronize local environment from remote (remote --> local)."
           depends="setup:drupal:settings">
+    <if>
+      <!-- There is multisite config. Allow it to override values for local:sync:site. -->
+      <available file="${blt.config-files.multisite}" />
+      <then>
+        <phingcall target="local:sync:site">
+          <property file="${blt.config-files.multisite}" logoutput="false"/>
+          <!--
+            We need to override drush.uri, which defaults to 'default'
+            in order to run commands against ${multisite.name}.
+          -->
+          <property name="drush.uri" value="${multisite.name}"/>
+        </phingcall>
+      </then>
+      <else>
+        <phingcall target="local:sync:site"/>
+      </else>
+    </if>
+  </target>
+
+  <target name="local:sync:site" hidden="true">
     <drush command="cc drush"/>
     <drush command="sql-drop"/>
     <if>
@@ -47,10 +67,27 @@
   </target>
 
   <target name="local:update" description="Update current database to reflect the state of the Drupal file system; uses local drush alias.">
-    <phingcall target="setup:update">
-      <property name="drush.alias" value="${drush.aliases.local}"/>
-      <property name="environment" value="local"/>
-    </phingcall>
+    <if>
+      <!-- There is multisite config. -->
+      <available file="${blt.config-files.multisite}" />
+      <then>
+        <phingcall target="setup:update">
+          <property name="drush.alias" value="${drush.aliases.local}"/>
+          <property name="environment" value="local"/>
+          <!--
+            We need to override drush.uri, which defaults to 'default'
+            in order to run commands against ${multisite.name}.
+           -->
+          <property name="drush.uri" value="${multisite.name}" />
+        </phingcall>
+      </then>
+      <else>
+        <phingcall target="setup:update">
+          <property name="drush.alias" value="${drush.aliases.local}"/>
+          <property name="environment" value="local"/>
+        </phingcall>
+      </else>
+    </if>
   </target>
 
 </project>

--- a/phing/tasks/properties.xml
+++ b/phing/tasks/properties.xml
@@ -56,6 +56,19 @@
     </then>
   </if>
 
+  <if>
+    <!-- There is multisite config. Allow it to override default values. -->
+    <available file="${blt.config-files.multisite}" />
+    <then>
+      <property file="${blt.config-files.multisite}" logoutput="false" override="true"/>
+      <!--
+        Here we override drush.uri explicitly (which defaults to 'default')
+        in order to run commands against multisite.name.
+      -->
+      <property name="drush.uri" value="${multisite.name}" override="true"/>
+    </then>
+  </if>
+
   <echo level="verbose">Executing commands against multisite "${multisite.name}"</echo>
 
   <!-- Default drush alias. -->


### PR DESCRIPTION
Fixes #1113.

Changes proposed:
- Allows site-specific config to be placed in `docroot/sites/*/site.yml`
  - Allows `local:sync` and `local:refresh` tasks to run against a multisite:
```sh
blt local:refresh -Dmultisite.name=secondsite
```
