### PR TITLE
Updating settings command.

### DIFF
--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -66,7 +66,6 @@ class SettingsCommand extends BltTasks {
       $project_local_drush_file = "$multisite_dir/local.drushrc.php";
 
       $copy_map = [
-        $default_project_default_settings_file => $project_default_settings_file,
         $blt_local_settings_file => $default_local_settings_file,
         $default_local_settings_file => $project_local_settings_file,
         $blt_local_drush_file => $default_local_drush_file,
@@ -74,8 +73,12 @@ class SettingsCommand extends BltTasks {
       ];
 
       // Only add the settings file if the default exists.
-      if (file_exists($project_default_settings_file)) {
+      if (file_exists($default_project_default_settings_file)) {
+        $copy_map[$default_project_default_settings_file] = $project_default_settings_file;
         $copy_map[$project_default_settings_file] = $project_settings_file;
+      }
+      else {
+        $this->yell("No $default_project_default_settings_file file found.");
       }
 
       $task = $this->taskFilesystemStack()

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -78,7 +78,7 @@ class SettingsCommand extends BltTasks {
         $copy_map[$project_default_settings_file] = $project_settings_file;
       }
       else {
-        $this->yell("No $default_project_default_settings_file file found.");
+        $this->logger->warning("No $default_project_default_settings_file file found.");
       }
 
       $task = $this->taskFilesystemStack()


### PR DESCRIPTION
Expands changes made in #1765. 
If `docroot/sites/default/default.settings.php` does not exist, don't try to copy it to the current multisite `default.settings.php`, and also don't try to copy it to current multisite `settings.php`.