### PR TITLE
Fixed Git fetch/merge during deploy

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -288,7 +288,8 @@ class DeployCommand extends BltTasks {
    */
   protected function mergeUpstreamChanges() {
     $git_remotes = $this->getConfigValue('git.remotes');
-    $remote_name = reset($git_remotes);
+    $remote_url = reset($git_remotes);
+    $remote_name = md5($remote_url);
 
     $this->say("Merging upstream changes into local artifact...");
     $this->taskExecStack()


### PR DESCRIPTION
I was getting this error on deploys during the merge step in BLT 8.9.0-beta1:

> merge: (branch name) - not something we can merge

The problem appears to be that the fetch and merge commands are using the repo URL rather than md5 hash.