### PR TITLE
Instruct local files sync to exclude image styles as well as the css/js cache folders

### DIFF
--- a/phing/tasks/local-sync.xml
+++ b/phing/tasks/local-sync.xml
@@ -70,6 +70,7 @@
     <drush command="rsync" alias="">
       <param>@${drush.aliases.remote}:%files/</param>
       <param>${docroot}/sites/${site.name}/files</param>
+      <option name="exclude-paths">styles:css:js</option>
     </drush>
   </target>
 


### PR DESCRIPTION
This seems reasonable to me?