### PR TITLE
Split deploy git variables

### DIFF
--- a/phing/tasks/deploy.xml
+++ b/phing/tasks/deploy.xml
@@ -236,13 +236,14 @@
     <echo>Global .gitignore file is being disabled for this repository to prevent unexpected behavior.</echo>
     <!-- Add the git username and email if necessary. -->
     <if>
-      <and>
-        <isset property="git.user.name"/>
-        <isset property="git.user.email"/>
-      </and>
-      <then>
-        <exec dir="${deploy.dir}" command="git config --local --add user.email ${git.user.email} user.name ${git.user.name}" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
-      </then>
+      <isset property="git.user.name"/>
+    <then>
+      <exec dir="${deploy.dir}" command="git config --local --add user.name ${git.user.name}" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
+    </if>
+    <if>
+      <isset property="git.user.email"/>
+    <then>
+      <exec dir="${deploy.dir}" command="git config --local --add user.email ${git.user.email}" logoutput="true" checkreturn="true" level="${blt.exec_level}" passthru="true"/>
     </if>
 
   </target>

--- a/template/blt/project.yml
+++ b/template/blt/project.yml
@@ -17,6 +17,10 @@ project:
 git:
   default_branch: master
   remotes: []
+  # Overrides git-config user.name and user.email respectively on deploy git repository.
+  #user:
+  #  name: 'John Doe'
+  #  email: 'john@example.com'
 
 drush:
   # You can set custom project aliases in drush/site-aliases/aliases.drushrc.php.


### PR DESCRIPTION
Fixes #1340.

Changes proposed:
- Split git config overrides on deploy git directory, so both of them are not required.
- Documents git.user.name and git.user.email blt options.