### PR TITLE
Don't run ACSF Cloud Hooks in update environments.

### DIFF
--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -8,8 +8,10 @@ drush_alias=${site}'.'${target_env}
 deploy_updates() {
 
   case $target_env in
-    [01]*)
+    01dev|01test|01live)
       acsf_deploy
+      ;;
+    01devup|01testup|01update)
       ;;
     *)
       ace_deploy


### PR DESCRIPTION
Currently, cloud hooks run whenever code is deployed on ACSF. This is problematic because of how ACSF deploys code (described below): it means that during normal deploys, update hooks will be run multiple times, and in some cases can run at the same time. This can cause staging deploys to crash, for instance, with errors like this:

> config_importer is already importing

Specifically, for each environment (dev/test/live), ACSF has a primary and "update" docroot, meaning there are actually six environments: 01dev, 01devup, 01test, 01testup, 01live, and 01update. It deploys code in the following manner (assuming the dev env):

1. Deploy old code to 01devup
2. Move domains to 01devup
3. Deploy new code to 01dev
4. Move domains to 01dev
5. Deploy new code to 01devup

The problem here is that cloud hooks (such as config-imports) run for every code deploy step. Best-case scenario, this means that they are running three times per site, when they only really need to run once. Worst-case scenario, this can actually cause staging deployments to fail because in that case ACSF deploys to _both_ 01dev and 01devup (or 01test and 01testup) simultaneously.

This PR solves this by only running cloud hooks in the primary variant of each environment.

@lcatlett this might affect you, let me know if you have any opinions