### PR TITLE
Fix drush site install command to disable update status module.

### DIFF
--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -36,6 +36,7 @@ class DrupalCommand extends BltTasks {
       ->drush("site-install")
       ->arg($this->getConfigValue('project.profile.name'))
       ->rawArg("install_configure_form.update_status_module='array(FALSE,FALSE)'")
+      ->rawArg("install_configure_form.enable_update_status_module=NULL")
       ->option('site-name', $this->getConfigValue('project.human_name'))
       ->option('site-mail', $this->getConfigValue('drupal.account.mail'))
       ->option('account-name', $username, '=')


### PR DESCRIPTION
This is a fix that was merged into the phing task but was left of of the robo conversion. See https://github.com/acquia/blt/pull/1360

and
https://www.drupal.org/node/1826652#comment-12071700
