### PR TITLE
Add additional option support for phpunit.

### DIFF
--- a/readme/testing.md
+++ b/readme/testing.md
@@ -160,10 +160,28 @@ Project level, functional PHPUnit tests are included in `tests/phpunit`. Any PHP
 
 You can customize the `tests:phpunit` command by [customize the configuration values](extending-blt.md#modifying-blt-configuration) for the `phpunit` key.
 
-Each row under the `phpunit` key should contain a `path` and a `config` key. The `path` key indicates a directory containing PHPUnit tests. The optional `config` key can be used to specify a PHP configuration file.
+Each row under the `phpunit` key should contain a combination of the following properties:
 
  * config: path to either the Core phpunit configuration file (docroot/core/phpunit.xml.dist) or a custom one. If left blank, no configuration will be loaded with the unit test.
  * path: the path to the custom phpunit test
+ * group: run tests only tagged with a specific `@group`
+ * exclude: run tests excluding any tagged with this `@group`
+ * filter: allows text filter for tests see [documentation](https://phpunit.de/manual/current/en/textui.htm) for more
+
+```yml
+phpunit:
+  -
+    config: ${docroot}/core/phpunit.xml.dist
+    group: 'example'
+  -
+    config: ${docroot}/core/phpunit.xml.dist
+    exclude: 'mylongtest'
+    group: 'example'
+  -
+    config: ${docroot}/core/phpunit.xml.dist
+    path: ${docroot}/modules/custom/example
+```
+
 
 ## Frontend Testing
 

--- a/src/Robo/Commands/Tests/PhpUnitCommand.php
+++ b/src/Robo/Commands/Tests/PhpUnitCommand.php
@@ -56,14 +56,27 @@ class PhpUnitCommand extends BltTasks {
         ->arg('.')
         ->printOutput(TRUE)
         ->printMetadata(FALSE);
+
       if (isset($test['path'])) {
         $task->dir($test['path']);
       }
-      if (isset($test['config'])) {
-        $task->option('--configuration', $test['config']);
+
+      $supported_options = [
+        'config' => 'configuration',
+        'group' => 'group',
+        'exclude-group' => 'exclude-group',
+        'filter' => 'filter',
+      ];
+
+      foreach ($supported_options as $yml_key => $option) {
+        if (isset($test[$yml_key])) {
+          $task->option("--$option", $test[$yml_key]);
+        }
       }
+
       $result = $task->run();
       $exit_code = $result->getExitCode();
+
       if ($exit_code) {
         throw new BltException("PHPUnit tests failed.");
       }


### PR DESCRIPTION
Update the support options list for the PHPUnit command so that custom modules for a site build can leverage the core provided `@ group` definition. When following automated testing guides from Drupal.org it suggests that modules should be tagged with groups so it makes sense that BLT supports this.

Fixes #1827

Changes proposed:
- Updates PhpUnitCommand to accept `group` option
- Updates PhpUnitCommand to accept `exclude-group` option
- Updates PhpUnitCommand to accept `filter` option

