### PR TITLE
BLT-1479: correcting example path to the phpunit.xml.dist file.

### DIFF
--- a/phing/build.yml
+++ b/phing/build.yml
@@ -133,7 +133,7 @@ phpunit:
   # Customization for one or more custom phpunit test locations
   # and if the core (or custom) config file should be included as a -c parameter.
   # - path: '${docroot}/custom/modules/<your_module>/tests'
-  #   config: '${docroot}/core/phpunit.dist.xml'
+  #   config: '${docroot}/core/phpunit.xml.dist'
 project:
   local:
     uri: ${project.local.protocol}://${project.local.hostname}


### PR DESCRIPTION
Fixes #1479  .

Changes proposed:
- updates the path to be to the correct file as listed in the build.yml file.
