### PR TITLE
Add node_modules and bower_components to yaml fileset excludes.

### DIFF
--- a/phing/tasks/filesets.xml
+++ b/phing/tasks/filesets.xml
@@ -24,6 +24,8 @@
   <patternset id="files.yaml">
     <include name="**/*.yaml"/>
     <include name="**/*.yml"/>
+    <exclude name="**/node_modules/**/*"/>
+    <exclude name="**/bower_components/**/*"/>
   </patternset>
 
   <!--


### PR DESCRIPTION
Fixes #1279.

Changes proposed:
- Some node_modules or bower_components can contain invalid YAML files.
- Exclude those directories from the YAML linting by adding excludes to the yaml fileset.
