### PR TITLE
Drupal libraries path in composer install should match .gitignore

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -19,7 +19,7 @@
             "docroot/profiles/custom/{$name}": ["type:drupal-custom-profile"],
             "docroot/themes/contrib/{$name}": ["type:drupal-theme"],
             "docroot/themes/custom/{$name}": ["type:drupal-custom-theme"],
-            "docroot/libraries/{$name}": ["type:drupal-library"],
+            "docroot/libraries/contrib/{$name}": ["type:drupal-library"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
         },
         "merge-plugin": {


### PR DESCRIPTION
- [.gitignore](https://github.com/acquia/blt/blob/8.x/template/.gitignore#L23) references `docroot/libraries/contrib`
- but [composer.json](https://github.com/acquia/blt/blob/8.x/template/composer.json#L22) uses `docroot/libraries/{$name}` 

It seems to me these should be the same.

This pull request updates the libraries path in `composer.json` to match `.gitignore`.