### PR TITLE
BLT-1490: removing invalid parameter (partial).

### DIFF
--- a/src/Robo/Commands/Drupal/DrupalCommand.php
+++ b/src/Robo/Commands/Drupal/DrupalCommand.php
@@ -48,9 +48,6 @@ class DrupalCommand extends BltTasks {
     if (!$config_strategy != 'none') {
       $cm_core_key = $this->getConfigValue('cm.core.key');
       $task->option('config-dir', $this->getConfigValue("cm.core.dirs.$cm_core_key.path"));
-      if ($config_strategy == 'features') {
-        $task->option('partial');
-      }
     }
 
     $result = $task->interactive()->run();


### PR DESCRIPTION
Fixes #1490  .

Changes proposed:
- removes invalid partial parameter as part of the site-install command
