### PR TITLE
Use legacy Travis infrastructure

### DIFF
--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -1,5 +1,7 @@
 # Note that the example .travis.yml file for child projects lives in /install.
-sudo: false
+# Temporarily use legacy infrastructure until Travis resolves MySQL issues with their containerized infrastructure.
+# @see https://github.com/travis-ci/travis-ci/issues/6842
+sudo: required
 language: php
 dist: trusty
 


### PR DESCRIPTION
On all of the projects I'm on, about half of our Travis builds have failed since BLT switched to containerized builds. The problem is described in depth here: https://github.com/travis-ci/travis-ci/issues/6842

Not only does this impact development velocity, but it sows confusion, since Travis is supposed to automatically deploy merges to dev for QA, but we can no longer rely on that.

I've been in touch with Travis support and they recommend reverting to the "legacy" infrastructure for now by simply changing sudo to required.

This should have a minimal impact on build times. In my experience, containerized builds are considerably faster than legacy ones.