### PR TITLE
Fix Selenium failure due to insufficient entropy

### DIFF
--- a/phing/tasks/tests.xml
+++ b/phing/tasks/tests.xml
@@ -134,7 +134,7 @@
         <echo message="Launching Selenium standalone server." />
         <touch file="${repo.root}/reports/selenium2.log"/>
         <property name="reports.selenium2" value="${reports.localDir}/selenium2.log"/>
-        <exec command="${composer.bin}/selenium-server-standalone -port 4444 -log ${reports.selenium2}"
+        <exec command="${composer.bin}/selenium-server-standalone -port 4444 -log ${reports.selenium2} -Djava.security.egd=file:///dev/urandom"
               dir="${repo.root}"
               passthru="true"
               spawn="true"


### PR DESCRIPTION
Selenium uses /dev/random and it was waiting for enough entropy to generate the random number. This can break CI integratiosn like travis when BLT waits for 15 before dying.

Fixes #1210.

Changes proposed:
- Add `java.security.egd=file:///dev/urandom` to the selenium launch.
