### PR TITLE
Prevent doctrine/inflector from advancing to 1.2.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "composer/installers":              "^1.2.0",
         "composer-plugin-api":              "^1.0.0",
         "doctrine/common":                  "^2.5",
+        "doctrine/inflector":               "~1.1.0",
         "oomphinc/composer-installers-extender": "^1.1",
         "dflydev/dot-access-data":          "^1.1.0",
         "drupal/coder":                     "^8.2.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "990d5664c4dbe263da779428b6317cb5",
+    "content-hash": "87dbdc4827d1320e4e9110facd47d403",
     "packages": [
         {
             "name": "asm89/twig-lint",


### PR DESCRIPTION
Changes proposed:
- Fix doctrine/inflector on 1.1.x, as 1.2.x requires PHP7

As of 1.2.0 (https://github.com/doctrine/inflector/commits/v1.2.0) doctrine/inflector requires 7.0, rather than 5.6|7.0. 

As Acquia has not yet rolled PHP7 out to production environments yet, we probably want to hold ourselves back.

See similar issue in for Laravel: https://github.com/laravel/framework/issues/20214