### PR TITLE
BLT-1047: adding ability to customize paths for phpunit tests.

### DIFF
--- a/phing/build.yml
+++ b/phing/build.yml
@@ -127,6 +127,13 @@ phpcbf:
     - files.php.custom.themes
     - files.frontend.custom.themes
 
+phpunit:
+  - path: '${repo.root}/tests/phpunit'
+    config: null
+  # Customization for one or more custom phpunit test locations
+  # and if the core (or custom) config file should be included as a -c parameter.
+  # - path: '${docroot}/custom/modules/<your_module>/tests'
+  #   config: '${docroot}/core/phpunit.dist.xml'
 project:
   local:
     uri: ${project.local.protocol}://${project.local.hostname}

--- a/readme/testing.md
+++ b/readme/testing.md
@@ -173,13 +173,12 @@ Project level, functional PHPUnit tests are included in `tests/phpunit`. Any PHP
 
 ### Configuration
 
-PHPunit's behavior(s) can be further customized via the project.yml file to provide additional levels of control on a per project basis. See [Extending BLT](extending-blt.md) for more information.
- 
- The each index in the  phpunit array in project.yml should contain a path (to a phpunit test or directory that  contains at least one test) and a config path (if custom configuration or boostrapping of Drupal is required):
+You can customize the `tests:phpunit` command by [customize the configuration values](extending-blt.md#modifying-blt-configuration) for the `phpunit` key.
+
+Each row under the `phpunit` key should contain a `path` and a `config` key. The `path` key indicates a directory containing PHPUnit tests. The optional `config` key can be used to specify a PHP configuration file.
  
  * config: path to either the Core phpunit configuration file (docroot/core/phpunit.xml.dist) or a custom one. If left blank, no configuration will be loaded with the unit test.
  * path: the path to the custom phpunit test
-
 
 ## Frontend Testing
 

--- a/readme/testing.md
+++ b/readme/testing.md
@@ -171,6 +171,16 @@ Project level, functional PHPUnit tests are included in `tests/phpunit`. Any PHP
 * [Unit testing: Why bother?](http://soundsoftware.ac.uk/unit-testing-why-bother/)
 
 
+### Configuration
+
+PHPunit's behavior(s) can be further customized via the project.yml file to provide additional levels of control on a per project basis. See [Extending BLT](extending-blt.md) for more information.
+ 
+ The each index in the  phpunit array in project.yml should contain a path (to a phpunit test or directory that  contains at least one test) and a config path (if custom configuration or boostrapping of Drupal is required):
+ 
+ * config: path to either the Core phpunit configuration file (docroot/core/phpunit.xml.dist) or a custom one. If left blank, no configuration will be loaded with the unit test.
+ * path: the path to the custom phpunit test
+
+
 ## Frontend Testing
 
 BLT supports a `frontend-test` target that can be used to execute a variety of testing frameworks. Examples may include Jest, Jasmine, Mocha, Chai, etc.

--- a/src/Robo/Commands/Tests/PhpUnitCommand.php
+++ b/src/Robo/Commands/Tests/PhpUnitCommand.php
@@ -10,7 +10,6 @@ use Robo\Contract\VerbosityThresholdInterface;
  */
 class PhpUnitCommand extends BltTasks {
 
-
   /**
    * Directory in which test logs and reports are generated.
    *
@@ -24,10 +23,11 @@ class PhpUnitCommand extends BltTasks {
   protected $reportFile;
 
   /**
-   * The directory path containing PHPUnit tests.
+   * An array that contains configuration to override /
+   * customize phpunit commands.
    *
-   * @var string*/
-  protected $testsDir;
+   * @var array*/
+  protected $phpunitConfig;
 
   /**
    * This hook will fire for all commands in this command file.
@@ -37,12 +37,8 @@ class PhpUnitCommand extends BltTasks {
   public function initialize() {
     $this->reportsDir = $this->getConfigValue('reports.localDir') . '/phpunit';
     $this->reportFile = $this->reportsDir . '/results.xml';
-    if (is_array($this->getConfigValue('phpunit.paths'))) {
-      $this->testsDir = $this->getConfigValue('phpunit.paths');
-    }
-    else {
-      $this->testsDir[] = $this->getConfigValue('repo.root') . '/tests/phpunit';
-    }
+    $this->testsDir = $this->getConfigValue('repo.root') . '/tests/phpunit';
+    $this->phpunitConfig = $this->getConfigValue('phpunit');
   }
 
   /**
@@ -53,13 +49,18 @@ class PhpUnitCommand extends BltTasks {
    */
   public function testsPhpUnit() {
     $this->createLogs();
-    foreach ($this->testsDir as $dir) {
+    foreach ($this->phpunitConfig as $test) {
       $task = $this->taskPHPUnit()
-        ->dir($dir)
         ->xml($this->reportFile)
         ->arg('.')
         ->printOutput(TRUE)
         ->printMetadata(FALSE);
+      if (isset($test['path'])) {
+        $task->dir($test['path']);
+      }
+      if (isset($test['config'])) {
+        $task->option('--configuration', $test['config']);
+      }
       $task->run();
     }
   }

--- a/src/Robo/Commands/Tests/PhpUnitCommand.php
+++ b/src/Robo/Commands/Tests/PhpUnitCommand.php
@@ -37,7 +37,12 @@ class PhpUnitCommand extends BltTasks {
   public function initialize() {
     $this->reportsDir = $this->getConfigValue('reports.localDir') . '/phpunit';
     $this->reportFile = $this->reportsDir . '/results.xml';
-    $this->testsDir = $this->getConfigValue('repo.root') . '/tests/phpunit';
+    if (is_array($this->getConfigValue('phpunit.paths'))) {
+      $this->testsDir = $this->getConfigValue('phpunit.paths');
+    }
+    else {
+      $this->testsDir[] = $this->getConfigValue('repo.root') . '/tests/phpunit';
+    }
   }
 
   /**
@@ -48,13 +53,15 @@ class PhpUnitCommand extends BltTasks {
    */
   public function testsPhpUnit() {
     $this->createLogs();
-    $this->taskPHPUnit()
-      ->dir($this->testsDir)
-      ->xml($this->reportFile)
-      ->arg('.')
-      ->printOutput(TRUE)
-      ->printMetadata(FALSE)
-      ->run();
+    foreach ($this->testsDir as $dir) {
+      $task = $this->taskPHPUnit()
+        ->dir($dir)
+        ->xml($this->reportFile)
+        ->arg('.')
+        ->printOutput(TRUE)
+        ->printMetadata(FALSE);
+      $task->run();
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #1047  .

Changes proposed:
- adds configurable paths for PHPUnit tests so that tests can live inline with custom modules
- adds configuration parameter for each PHPUnit test so that drupal may be bootstrapped on demand