### PR TITLE
Settings files_exists check.

### DIFF
--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -75,9 +75,7 @@ class SettingsCommand extends BltTasks {
 
       // Only add the settings file if the default exists.
       if (file_exists($project_default_settings_file)) {
-        $copy_map[] = [
-          $project_default_settings_file => $project_settings_file,
-        ];
+        $copy_map[$project_default_settings_file] = $project_settings_file;
       }
 
       $task = $this->taskFilesystemStack()

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -67,12 +67,18 @@ class SettingsCommand extends BltTasks {
 
       $copy_map = [
         $default_project_default_settings_file => $project_default_settings_file,
-        $project_default_settings_file => $project_settings_file,
         $blt_local_settings_file => $default_local_settings_file,
         $default_local_settings_file => $project_local_settings_file,
         $blt_local_drush_file => $default_local_drush_file,
         $default_local_drush_file => $project_local_drush_file,
       ];
+
+      // Only add the settings file if the default exists.
+      if (file_exists($project_default_settings_file)) {
+        $copy_map[] = [
+          $project_default_settings_file => $project_settings_file,
+        ];
+      }
 
       $task = $this->taskFilesystemStack()
         ->stopOnFail()


### PR DESCRIPTION
Changes proposed:
- Adds a check for `docroot/sites/$multisite/default.settings.php` exists before it tries to copy that file to `docroot/sites/$multisite/settings.php`

Reasoning...
In my multisite, I like to keep a single copy of Drupal's `default.settings.php` file. We keep it in `docroot/sites/all/` and have it copied there via composer and drupal-scaffold (see below). I think this means we will be responsible for generating a new settings file if we set up a new multi-site, but I think that's a fair trade-off. This really just stops this function from throwing an error for me that the file does not exist.
Maybe in a perfect world, this could optionally read the `drupal-scaffold` setting, if it exists, from composer.json, and then use that value, but that felt a little too optimistic to me. Figured I'd see where this one goes first.

in `composer.json`
```
drupal-scaffold: {
  initial: {
    sites/default/default.services.yml: "sites/default/services.yml",
    sites/default/default.settings.php: "sites/default/settings.php"
  },
  excludes: [
    "web.config",
    "sites/development.services.yml"
  ]
}
```
