### PR TITLE
Preventing Probo builds from failing due to incorrect path.

### DIFF
--- a/scripts/probo/.probo.yml
+++ b/scripts/probo/.probo.yml
@@ -5,7 +5,7 @@ steps:
     plugin: Script
     script:
      - cd $SRC_DIR
-     - "PHP_VERSION='5.6' $SRC_DIR/vendor/acquia/blt/scripts/probo/setup_environment"
+     - "PHP_VERSION='5.6' scripts/probo/setup_environment"
      - composer self-update
      - composer validate --no-check-all --ansi
      - composer install


### PR DESCRIPTION
Fixes #1824 .

Changes proposed:
- Adjust the path to the Probo `setup_environment.sh` script in the default `.probo.yaml` file.
