### PR TITLE
Added node modules to the php linting excludes list.

### DIFF
--- a/phing/tasks/filesets.xml
+++ b/phing/tasks/filesets.xml
@@ -9,6 +9,7 @@
     <include name="**/*.test"/>
     <include name="**/*.theme"/>
     <exclude name="**/vendor/**/*"/>
+    <exclude name="**/node_modules/**/*"/>
     <!-- Behat php files are ignored because method names and comments do not conform to Drupal coding standards by default. -->
     <exclude name="**/behat/**/*"/>
   </patternset>


### PR DESCRIPTION
Prevents PHPCS from scanning the node-modules directory.  

Changes proposed:
- add node_modules to the php excludes
