### PR TITLE
Fix misleading "Your composer.json file was modified by BLT" error message

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -143,7 +143,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
       $post_composer_json = md5_file($this->getRepoRoot() . DIRECTORY_SEPARATOR . 'composer.json');
 
       if ($pre_composer_json != $post_composer_json) {
-        $this->io->write('<error>Your composer.json file was modified by BLT, you MUST run "composer update" to update your composer.lock file.</error>');
+        $this->io->write('<error>Your composer.json file was modified by BLT, you MUST run "composer update" to re-process and update dependencies.</error>');
       }
     }
     else {


### PR DESCRIPTION
If BLT modifies your `composer.json` file during an upgrade, it currently emits the following message:

> Your composer.json file was modified by BLT, you MUST run "composer update" to update your composer.lock file.

This is misleading, because `composer update` does not update your `composer.lock` file--it _upgrades all_ your dependencies, which would completely negate the effect of upgrading with `composer update acquia/blt --with-dependencies`. What is actually wanted is `composer update --lock`, which _does_ just update your `composer.lock` file.