### PR TITLE
Implementing exit_early after composer install.

### DIFF
--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -44,13 +44,13 @@ notifications:
 # - slack: '<account>:<token>#[channel]'
 
 before_install:
-  # Exit build early if only documentation was changed in a Pull Request.
-  - source ${BLT_DIR}/scripts/travis/exit_early
   # Disable xdebug.
   - phpenv config-rm xdebug.ini
   - composer self-update
   - composer validate --no-check-all --ansi
   - composer install
+  # Exit build early if only documentation was changed in a Pull Request.
+  - source ${BLT_DIR}/scripts/travis/exit_early
 
 install:
   - source ${BLT_DIR}/scripts/travis/setup_environment


### PR DESCRIPTION
I'm getting an error with this here. I think at the time this runs, the "exit_early" script doesn't exist b/c there are no composer files yet. Moving the text after composer install, probably the earliest conceivable point in time we could call this script.