### PR TITLE
Making Drupal-VM config customizable. 🇺🇸

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -29,6 +29,7 @@ blt:
     example-local: ${repo.root}/blt/example.project.local.yml
     schema-version: ${repo.root}/blt/.schema_version
     multisite: ${docroot}/sites/${site}/site.yml
+    drupal-vm: ${repo.root}/box/config.yml
   command-cache-dir: ${blt.root}/cache/commands
 
 composer:

--- a/scripts/drupal-vm/Vagrantfile
+++ b/scripts/drupal-vm/Vagrantfile
@@ -4,7 +4,7 @@ ENV['DRUPALVM_PROJECT_ROOT'] = "#{__dir__}"
 
 # The relative path from the project root to the config directory where you
 # placed your config.yml file.
-ENV['DRUPALVM_CONFIG_DIR'] = "box"
+ENV['DRUPALVM_CONFIG_DIR'] = "${drupalvm.config.dir}"
 
 # The relative path from the project root to the directory where Drupal VM is located.
 ENV['DRUPALVM_DIR'] = "vendor/geerlingguy/drupal-vm"
@@ -18,4 +18,3 @@ Vagrant.configure('2') do |config|
     config.exec.commands '*', directory: "/var/www/${project.machine_name}"
   end
 end
-

--- a/scripts/drupal-vm/post-provision.sh
+++ b/scripts/drupal-vm/post-provision.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# This command is run as sudo, '~' will expand to '/root'.
-CONFIG_FILE="/vagrant/box/config.yml"
-if [ -f "$CONFIG_FILE" ]
-then
-    VAGRANT_MACHINE_NAME=$(grep vagrant_machine_name: "$CONFIG_FILE" | cut -d' ' -f 2)
-    REPO_ROOT=/var/www/${VAGRANT_MACHINE_NAME}
-    cd ${REPO_ROOT}
-else
-  echo "Could not find repo root!"
-fi
-
 # Add blt alias to front of .bashrc so that it applies to non-interactive shells.
-BLT_ALIAS_FILE="./vendor/acquia/blt/scripts/blt/alias"
+BLT_ALIAS_FILE="/vagrant/vendor/acquia/blt/scripts/blt/alias"
 if [ -f "$BLT_ALIAS_FILE" ]
 then
     grep -q -F 'function blt' /home/vagrant/.bashrc || (cat "$BLT_ALIAS_FILE" /home/vagrant/.bashrc > temp && mv temp /home/vagrant/.bashrc)

--- a/src/Drush/Command/BltDoctorCommand.php
+++ b/src/Drush/Command/BltDoctorCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Yaml\Yaml;
 use Drupal\Core\Installer\Exception\AlreadyInstalledException;
+use Acquia\Blt\Robo\Commands\Vm\VmCommand;
 
 /**
  *
@@ -709,8 +710,9 @@ class BltDoctor {
   protected function checkDrupalVm() {
     if ($this->drupalVmEnabled) {
       $passed = TRUE;
-      if (!file_exists($this->repoRoot . '/box/config.yml')) {
-        $this->logOutcome(__FUNCTION__ . ':init', "You have DrupalVM initialized, but box/config.yml is missing.", 'error');
+      $drupal_vm_config = $this->getDrupalVmConfigFile();
+      if (!file_exists($this->repoRoot . $drupal_vm_config)) {
+        $this->logOutcome(__FUNCTION__ . ':init', "You have DrupalVM initialized, but $drupal_vm_config is missing.", 'error');
 
         $passed = FALSE;
       }
@@ -770,10 +772,20 @@ class BltDoctor {
   }
 
   /**
+   * @return string
+   */
+  protected function getDrupalVmConfigFile() {
+    $drupal_vm_config = isset($this->config['blt']['config-files']['drupal-vm']) ? $this->config['blt']['config-files']['drupal-vm'] : 'box/config.yml';
+    # Is there a way to calculate this "${repo.root}"? Removing for now.
+    $drupal_vm_config = str_replace('${repo.root}', "", $drupal_vm_config);
+    return $drupal_vm_config;
+  }
+
+  /**
    * @return array|mixed
    */
   protected function setDrupalVmConfig() {
-    $this->drupalVmConfig = Yaml::parse(file_get_contents($this->repoRoot . '/box/config.yml'));
+    $this->drupalVmConfig = Yaml::parse(file_get_contents($this->repoRoot . $this->getDrupalVmConfigFile()));
 
     return $this->drupalVmConfig;
   }

--- a/src/Robo/Commands/Blt/DoctorCommand.php
+++ b/src/Robo/Commands/Blt/DoctorCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Blt\Robo\Commands\Blt;
 
 use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Commands\Vm\VmCommand;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -67,7 +68,7 @@ class DoctorCommand extends BltTasks {
    * @throws \Exception
    */
   protected function executeDoctorInsideVm() {
-    $drupal_vm_config_filepath = $this->getConfigValue('repo.root') . '/box/config.yml';
+    $drupal_vm_config_filepath = $this->getConfigValue(VmCommand::DRUPALVM_CONFIG_KEY);
     $drupal_vm_config = Yaml::parse(file_get_contents($drupal_vm_config_filepath));
     $repo_root = $drupal_vm_config['drupal_core_path'] . '/..';
     if (strstr($repo_root, '{{')) {

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -4,6 +4,7 @@ namespace Acquia\Blt\Robo\Inspector;
 
 use Acquia\Blt\Robo\Config\YamlConfigProcessor;
 use Acquia\Blt\Robo\Exceptions\BltException;
+use Acquia\Blt\Robo\Commands\Vm\VmCommand;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 use Consolidation\Config\Loader\YamlConfigLoader;
@@ -328,7 +329,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
       }
     }
 
-    $file_path = $this->getConfigValue('repo.root') . '/box/config.yml';
+    $file_path = $this->getConfigValue(VmCommand::DRUPALVM_CONFIG_KEY);
     if (!file_exists($file_path)) {
       $this->logger->error("$file_path is missing. Please re-run `blt vm`.");
       $valid = FALSE;


### PR DESCRIPTION
This PR attempts to make the installation directory (currently `box/`) configurable when the vm command runs. That will remain the default, but this command uses `askDefault()` method to request a change to the installation.

The location of the drupal-vm config file is moved into `build.yml` config and will be overridable in the local `project.yml`. In fact, if you specify an override at runtime, that new location is written to your `project.yml`

The input is stripped of the directory separators, so you can enter `/box2` or `box2/` and they will all equal `box2`. The proper files are copied into this new location, and all references to the file are updated (Vagrantfile).

I also cut down on the size of the Drupal-VM post-provision script. I'm not sure if the lines deleted in that file were doing something else I'm unaware of, or just getting the docroot to install the alias. Instead of "cd"ing into the `/var/www` path, I just specified the install-alias script from the `/vagrant/vendor` directory, and this seemed to work for me. Thoughts on this approach? That felt too simple, so maybe I'm missing something here...?

#### What could be better?
* It seems to me the block to write to the `project.yml` file is a little larger than it feels like it should be. I copied this example from the SAML command, but there might be room to make a class for updating that file to make it easier.
* Validation of user entry. I wonder what happens if you enter "../box"?
* Tests to ensure default and custom entries work, and that `vm:nuke` considers custom filepath. Anything else?

_I'm not sure how this is going to play with tests, so I'll just watch Travis. I may need help trying to figure out how to "hit enter" or enter an alternate value._