### PR TITLE
Issue #1141: Fixes deploy updates only applied to default site.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -237,6 +237,8 @@
       <param name="environment" value="deploy"/>
       <!-- Drush alias should be set to sites to update all sites. -->
       <property name="drush.alias" value="sites"/>
+      <!-- Kill Drush uri, since we want to run updates against all sites. -->
+      <property name="drush.uri" value=""/>
       <!-- Most sites store their version-controlled configuration in /config/default. -->
       <!-- ACE internally sets the vcs configuration directory to /config/default, so we use that. -->
       <property name="cm.config-dir.key" value="${cm.config-dir.deploy-key}"/>


### PR DESCRIPTION
Because build.yml sets the URI to "default", updates only get applied to the default site, even though we are using the `@sites` alias.