### PR TITLE
Remove duplicate simplesamlphp documentation.

### DIFF
--- a/readme/simplesamlphp-setup.md
+++ b/readme/simplesamlphp-setup.md
@@ -71,23 +71,7 @@ Request the remote IdP metadata (XML) from the customer. Note that each environm
          $protocol = 'https://';
          $port = ':' . $_SERVER['SERVER_PORT'];
        }
-       $config['baseurlpath'] = $protocol . $_SERVER['HTTP_HOST'] . $port . '/simplesaml/';
-
-      1. Optionally set the following values to prevent Varnish from interfering with SimpleSAMLphp.
- 
-                // Prevent Varnish from interfering with SimpleSAMLphp.
-                // SSL terminated at the ELB/balancer so we correctly set the SERVER_PORT.
-                // and HTTPS for SimpleSAMLphp baseurl configuration.
-                $protocol = 'http://';
-                $port = ':80';
-                if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
-                  $_SERVER['SERVER_PORT'] = 443;
-                  $_SERVER['HTTPS'] = 'true';
-                  $protocol = 'https://';
-                  $port = ':' . $_SERVER['SERVER_PORT'];
-                }
-                $config['baseurlpath'] = $protocol . $_SERVER['HTTP_HOST'] . $port . '/simplesaml/';
-	  
+       $config['baseurlpath'] = $protocol . $_SERVER['HTTP_HOST'] . $port . '/simplesaml/';	  
 
 1. Configure IdP Remote Metadata.
 


### PR DESCRIPTION
Fixes # Documentation is included twice.

Changes proposed:
- Remove duplicate docs.
