### PR TITLE
Fixes #1232: provide common variables to hook scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ script:
   - source ${BLT_DIR}/scripts/blt/ci/internal/doctor.sh
   # Execute PHP Unit tests.
   - phpunit ${BLT_DIR}/tests/phpunit --group blt-project -c ${BLT_DIR}/tests/phpunit/phpunit.xml
+  - phpunit ${BLT_DIR}/tests/phpunit --group blt-hooks -c ${BLT_DIR}/tests/phpunit/phpunit.xml
   - phpunit ${BLT_DIR}/tests/phpunit --group blt-multisite -c ${BLT_DIR}/tests/phpunit/phpunit.xml
   # Deploy build artifact.
   - blt deploy:build

--- a/phing/build.xml
+++ b/phing/build.xml
@@ -75,6 +75,9 @@
   <!-- Contains tasks that fix custom code. -->
   <import file="${phing.dir}/tasks/fix.xml"/>
 
+  <!-- Contains hook tasks. -->
+  <import file="${phing.dir}/tasks/hook.xml"/>
+
   <!-- Disable targets defined in the disable-targets array in project.yml or project.local.yml. -->
   <!-- This must be executed after all targets are defined. -->
   <disabletargets file="${blt.config-files.project}" property="disable-targets"/>
@@ -83,28 +86,6 @@
   <target name="list" hidden="true">
     <exec dir="${repo.root}" command="cat ${blt.root}/scripts/blt/ascii-art.txt" logoutput="true" passthru="true" checkreturn="false"/>
     <exec dir="${blt.root}" command="${repo.root}/vendor/bin/phing -f ${phing.dir}/build.xml -q -l" passthru="true"/>
-  </target>
-
-  <target name="target-hook:invoke" description="Executes a command defined in the target-hooks array." hidden="true">
-    <fail unless="hook-name"/>
-    <if>
-      <isset property="target-hooks.${hook-name}.command"/>
-      <then>
-        <if>
-          <available file="${target-hooks.${hook-name}.dir}" type="dir" property="dirExists" />
-          <then>
-            <echo>Executing command in ${target-hooks.${hook-name}.dir}:</echo>
-            <exec dir="${target-hooks.${hook-name}.dir}" command="${target-hooks.${hook-name}.command}" logoutput="true" checkreturn="true" level="info" passthru="true" />
-          </then>
-          <else>
-            <fail>The directory ${target-hooks.${hook-name}.dir} does not exist. Will not run command for ${hook-name}.</fail>
-          </else>
-        </if>
-      </then>
-      <else>
-        <echo>No commands are defined for ${hook-name}. Skipping.</echo>
-      </else>
-    </if>
   </target>
 
 </project>

--- a/phing/hooks/common/common
+++ b/phing/hooks/common/common
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-export site_name=${multisite.name}
+export multisite_name=${multisite.name}
+export environment=${environment}

--- a/phing/hooks/common/common
+++ b/phing/hooks/common/common
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export site_name=${multisite.name}

--- a/phing/hooks/common/common
+++ b/phing/hooks/common/common
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
 export multisite_name=${multisite.name}
-export environment=${environment}

--- a/phing/hooks/common/common.deploy
+++ b/phing/hooks/common/common.deploy
@@ -1,1 +1,1 @@
-export site_name=${deploy.site.name}
+export multisite_name=${deploy.site.name}

--- a/phing/hooks/common/common.deploy
+++ b/phing/hooks/common/common.deploy
@@ -1,0 +1,1 @@
+export site_name=${deploy.site.name}

--- a/phing/hooks/common/common.dev
+++ b/phing/hooks/common/common.dev
@@ -1,0 +1,3 @@
+# Use common.deploy as these values won't change
+# within the 'dev' environment.
+. ${hook.expand.dir}/common.deploy

--- a/phing/hooks/common/common.prod
+++ b/phing/hooks/common/common.prod
@@ -1,0 +1,3 @@
+# Use common.deploy as these values won't change
+# within the 'prod' environment.
+. ${hook.expand.dir}/common.deploy

--- a/phing/hooks/common/common.test
+++ b/phing/hooks/common/common.test
@@ -1,0 +1,3 @@
+# Use common.deploy as these values won't change
+# within the 'test' environment.
+. ${hook.expand.dir}/common.deploy

--- a/phing/tasks/hook.xml
+++ b/phing/tasks/hook.xml
@@ -1,0 +1,134 @@
+<project name="hook" default="target-hook:invoke">
+
+    <target name="target-hook:invoke" description="Executes a command defined in the target-hooks array." hidden="true">
+        <fail unless="hook-name" message="hook-name must be set."/>
+        <if>
+            <isset property="target-hooks.${hook-name}.command"/>
+            <then>
+
+                <!-- BLT's internal hooks directory where variable assignment templates are placed. -->
+                <property name="hook.template.dir" value="${phing.dir}/hooks"/>
+
+                <!-- Directory for variable templates common to all hooks. -->
+                <property name="hook.common.dir" value="${hook.template.dir}/common"/>
+
+                <!-- Directory for the variable templates for the current hook. -->
+                <property name="hook.current.dir" value="${hook.template.dir}/${hook-name}"/>
+
+                <!-- File names for common hook variables. -->
+                <property name="hook.file.common.base" value="common"/>
+                <property name="hook.file.common.env" value="${hook.file.common.base}.${environment}"/>
+
+                <!-- File names for the current hook. -->
+                <property name="hook.file.current.base" value="${hook-name}"/>
+                <property name="hook.file.current.env" value="${hook.file.current.base}.${environment}"/>
+
+                <!-- Create a random string to use as a random temporary directory. -->
+                <randomString propertyName="hook.dir.rand"/>
+                <php function="substr" returnProperty="hook.dir.rand" level="verbose">
+                    <param>${hook.dir.rand}</param>
+                    <param>-5</param>
+                </php>
+
+                <property name="hook.expand.base.dir" value="/tmp"/>
+                <!-- The absolute directory path that property expansions are output to. -->
+                <property name="hook.expand.dir" value="${hook.expand.base.dir}/blt_${hook.dir.rand}"/>
+
+                <echo>Sourcing variables for ${hook-name}</echo>
+                <mkdir dir="${hook.expand.dir}"/>
+
+                <!-- Expand common hook variable templates. -->
+                <copy todir="${hook.expand.dir}" verbose="false">
+                    <filterchain>
+                        <expandproperties/>
+                    </filterchain>
+                    <fileset dir="${hook.common.dir}">
+                        <include name="*"/>
+                    </fileset>
+                </copy>
+
+                <!-- Expand hook variable templates if they exist for the current hook invocation. -->
+                <if>
+                    <available file="${hook.current.dir}" type="dir" property="hookDirExists"/>
+                    <then>
+                        <copy todir="${hook.expand.dir}" verbose="false">
+                            <filterchain>
+                                <expandproperties/>
+                            </filterchain>
+                            <fileset dir="${hook.current.dir}">
+                                <include name="*"/>
+                            </fileset>
+                        </copy>
+                    </then>
+                </if>
+
+                <!-- Create the final file. We assume the common base file exists. -->
+                <!-- This will (potentially) be appended to below. -->
+                <property name="hook.source.file" value="${hook.expand.dir}/${hook-name}.sh"/>
+                <copy file="${hook.expand.dir}/${hook.file.common.base}" tofile="${hook.source.file}" verbose="false"/>
+
+                <!--
+                    Build the additional file list in the following order, allowing each to
+                    progressively overwrite values defined in any previous file:
+                        1. common environment-specific file
+                        2. hook-specific file
+                        3. hook and environment-specific file
+                    Any of these files are allowed to be absent, so first check their availability.
+                -->
+                <property name="hook.file.list" value=""/>
+                <if>
+                    <available file="${hook.expand.dir}/${hook.file.common.env}" type="file"
+                               property="commonEnvExists"/>
+                    <then>
+                        <property name="hook.file.list" value="${hook.file.list},${hook.file.common.env}"
+                                  override="true"/>
+                    </then>
+                </if>
+                <if>
+                    <available file="${hook.expand.dir}/${hook.file.current.base}" type="file"
+                               property="hookBaseExists"/>
+                    <then>
+                        <property name="hook.file.list" value="${hook.file.list},${hook.file.current.base}"
+                                  override="true"/>
+                    </then>
+                </if>
+                <if>
+                    <available file="${hook.expand.dir}/${hook.file.current.env}" type="file"
+                               property="hookEnvExists"/>
+                    <then>
+                        <property name="hook.file.list" value="${hook.file.list},${hook.file.current.env}"
+                                  override="true"/>
+                    </then>
+                </if>
+
+                <!-- Append to final file. -->
+                <append destFile="${hook.source.file}">
+                    <filelist dir="${hook.expand.dir}" files="${hook.file.list}"/>
+                </append>
+
+                <if>
+                    <available file="${target-hooks.${hook-name}.dir}" type="dir" property="dirExists"/>
+                    <then>
+                        <exec dir="${target-hooks.${hook-name}.dir}"
+                              command=". ${hook.source.file}; ${target-hooks.${hook-name}.command}"
+                              logoutput="true" checkreturn="true" level="info" passthru="true"/>
+                    </then>
+                    <else>
+                        <fail>The directory ${target-hooks.${hook-name}.dir} does not exist. Will not run command for
+                            ${hook-name}.
+                        </fail>
+                    </else>
+                </if>
+
+                <!--Clean up. -->
+                <delete dir="${hook.expand.dir}" quiet="true" verbose="false" includeemptydirs="true"/>
+
+            </then>
+            <else>
+                <echo>No commands are defined for ${hook-name}. Skipping.</echo>
+            </else>
+        </if>
+
+    </target>
+
+</project>

--- a/tests/phpunit/BltProject/HookTest.php
+++ b/tests/phpunit/BltProject/HookTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Acquia\Blt\Tests\BltProject;
+
+use Acquia\Blt\Tests\BltProjectTestBase;
+
+/**
+ * Class HookTest.
+ *
+ * Verifies that BLT hook variables are set as expected.
+ */
+class HookTest extends BltProjectTestBase {
+
+  /**
+   * Tests whether hook variables are set as expected.
+   *
+   * @group blt-hooks
+   */
+  public function testHookVariables() {
+    $this->assertVariableEquals('environment', BLT_ENV);
+    $this->assertVariableEquals('multisite_name', BLT_MULTISITE_NAME);
+  }
+
+  /**
+   * Asserts that a given variable is set as expected.
+   *
+   * @param string $variable
+   *   The variable name to check.
+   * @param string $expected
+   *   The expected value of $variable.
+   */
+  protected function assertVariableEquals($variable, $expected) {
+    $value = $this->getHookVariable($variable);
+    $this->assertEquals($expected, $value,
+      "Expected value at $variable to equal '$expected'. Instead, $variable equals '$value'.");
+  }
+
+  /**
+   * Gets the value of a given hook variable.
+   *
+   * @param string $variable
+   *   The property to check.
+   *
+   * @return string
+   *   The value of $variable.
+   */
+  private function getHookVariable($variable) {
+    $output = [];
+    $blt_bin = "$this->projectDirectory/vendor/bin/blt";
+    // Override normal command execution to use the 'hook-test' namespace and
+    // run a command which will echo our specified variable value.
+    $namespace = 'hook-test';
+    // Run command with minimal output and console styling.
+    $cmd = "$blt_bin target-hook:invoke -emacs -silent";
+    $cmd .= " -Dhook-name=$namespace";
+    $cmd .= " -Dtarget-hooks.$namespace.dir=$this->projectDirectory";
+    $cmd .= " -Dtarget-hooks.$namespace.command=\"echo \\$$variable\"";
+    exec($cmd, $output);
+    // Property value will be output to the 1st line.
+    // Return an empty string if $variable does not exist.
+    return !empty($output[0]) ? $output[0] : '';
+  }
+
+}

--- a/tests/phpunit/BltProject/HookTest.php
+++ b/tests/phpunit/BltProject/HookTest.php
@@ -17,7 +17,6 @@ class HookTest extends BltProjectTestBase {
    * @group blt-hooks
    */
   public function testHookVariables() {
-    $this->assertVariableEquals('environment', BLT_ENV);
     $this->assertVariableEquals('multisite_name', BLT_MULTISITE_NAME);
   }
 


### PR DESCRIPTION
Fixes #1232.

Mostly just a proof of concept here, but something along these lines would allow a common set of variables to be passed to all of BLT's hook invocations and would allow specific variables to be declared and passed during specific hook invocations.

Changes proposed:
- Create an interface for common internal variables to be passed to hook scripts automatically
- Alter hook variable values based on what environment BLT is run in (when necessary)
