### PR TITLE
1183: Add name property to installer-paths for type:drupal-library.

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -74,7 +74,7 @@
             "docroot/themes/custom/{$name}": [
                 "type:drupal-custom-theme"
             ],
-            "docroot/libraries": [
+            "docroot/libraries/{$name}": [
                 "type:drupal-library"
             ],
             "drush/contrib/{$name}": [


### PR DESCRIPTION
Fixes #1183 .

Changes proposed:
Add name property to installer-paths for type:drupal-library.