### PR TITLE
Allow project.prefix to use overridden value

### DIFF
--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -6,7 +6,7 @@
 # 15 characters.
 
 ROOT_DIR="$(pwd)"
-COMMAND="$ROOT_DIR/vendor/bin/yaml-cli get:value $ROOT_DIR/blt/project.yml project.prefix"
+COMMAND="$ROOT_DIR/vendor/bin/blt echo-property -Dproperty.name=project.prefix -silent -emacs"
 ERROR=$($COMMAND 2>&1 > /dev/null)
 PREFIX=$($COMMAND)
 RED='\033[0;31m'


### PR DESCRIPTION
Changes proposed:
- Allow the commit message hook to get `project.prefix` from BLT so that an overridden value may be used (such as one in `project.local.yml`).
