### PR TITLE
Set site_dir to fix config imports on ACSF.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -4,14 +4,6 @@
  * Setup BLT utility variables.
  ******************************************************************************/
 
-try {
-  $site_path = \Drupal\Core\DrupalKernel::findSitePath(\Symfony\Component\HttpFoundation\Request::createFromGlobals());
-}
-catch (\Symfony\Component\HttpKernel\Exception\BadRequestHttpException $e) {
-  $site_path = 'sites/default';
-}
-$site_dir = str_replace('sites/', '', $site_path);
-
 /**
  * Host detection.
  */
@@ -45,6 +37,22 @@ $is_ah_ode_env = (preg_match('/^ode[0-9]*$/', $ah_env));
 $is_acsf = (!empty($ah_group) && file_exists("/mnt/files/$ah_group.$ah_env/files-private/sites.json"));
 $acsf_db_name = $is_acsf ? $GLOBALS['gardens_site_settings']['conf']['acsf_db_name'] : NULL;
 $is_local_env = !$is_ah_env;
+
+/**
+ * Site directory detection.
+ */
+try {
+  $site_path = \Drupal\Core\DrupalKernel::findSitePath(\Symfony\Component\HttpFoundation\Request::createFromGlobals());
+}
+catch (\Symfony\Component\HttpKernel\Exception\BadRequestHttpException $e) {
+  $site_path = 'sites/default';
+}
+$site_dir = str_replace('sites/', '', $site_path);
+// ACSF uses a pseudo-multisite architecture that places all site files under
+// sites/g/files, which isn't useful for our purposes.
+if ($is_acsf) {
+  $site_dir = 'default';
+}
 
 /*******************************************************************************
  * Acquia Cloud settings.


### PR DESCRIPTION
BLT sets the `$site_dir` variable in blt.settings.php and uses this variable in three places:

1. Elsewhere in blt.settings.php (but only for ACE and local environments) to find settings include files.
2. In filesystem.settings.php (again, only for ACE environments)
3. In config.settings.php to determine where to look for config files (i.e. `/config/$site_dir`, usually `/config/default`)

The problem is that on ACSF, the site_dir is something like `g/files/abc1234`, because ACSF doesn't use true multisite. This is problematic because it prevents you from using a common configuration directory like `config/default`.

This patch overrides this behavior to set the site_dir to `default` on ACSF.

I could also see an argument for making the site_dir 'g', but this would make codebases less portable between ACE and ACSF (since you'd need to use a config directory like `/config/default` on ACE and `/config/g` on ACSF).

The only possible adverse effect I can see from this change is for sites that have legitimately separate configuration directories for all of their ACSF sites. But that just doesn't seem like it would be practical.