### PR TITLE
Run the appropriate behat tags when testing on pipelines.

### DIFF
--- a/scripts/pipelines/tests
+++ b/scripts/pipelines/tests
@@ -4,6 +4,6 @@ set -ev
 
 export PATH=${COMPOSER_BIN}:${PATH}
 
-blt tests:all -D tests.run-server=true -D behat.web-driver=phantomjs -D behat.tags='~experimental' --yes -v --ansi
+blt tests:all -D tests.run-server=true -D behat.web-driver=phantomjs --yes -v --ansi
 
 set +v


### PR DESCRIPTION
The test script currently hard codes the behat.tags to just ~experimental. This should not be the case.