### PR TITLE
Fix Documentation Title typo in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Acquia BLT Documentaton
+site_name: Acquia BLT Documentation
 
 repo_url: https://github.com/acquia/blt
 site_description: 'BLT - Acquia Build & Launch Tools'


### PR DESCRIPTION
Fixes #1496  .

Changes proposed:
- updates mkdocs.yml with a new site name
