### PR TITLE
Update notifications not disabled during Drupal 8.3.x installation

### DIFF
--- a/phing/tasks/drupal.xml
+++ b/phing/tasks/drupal.xml
@@ -24,7 +24,7 @@
                   <option name="account-mail">"${drupal.account.mail}"</option>
                   <option name="locale">"${drupal.locale}"</option>
                   <param>"${project.profile.name}"</param>
-                  <param>"install_configure_form.update_status_module='array(FALSE,FALSE)'"</param>
+                  <param>"install_configure_form.update_status_module='array(FALSE,FALSE)';install_configure_form.enable_update_status_module=FALSE;install_configure_form.enable_update_status_emails=FALSE"</param>
               </drush>
           </then>
           <else>
@@ -37,7 +37,7 @@
                   <option name="locale">"${drupal.locale}"</option>
                   <option name="config-dir">${cm.core.dirs.${cm.core.key}.path}</option>
                   <param>"${project.profile.name}"</param>
-                  <param>"install_configure_form.update_status_module='array(FALSE,FALSE)'"</param>
+                  <param>"install_configure_form.update_status_module='array(FALSE,FALSE)';install_configure_form.enable_update_status_module=FALSE;install_configure_form.enable_update_status_emails=FALSE"</param>
               </drush>
           </else>
       </if>


### PR DESCRIPTION
BLT disables update notifications during install time via a command-line argument to Drush. This is nice because it prevents Drupal from sending an email that can cause problems on systems without a local mail transport agent.

The problem is that Drupal changed the update notification configuration form in 8.3.0: http://cgit.drupalcode.org/drupal/commit/?h=8.3.x&id=b97e6a73ab0593efa99c84a36c635bbe3fe9f4e6

This caused this parameter to stop working, and for some users errors due to their system being unable to send the email.

This fixes it by adding the new parameter (leaving the old parameter for 8.2.x users shouldn't hurt anything).

I also considered making this a Phing property / variable to reduce duplication, let me know if you'd prefer that.