### PR TITLE
Fix local warnings about trusted host pattern

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -129,6 +129,6 @@ $settings['file_private_path'] = $dir . '/files-private';
  *
  * See full description in default.settings.php.
  */
-# $settings['trusted_host_patterns'] = array(
-#   '^example\.local$',
-# );
+$settings['trusted_host_patterns'] = array(
+  '^.+$',
+);


### PR DESCRIPTION
In local environments, there's a big scary warning on the status report about missing trusted host patterns. It isn't really necessary to have trusted host patterns locally, since I can't imagine any scenario where the local environment is an attack surface for host header spoofing.

This sets the trusted host pattern to a wildcard (i.e. accept any host) to get rid of the warning.