### PR TITLE
Return to containerized Travis builds

### DIFF
--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -1,7 +1,5 @@
 # Note that the example .travis.yml file for child projects lives in /install.
-# Temporarily use legacy infrastructure until Travis resolves MySQL issues with their containerized infrastructure.
-# @see https://github.com/travis-ci/travis-ci/issues/6842
-sudo: required
+sudo: false
 language: php
 dist: trusty
 


### PR DESCRIPTION
We stopped using containerized builds because of MySQL timeout errors, but TravisCI support recently contacted me and told me that this should no longer be an issue. So maybe we roll the dice and try containerized builds again?