### PR TITLE
BLT-1667: Provide memcache integration and sample settings template.

### DIFF
--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -4,13 +4,16 @@
     "drupal/acquia_connector": "^1.5.0",
     "drupal/cog": "^1.0.0",
     "drupal/qa_accounts": "^1.0.0-alpha1",
-    "drupal/memcache": "2.x-dev",
+    "drupal/memcache": "^2.0-alpha3",
     "drupal/seckit": "^1.0.0-alpha2",
     "drupal/security_review": "*",
     "drupal/shield": "^1.0.0"
   },
   "extra": {
     "patches": {
+        "drupal/core": {
+            "2766509 - Graceful cache fallbacks": "https://www.drupal.org/files/issues/drupal-graceful-cache-error-2766509-25.patch"
+        }
     }
   }
 }

--- a/settings/sample-memcache.settings.php
+++ b/settings/sample-memcache.settings.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Template for memcache configuration and SASL authentication for Acquia Cloud
+ */
+
+if ($is_ah_env) {
+  $settings['cache']['default'] = 'cache.backend.memcache';
+  $settings['memcache']['sasl'] = [
+  'username' => 'user',
+  'password' => 'password',
+];
+  // When using SASL, Memcached extension needs to be used
+  // because Memcache extension doesn't support it.
+  $settings['memcache']['extension'] = 'Memcached';
+  $settings['memcache']['options'] = [
+  \Memcached::OPT_BINARY_PROTOCOL => TRUE,
+];
+}


### PR DESCRIPTION
Fixes #1667 

Changes proposed:
- Update memcache suggested version to 
- Patch core to allow for graceful cache fallback
- Provide sample settings.php for configuring memcache for default cache, per-site memcached and SASL authentication
