### PR TITLE
Pass --yes parameter for cloud db sanitize script.

### DIFF
--- a/scripts/cloud-hooks/hooks/common/post-db-copy/db-scrub.sh
+++ b/scripts/cloud-hooks/hooks/common/post-db-copy/db-scrub.sh
@@ -14,6 +14,6 @@ source_env="$4"
 acsf_file="/mnt/files/$AH_SITE_GROUP.$AH_SITE_ENVIRONMENT/files-private/sites.json"
 if [ ! -f $acsf_file ]; then
   echo "$site.$target_env: Scrubbing database $db_name"
-  drush @$site.$target_env sql-sanitize
+  drush @$site.$target_env sql-sanitize --yes
   drush @$site.$target_env cache-rebuild
 fi


### PR DESCRIPTION
Changes proposed:
- Add `--yes` parameter to `drush sql-sanitize`, without this the command eventually does not run, but times out on ACE:

```sh
The following operations will be done on the target database:
 * Reset passwords and email addresses in users_field_data table
 * Truncate Drupal's sessions table
 * Remove names and email addresses from anonymous user comments.
 * Replace names and email addresses from authenticated user comments.

Do you really want to sanitize the current database? (y/n): 
Cancelled.                                                              [cancel]
Cache rebuild complete.                                                     [ok]
```
