### PR TITLE
Ignore platform requirements when running composer for a build artifact.

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -162,7 +162,7 @@
             <include name="composer.lock"/>
           </fileset>
         </copy>
-        <exec dir="${deploy.dir}" command="export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --no-dev --no-interaction --optimize-autoloader" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+        <exec dir="${deploy.dir}" command="export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --no-dev --no-interaction --optimize-autoloader --ignore-platform-reqs" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
       </then>
       <else>
         <echo>Dependencies will not be built because deploy.build-dependencies is not enabled.</echo>


### PR DESCRIPTION
When creating a build artifact, I don't think composer needs to consider platform requirements, such as PHP versions or PHP extensions being available. It's most likely that the server creating the build artifact is not the one running the code.