### PR TITLE
Adds default memcache prefix for simplesaml.

### DIFF
--- a/scripts/simplesamlphp/acquia_config.php
+++ b/scripts/simplesamlphp/acquia_config.php
@@ -53,6 +53,7 @@ function acquia_logging_config($config) {
 function mc_session_store($config) {
   $config['store.type'] = 'memcache';
   $config['memcache_store.servers'] = mc_info();
+  $config['memcache_store.prefix'] = $ah_options['database_name'];
   return $config;
 }
 function mc_info() {


### PR DESCRIPTION
Default config dies in test/prod because no prefix is set. I've tied the memcache prefix to the database name specified at the top of the file to work both locally and with multisite installations. This 'non-bug' was reported upstream already. https://github.com/simplesamlphp/simplesamlphp/issues/496.