### PR TITLE
Add QA Accounts module

### DIFF
--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -3,6 +3,7 @@
     "acquia/lightning": "^2.0.3",
     "drupal/acquia_connector": "^1.5.0",
     "drupal/cog": "^1.0.0",
+    "drupal/qa_accounts": "^1.0.0-alpha1",
     "drupal/memcache": "2.x-dev",
     "drupal/seckit": "^1.0.0-alpha2",
     "drupal/security_review": "*",


### PR DESCRIPTION
Most projects need to create user accounts for QA and UAT on dev/stage. Rather than every project re-inventing the wheel, I figured I'd create a module that we can also use and contribute to: https://www.drupal.org/project/qa_accounts

Can we include this by default on BLT builds?