### PR TITLE
Use trailing slash for sync:files.

### DIFF
--- a/src/Robo/Commands/Sync/FilesCommand.php
+++ b/src/Robo/Commands/Sync/FilesCommand.php
@@ -25,8 +25,8 @@ class FilesCommand extends BltTasks {
       ->assume('')
       ->uri('')
       ->drush('rsync')
-      ->arg($remote_alias . ':%files')
-      ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files")
+      ->arg($remote_alias . ':%files/')
+      ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files/")
       ->option('exclude-paths', 'styles:css:js');
 
     $result = $task->run();

--- a/src/Robo/Commands/Sync/FilesCommand.php
+++ b/src/Robo/Commands/Sync/FilesCommand.php
@@ -26,7 +26,7 @@ class FilesCommand extends BltTasks {
       ->uri('')
       ->drush('rsync')
       ->arg($remote_alias . ':%files/')
-      ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files/")
+      ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files")
       ->option('exclude-paths', 'styles:css:js');
 
     $result = $task->run();


### PR DESCRIPTION
Changes proposed:
- Use trailing slash for the `sync:files` command

Without the trailing slash, files are synced to a subdirectory of `sites/$site_dir/files` E.g. `sites/default/files/files` instead of `sites/default/files`.

See the [phing version](https://github.com/acquia/blt/blob/8.8.7/phing/tasks/local-sync.xml#L89)  of this task.
