### PR TITLE
Fixed errors for BLT doctor.

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -25,6 +25,8 @@ $databases = array(
   ),
 );
 
+$dir = dirname(DRUPAL_ROOT);
+
 // Use development service parameters.
 $settings['container_yamls'][] = $dir . '/docroot/sites/development.services.yml';
 


### PR DESCRIPTION
#1299 moved the `$dir` variable out of default.local.settings.php, even though it was still in use elsewhere in the file. This causes notices if local.settings.php happens to be included prior to config.settings.php (where the variable wound up).

I've seen this happen when running `blt doctor`, I'm sure there are other ways it could manifest.

There's probably better ways of handling this than defining an essentially global variable twice. Maybe move it to blt.settings.php and namespace it properly?