### PR TITLE
Run config-import twice

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -229,6 +229,10 @@
         <drush command="config-import" assume="yes" alias="${drush.alias}" passthru="false">
           <param>${cm.core.key}</param>
         </drush>
+        <!-- Sometimes config-import has to be run twice to catch everything. Can be removed once the core configuration system is more stable. -->
+        <drush command="config-import" assume="yes" alias="${drush.alias}" passthru="false">
+          <param>${cm.core.key}</param>
+        </drush>
       </then>
     </if>
 

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -254,6 +254,11 @@
           <param>sync</param>
         </drush>
 
+        <!-- Sometimes config-import has to be run twice to catch everything. Can be removed once the core configuration system is more stable. -->
+        <drush command="config-import" assume="yes" alias="${drush.alias}">
+          <param>sync</param>
+        </drush>
+
       </then>
     </if>
 


### PR DESCRIPTION
It's sometimes necessary to run config-import twice to completely import all configuration changes. This shouldn't be necessary in theory, but I've identified a number of core bugs that can cause this (such as [this](https://github.com/drush-ops/drush/issues/2709), [this](https://www.drupal.org/node/2622160#comment-12038215), and some other related to dependency detection that I haven't been able to pin down yet).