### PR TITLE
#1751 bad local alias breaks site install.

### DIFF
--- a/template/blt/project.yml
+++ b/template/blt/project.yml
@@ -24,7 +24,7 @@ drush:
     # The remote environment from which the database will be pulled.
     remote: ${project.machine_name}.test
     # The local environment against which all local drush commands are run.
-    local: self
+    local: ${project.machine_name}.local
     # The drush alias against which all ci commands are run.
     ci: self
     # The default drush alias to be used when no environment is specified.


### PR DESCRIPTION
Fixes #1751 .

Changes proposed:
-
Use variable in template project.yml for local drush alias.
-
