### PR TITLE
Ensure integrity of configuration exports

### DIFF
--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -234,6 +234,14 @@
           <param>${cm.core.key}</param>
         </drush>
       </then>
+      <if>
+        <not><equals arg1="${cm.allow-overrides}" arg2="true"/></not>
+        <then>
+          <phingcall target="setup:update:config-override-check">
+            <property name="cm.dir" value="${cm.core.key}"/>
+          </phingcall>
+        </then>
+      </if>
     </if>
 
   </target>
@@ -258,6 +266,15 @@
         <drush command="config-import" assume="yes" alias="${drush.alias}">
           <param>sync</param>
         </drush>
+
+        <if>
+          <not><equals arg1="${cm.allow-overrides}" arg2="true"/></not>
+          <then>
+            <phingcall target="setup:update:config-override-check">
+              <property name="cm.dir" value="sync"/>
+            </phingcall>
+          </then>
+        </if>
 
       </then>
     </if>
@@ -364,6 +381,17 @@
       <istrue value="${features.overrides}"/>
       <then>
         <fail>A feature in the ${bundle} bundle is overridden. You must re-export this feature to incorporate the changes.</fail>
+      </then>
+    </if>
+  </target>
+
+  <target name="setup:update:config-override-check" description="Checks if core configuration is overridden.">
+    <echo>Checking for config overrides...</echo>
+    <exec dir="${docroot}" command="${drush.cmd} cex ${cm.dir} -n | grep 'Differences of the active config'" outputProperty="config.overrides"/>
+    <if>
+      <istrue value="${config.overrides}"/>
+      <then>
+        <fail>Configuration in the database does not match configuration on disk. You must re-export configuration to capture the changes. This could also indicate a problem with the import process, such as changed field storage for a field with existing content.</fail>
       </then>
     </if>
   </target>

--- a/phing/tasks/setup.xml
+++ b/phing/tasks/setup.xml
@@ -226,22 +226,26 @@
     <if>
       <available file="${docroot}/${cm.core.dirs.${cm.core.key}.path}/core.extension.yml"/>
       <then>
+
         <drush command="config-import" assume="yes" alias="${drush.alias}" passthru="false">
           <param>${cm.core.key}</param>
         </drush>
+
         <!-- Sometimes config-import has to be run twice to catch everything. Can be removed once the core configuration system is more stable. -->
         <drush command="config-import" assume="yes" alias="${drush.alias}" passthru="false">
           <param>${cm.core.key}</param>
         </drush>
+
+        <if>
+          <not><equals arg1="${cm.allow-overrides}" arg2="true"/></not>
+          <then>
+            <phingcall target="setup:update:config-override-check">
+              <property name="cm.dir" value="${cm.core.key}"/>
+            </phingcall>
+          </then>
+        </if>
+
       </then>
-      <if>
-        <not><equals arg1="${cm.allow-overrides}" arg2="true"/></not>
-        <then>
-          <phingcall target="setup:update:config-override-check">
-            <property name="cm.dir" value="${cm.core.key}"/>
-          </phingcall>
-        </then>
-      </if>
     </if>
 
   </target>


### PR DESCRIPTION
This helps to ensure integrity of configuration exports by adding a test for configuration overrides subsequent to each config import. If a configuration remains overridden after import, it's a strong indication that you have a corrupt configuration export (typically uncaptured configuration changes.)

Note that these types of errors have been hidden for so long that I suspect almost all projects using core config or config split have at least one. Thus, I expect this test will fail when a lot of projects update BLT. We should make it clear in the release notes that this test is being added, so no one is surprised.

I think it's important that this test runs by default, but I have provided the option of disabling it via the `cm.allow-overrides` flag, if projects need to do that in the interim while fixing already-broken config.