### PR TITLE
Exclude composer files from artifact.

### DIFF
--- a/phing/files/deploy-exclude.txt
+++ b/phing/files/deploy-exclude.txt
@@ -17,6 +17,7 @@
 /docroot/sites/*/private
 /docroot/themes/contrib
 /drush/contrib
+/patches
 /README.md
 /readme
 /sites/development.services.yml
@@ -29,5 +30,6 @@ example.*
 local.settings.php
 local.drushrc.php
 node_modules
+/composer.*
 /vendor
 project.local.yml


### PR DESCRIPTION
Throwing this up as a reaction to some of the composer BoF discussion at Drupalcon. I don't know if there some consideration here for why we want `composer.json`, `composer.lock` and `/patches` in your artifact. If we don't want people running `composer install` on production, this takes away that option.

This is probably more for discussion, but figured getting this up would be the best way to start the convo.  =)