### PR TITLE
Add type hint to align with parent class (#1753).

### DIFF
--- a/src/Robo/Config/YamlConfigProcessor.php
+++ b/src/Robo/Config/YamlConfigProcessor.php
@@ -14,7 +14,7 @@ class YamlConfigProcessor extends ConfigProcessor {
    * @param array $config
    * @return array
    */
-  protected function preprocess($config)
+  protected function preprocess(array $config)
   {
     $config = ArrayManipulator::expandFromDotNotatedKeys(ArrayManipulator::flattenToDotNotatedKeys($config));
 


### PR DESCRIPTION
This is already fixed upstream in 8.x.

Fixes #1753.

Changes proposed:
- Adds a type hint.
