### PR TITLE
Fixes #1845: provide trailing slash for files path.

### DIFF
--- a/src/Robo/Commands/Sync/FilesCommand.php
+++ b/src/Robo/Commands/Sync/FilesCommand.php
@@ -25,7 +25,7 @@ class FilesCommand extends BltTasks {
       ->assume('')
       ->uri('')
       ->drush('rsync')
-      ->arg($remote_alias . ':%files')
+      ->arg($remote_alias . ':%files/')
       ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files")
       ->option('exclude-paths', 'styles:css:js');
 


### PR DESCRIPTION
Fixes #1845.

Changes proposed:
- provide trailing slash to fix #1845.
