### PR TITLE
Removed redundant file path setting.

### DIFF
--- a/settings/filesystem.settings.php
+++ b/settings/filesystem.settings.php
@@ -14,6 +14,5 @@ if ($is_acsf) {
 }
 // Acquia cloud file paths.
 elseif ($is_ah_env) {
-  $config['system.file']['path']['temporary'] = '/mnt/tmp/' . $_ENV['AH_SITE_NAME'];
   $settings['file_private_path'] = "/mnt/files/$ah_group.$ah_env/files-private";
 }


### PR DESCRIPTION
Acquia Cloud already sets the temporary file system path using a nearly identical statement on the server-side settings include. Setting it here is redundant and could produce unexpected behavior if Acquia Cloud decides to move the directory in the future.