### PR TITLE
Config module isn't necessary to handle config updates

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -37,7 +37,6 @@ class ConfigCommand extends BltTasks {
         ->assume(TRUE)
         // Sometimes drush forgets where to find its aliases.
         ->drush("cc")->arg('drush')
-        ->drush("pm-enable")->arg('config')
         // Rebuild caches in case service definitions have changed.
         // @see https://www.drupal.org/node/2826466
         ->drush("cache-rebuild")


### PR DESCRIPTION
TIL that the Config module is more or less just an administrative interface. I don't think it should be necessary in order to manage configuration via the command line (drush, features, config split, etc). So BLT shouldn't need to enable it.

I've also opened an upstream issue to try to make this fact a little more obvious: https://www.drupal.org/node/2877111