### PR TITLE
Fix broken core-only config strategy

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -224,7 +224,7 @@
   <target name="setup:config-import:core-only">
 
     <if>
-      <available file="${cm.core.dirs.${cm.core.key}.path}/core.extension.yml"/>
+      <available file="${docroot}/${cm.core.dirs.${cm.core.key}.path}/core.extension.yml"/>
       <then>
         <drush command="config-import" assume="yes" alias="${drush.alias}" passthru="false">
           <param>${cm.core.key}</param>


### PR DESCRIPTION
The directory path for checking if the core.extension.yml file exists needs to be rooted to `${docroot}`. I think there was a similar fix that I saw for config-split strategy, but it was missed for core-only.