### PR TITLE
Enhance nuke command.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -55,7 +55,7 @@
     "blt-alias": "blt install-alias -Dcreate_alias=true",
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "nuke": [
-      "rm -rf vendor composer.lock",
+      "rm -rf vendor composer.lock docroot/core docroot/modules/contrib docroot/profiles/contrib docroot/themes/contrib",
       "@composer clearcache",
       "@composer install"
     ],


### PR DESCRIPTION
Another random change for discussion.

Changes proposed:
- The `composer nuke` command currently deletes `vendor/` and `composer.lock`, clears cache and re-runs `$ composer install`. This change also deletes the common Drupal folders for core, modules/contrib, themes/contrib and profiles/contrib.
- At first I was thinking this is a bit of an assumption, because users can actually put their contrib modules in somewhere other than `docroot/modules/contrib`, but at the same time, I can put my composer dependencies in something other than `vendor/` too. The former is admittedly a little more common.
- `docroot/libraries/contrib` felt a little too heavy handed, because it's equally as likely that composer is not managing that directory for a user. Happy to add it though if there are any thoughts there.
