### PR TITLE
Allow Drupal-VM config flexibility.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -210,3 +210,4 @@ validate:
 
 vm:
   enable: false
+  config: ${repo.root}/box/config.yml

--- a/scripts/drupal-vm/Vagrantfile
+++ b/scripts/drupal-vm/Vagrantfile
@@ -4,7 +4,7 @@ ENV['DRUPALVM_PROJECT_ROOT'] = "#{__dir__}"
 
 # The relative path from the project root to the config directory where you
 # placed your config.yml file.
-ENV['DRUPALVM_CONFIG_DIR'] = "box"
+ENV['DRUPALVM_CONFIG_DIR'] = "${drupalvm.config.dir}"
 
 # The relative path from the project root to the directory where Drupal VM is located.
 ENV['DRUPALVM_DIR'] = "vendor/geerlingguy/drupal-vm"
@@ -18,4 +18,3 @@ Vagrant.configure('2') do |config|
     config.exec.commands '*', directory: "/var/www/${project.machine_name}"
   end
 end
-

--- a/scripts/drupal-vm/post-provision.sh
+++ b/scripts/drupal-vm/post-provision.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# This command is run as sudo, '~' will expand to '/root'.
-CONFIG_FILE="/vagrant/box/config.yml"
-if [ -f "$CONFIG_FILE" ]
-then
-    VAGRANT_MACHINE_NAME=$(grep vagrant_machine_name: "$CONFIG_FILE" | cut -d' ' -f 2)
-    REPO_ROOT=/var/www/${VAGRANT_MACHINE_NAME}
-    cd ${REPO_ROOT}
-else
-  echo "Could not find repo root!"
-fi
-
 # Add blt alias to front of .bashrc so that it applies to non-interactive shells.
-BLT_ALIAS_FILE="./vendor/acquia/blt/scripts/blt/alias"
+BLT_ALIAS_FILE="/vagrant/vendor/acquia/blt/scripts/blt/alias"
 if [ -f "$BLT_ALIAS_FILE" ]
 then
     grep -q -F 'function blt' /home/vagrant/.bashrc || (cat "$BLT_ALIAS_FILE" /home/vagrant/.bashrc > temp && mv temp /home/vagrant/.bashrc)

--- a/src/Drush/Command/BltDoctorCommand.php
+++ b/src/Drush/Command/BltDoctorCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Yaml\Yaml;
 use Drupal\Core\Installer\Exception\AlreadyInstalledException;
+use Acquia\Blt\Robo\Commands\Vm\VmCommand;
 
 /**
  *
@@ -709,8 +710,9 @@ class BltDoctor {
   protected function checkDrupalVm() {
     if ($this->drupalVmEnabled) {
       $passed = TRUE;
-      if (!file_exists($this->repoRoot . '/box/config.yml')) {
-        $this->logOutcome(__FUNCTION__ . ':init', "You have DrupalVM initialized, but box/config.yml is missing.", 'error');
+      $drupal_vm_config = $this->getDrupalVmConfigFile();
+      if (!file_exists($this->repoRoot . $drupal_vm_config)) {
+        $this->logOutcome(__FUNCTION__ . ':init', "You have DrupalVM initialized, but $drupal_vm_config is missing.", 'error');
 
         $passed = FALSE;
       }
@@ -770,10 +772,21 @@ class BltDoctor {
   }
 
   /**
+   * @return string
+   */
+  protected function getDrupalVmConfigFile() {
+    // This is the only non-config "box/config.yml" entry.
+    $drupal_vm_config = isset($this->config['blt']['config-files']['drupal-vm']) ? $this->config['blt']['config-files']['drupal-vm'] : 'box/config.yml';
+    // Is there a way to calculate this "${repo.root}"? Removing for now.
+    $drupal_vm_config = str_replace('${repo.root}', "", $drupal_vm_config);
+    return $drupal_vm_config;
+  }
+
+  /**
    * @return array|mixed
    */
   protected function setDrupalVmConfig() {
-    $this->drupalVmConfig = Yaml::parse(file_get_contents($this->repoRoot . '/box/config.yml'));
+    $this->drupalVmConfig = Yaml::parse(file_get_contents($this->repoRoot . $this->getDrupalVmConfigFile()));
 
     return $this->drupalVmConfig;
   }

--- a/src/Robo/Commands/Blt/DoctorCommand.php
+++ b/src/Robo/Commands/Blt/DoctorCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Blt\Robo\Commands\Blt;
 
 use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Commands\Vm\VmCommand;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -67,7 +68,7 @@ class DoctorCommand extends BltTasks {
    * @throws \Exception
    */
   protected function executeDoctorInsideVm() {
-    $drupal_vm_config_filepath = $this->getConfigValue('repo.root') . '/box/config.yml';
+    $drupal_vm_config_filepath = $this->getConfigValue(VmCommand::DRUPALVM_CONFIG_KEY);
     $drupal_vm_config = Yaml::parse(file_get_contents($drupal_vm_config_filepath));
     $repo_root = $drupal_vm_config['drupal_core_path'] . '/..';
     if (strstr($repo_root, '{{')) {

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -4,6 +4,7 @@ namespace Acquia\Blt\Robo\Inspector;
 
 use Acquia\Blt\Robo\Config\YamlConfigProcessor;
 use Acquia\Blt\Robo\Exceptions\BltException;
+use Acquia\Blt\Robo\Commands\Vm\VmCommand;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 use Consolidation\Config\Loader\YamlConfigLoader;
@@ -328,7 +329,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
       }
     }
 
-    $file_path = $this->getConfigValue('repo.root') . '/box/config.yml';
+    $file_path = $this->getConfigValue(VmCommand::DRUPALVM_CONFIG_KEY);
     if (!file_exists($file_path)) {
       $this->logger->error("$file_path is missing. Please re-run `blt vm`.");
       $valid = FALSE;


### PR DESCRIPTION
Alternate approach to 1754. If this goes in, this closes #1754.

Two main changes here...
* I used `vm.config` as my config key as opposed to `blt.config-files.drupal-vm`. This alternate key feels like a more appropriate place to me after the `vm` key was created in build.yml.
* The `vm:config` command no longer prompts the user for an installation path for Drupal-VM, per request of @grasmash in 1754. The decision to use an alternate installation path for Drupal-VM becomes slightly more manual, but the flexibility still exists to move it, which is the key for me.

_Just FYI, I created this new PR as I'm referencing 1754.patch directly in my project, and this change in approach will require me to update my project._

Similar to comments in the other PR, the one thing I'm not 100% confident in the changes to `post-provision.sh` script. I believe referencing the alias script directly at `/vagrant/vendor/.../alias` works as intended, I'm just not sure if there was reason this didn't work originally (maybe other OS or something?).
