### PR TITLE
Update .gitattributes (Woff files are binary)

### DIFF
--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -64,6 +64,7 @@
 *.OTF     -text diff
 *.eot     -text diff
 *.EOT     -text diff
+*.woff    -text diff
 *.woff2   -text diff
 *.WOFF2   -text diff
 *.swf     -text diff


### PR DESCRIPTION
Currently, woff font files get detected as text files, causing them to be corrupted or incorrectly detected as modified on some systems.