### PR TITLE
Exclude sites/all from multisite variable.

### DIFF
--- a/phing/tasks/properties.xml
+++ b/phing/tasks/properties.xml
@@ -67,7 +67,7 @@
         <available file="${docroot}/sites"/>
         <then>
           <!-- Find directories in ${docroot}/sites/*/ and format into a comma-separated list. Exclude ${docroot}/sites/g. -->
-          <exec command="find ${docroot}/sites/* -maxdepth 0 -type d | grep -v -e '${docroot}/sites/g$' | sed -e 's%${docroot}/sites/%%g' -e '2,$s%^%,%' | tr -d '\n'"
+          <exec command="find ${docroot}/sites/* -maxdepth 0 -type d | grep -v -e '${docroot}/sites/g$' -e '${docroot}/sites/all$' | sed -e 's%${docroot}/sites/%%g' -e '2,$s%^%,%' | tr -d '\n'"
                 outputProperty="multisite.name" logoutput="false" checkreturn="true"/>
         </then>
         <else>


### PR DESCRIPTION
Fixes #1386.

Changes proposed:
- Exclude `docroot/sites/all` from multisite variable assignment.
