### PR TITLE
Post-deploy-build example

### DIFF
--- a/template/blt/project.yml
+++ b/template/blt/project.yml
@@ -52,7 +52,7 @@ target-hooks:
     command: echo 'No pre-config-import configured.'
   # Executed after deployment artifact is created.
   post-deploy-build:
-    dir: ${docroot}
+    dir: '${deploy.dir}/docroot'
     command: echo 'No post-deploy build configured.'
   # Executed after setup:build is run.
   post-setup-build:


### PR DESCRIPTION
If you're writing a post-deploy-build hook, you're almost certainly doing something to the files in the deploy docroot. It might not be obvious to folks how to reference this file location, so it would probably be best to lead by example.