### PR TITLE
Normalize and covert svg line endings to native on checkout

### DIFF
--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -40,6 +40,7 @@
 *.txt     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.xml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.yml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.svg     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 
 # Define binary file attributes.
 # - Do not treat them as text.

--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -35,12 +35,12 @@
 *.script  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.sh      text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
 *.sql     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.svg     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.test    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
 *.theme   text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
 *.txt     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.xml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.yml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
-*.svg     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 
 # Define binary file attributes.
 # - Do not treat them as text.


### PR DESCRIPTION
Changes proposed:
- Normalize svg line endings on checkout

There is no `.gitattributes` entry for `.svg` files, which means we're relying on what ever the value of `core.autocrlf` is on each developers machine. I propose that we add a new entry to `template/.gitattributes` to set this on a per-repository basis.

In my opinion, `.svg` files should be treated as text so that their line endings will be converted to native on checkout. This makes sense to me because `.svg` files can be edited manually, and they are not binary files. If others disagree I'm happy to hear counter arguments.
