### PR TITLE
Remove nonexistent ansi option.

### DIFF
--- a/scripts/pipelines/run_tests
+++ b/scripts/pipelines/run_tests
@@ -6,8 +6,8 @@ export PATH=${COMPOSER_BIN}:${PATH}
 
 yaml-cli update:value blt/project.yml project.local.hostname '127.0.0.1:8888'
 
-blt validate:all --ansi
-blt ci:setup -Dcreate_alias=false --ansi
+blt validate:all
+blt ci:setup -Dcreate_alias=false
 blt tests:all -D behat.run-server=true -D behat.launch-selenium=false -D behat.launch-phantomjs=true -D behat.tags='~experimental' --yes -v --ansi
 
 set +v


### PR DESCRIPTION
In 8.8.4 `scripts/pipelines/run_tests` fails because `--ansi` is not a phing option

Changes proposed:
- Removes the `--ansi` option from the call to `blt validate:all`
- Removes the `--ansi` option from the clall to `blt ci:setup`

NOTE: the presence of the `--ansi` option did not seem to affect the call to `blt tests:all` 


