### PR TITLE
Fix config imports

### DIFF
--- a/phing/build.yml
+++ b/phing/build.yml
@@ -42,7 +42,7 @@ cm:
   strategy: config-split
   core:
     # The parent directory for configuration directories, relative to the docroot.
-    path: ../config
+    path: ${repo.root}/config
     # The default config key to use for imports. This is the key used in Drupal's global $config_directories variable.
     # E.g., $config_directories['sync']. It must have a corresponding key in cm.core.dirs. E.g., `cm.core.dirs.sync`.
     key: sync


### PR DESCRIPTION
BLT version 8.7.0-beta3+several patches for more recent commits

setup:config-import:config-split is currently broken because for whatever reason Phing doesn't like the relative path used in cm.core.dirs.sync.path and cm.core.path. Simply changing this to an absolute path fixes it.