### PR TITLE
Issue #1724: Fixed missing dev dependency.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -22,7 +22,8 @@
     "jarnaiz/behat-junit-formatter": "^1.3.2",
     "se/selenium-server-standalone": "^2.53",
     "jakoch/phantomjs-installer":   "2.1.1-p07",
-    "dmore/behat-chrome-extension": "^1.0.0"
+    "dmore/behat-chrome-extension": "^1.0.0",
+    "mikey179/vfsStream": "~1.2"
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
Fixes #1724

This just adds the [same dev dependency as core](http://cgit.drupalcode.org/drupal/tree/core/composer.json#n46) (but that composer doesn't inherit--it has to be present in a project's root composer requirements)