### PR TITLE
Increase DrupalVM memory

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -74,7 +74,7 @@ php_xdebug_remote_connect_back: 1
 php_xdebug_idekey: PHPSTORM
 php_xdebug_max_nesting_level: 256
 php_xdebug_remote_port: "9000"
-php_memory_limit: "256M"
+php_memory_limit: "512M"
 
 post_provision_scripts:
   - "../../../acquia/blt/scripts/drupal-vm/post-provision.sh"


### PR DESCRIPTION
This mirrors the recent change to Travis to accommodate the increased memory usage of Drupal 8.3.3