### PR TITLE
Issue #53: Added support for custom git username and email

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -217,6 +217,17 @@
     <exec command="git init ${deploy.dir}" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="false"/>
     <exec dir="${deploy.dir}" command="git config --local core.excludesfile false" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
     <echo>Global .gitignore file is being disabled for this repository to prevent unexpected behavior.</echo>
+    <!-- Add the git username and email if necessary. -->
+    <if>
+      <and>
+        <isset property="git.user.name"/>
+        <isset property="git.user.email"/>
+      </and>
+      <then>
+        <exec dir="${deploy.dir}" command="git config --local --add user.email ${git.user.email} user.name ${git.user.name}" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+      </then>
+    </if>
+
   </target>
 
   <target name="deploy:push-all" hidden="true">


### PR DESCRIPTION
Fixes #53 

This adds a set of hidden properties for git identification (git.user.name and git.user.email). If these properties are set, the deploy repo will be initialized with them.

You can set these either in `project.yml`, `project.local.yml`, or via the command line (e.g. `blt deploy -Dgit.user.name=Joe`)

I didn't document these because it seems like an edge case, but one that's worth supporting. Maybe it would be good to document them somewhere? I don't know that we have a comprehensive list of Phing properties anywhere...