### PR TITLE
Allow non-200 connections when waiting for server for tests.

### DIFF
--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -137,7 +137,7 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
   }
 
   /**
-   * Waits until a given URL responds with a 200.
+   * Waits until a given URL responds with a non-50x response.
    *
    * This does have a maximum timeout, defined in wait().
    *
@@ -194,13 +194,13 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
   }
 
   /**
-   * Checks a URL for a 200 response.
+   * Checks a URL for a non-50x response.
    *
    * @param string $url
    *   The URL to check.
    *
    * @return bool
-   *   TRUE if URL responded with a 200.
+   *   TRUE if URL responded with a non-50x response.
    */
   public function checkUrl($url) {
     try {
@@ -210,7 +210,12 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
         'timeout' => 2,
         'exceptions' => FALSE,
       ]);
-      return $res->getStatusCode() == 200;
+      if ($res->getStatusCode() && substr($res->getStatusCode(), 0, 1) != '5') {
+        return TRUE;
+      }
+      else {
+        return FALSE;
+      }
     }
     catch (\Exception $e) {
 


### PR DESCRIPTION
Currently when running Behat tests using the built-in php server (the default test setup), BLT waits for a 200 connection before proceeding with tests.

The problem is that not all sites will return a 200 on the homepage, such as Reservoir-based installs that return a 403.

It seems that BLT should accept any connection except for one that might indicate the server is still starting (i.e. 50x).