### PR TITLE
Issue #813: Clear twig caches on deployments.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -125,7 +125,7 @@
   </target>
 
   <target name="deploy:build" description="Generates a deploy-ready build in deploy.dir."
-          depends="frontend, setup:hash-salt, deploy:copy, deploy:composer:install, deploy:sanitize">
+          depends="frontend, setup:hash-salt, deploy:copy, deploy:composer:install, deploy:id, deploy:sanitize">
     <!--Allow custom commands to be run before commit.-->
     <phingcall target="target-hook:invoke">
       <property name="hook-name" value="post-deploy-build"/>
@@ -136,6 +136,16 @@
         <then>
           <phingcall target="simplesamlphp:deploy:config"/>
         </then>
+    </if>
+  </target>
+
+  <target name="deploy:id" description="Writes deployment id information to artifact.">
+    <if>
+      <isset property="deploy.tag"/>
+      <then>
+        <!-- Write tag name for the benefit of environments like ACE that can't access it. -->
+        <exec dir="${deploy.dir}" command="echo '${deploy.tag}' > deploy_id.txt" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
+      </then>
     </if>
   </target>
 

--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -144,7 +144,7 @@
       <isset property="deploy.tag"/>
       <then>
         <!-- Write tag name for the benefit of environments like ACE that can't access it. -->
-        <exec dir="${deploy.dir}" command="echo '${deploy.tag}' > deploy_id.txt" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
+        <exec dir="${deploy.dir}" command="echo '${deploy.tag}' > deployment_identifier" logoutput="true" checkreturn="true" level="${blt.exec_level}"/>
       </then>
     </if>
   </target>

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -80,6 +80,17 @@ if (file_exists(__DIR__ . '/simplesamlphp.settings.php')) {
  */
 $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
 
+/**
+ * Deployment identifier.
+ *
+ * Drupal's dependency injection container will be automatically invalidated and
+ * rebuilt when the Drupal core version changes. When updating contributed or
+ * custom code that changes the container, changing this identifier will also
+ * allow the container to be invalidated as soon as code is deployed.
+ */
+$deploy_id = file_get_contents(DRUPAL_ROOT . '/../deploy_id.txt');
+$settings['deployment_identifier'] = $deploy_id ? $deploy_id : \Drupal::VERSION;
+
 /*******************************************************************************
  * Environment-specific includes.
  ******************************************************************************/

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -88,8 +88,11 @@ $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
  * custom code that changes the container, changing this identifier will also
  * allow the container to be invalidated as soon as code is deployed.
  */
-$deploy_id = file_get_contents(DRUPAL_ROOT . '/../deploy_id.txt');
-$settings['deployment_identifier'] = $deploy_id ? $deploy_id : \Drupal::VERSION;
+$settings['deployment_identifier'] = \Drupal::VERSION;
+$deploy_id_file = DRUPAL_ROOT . '/../deployment_identifier';
+if (file_exists($deploy_id_file)) {
+  $settings['deployment_identifier'] = file_get_contents($deploy_id_file);
+}
 
 /*******************************************************************************
  * Environment-specific includes.

--- a/template/composer.json
+++ b/template/composer.json
@@ -79,6 +79,11 @@
             "drush/contrib/{$name}": [
                 "type:drupal-drush"
             ]
+        },
+        "patches": {
+            "drupal/core": {
+                "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/no_reliable_method-2752961-29.patch"
+            }
         }
     },
     "scripts": {


### PR DESCRIPTION
Fixes #813 

Changes proposed:
- Add `deploy:id` step to deployments that writes current deploy tag (if present) to a file in the deploy dir.
- Modify settings.php to read this new tag from disk (if it exists) and set `$settings['deployment_identifier']` accordingly.
- Patch core to use `$settings['deployment_identifier']` to handle stale Twig caches on multiple web heads.

I've tested this on a real project and confirmed that the identifier is set correctly, although I haven't been able to test that this actually fixes the problem with stale Twig templates, since that involves a production deploy. I'm fairly confident it will work though.