### PR TITLE
Fixes #1307: Specify sync config directory for config import.

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -250,7 +250,9 @@
           <param>config_split</param>
         </drush>
 
-        <drush command="config-import" assume="yes" alias="${drush.alias}"></drush>
+        <drush command="config-import" assume="yes" alias="${drush.alias}">
+          <param>sync</param>
+        </drush>
 
       </then>
     </if>


### PR DESCRIPTION
Fixes #1307.

Changes proposed:
- Set the sync directory as the config directory
