### PR TITLE
BLT-1852 assuming -y when prompting while executing something in blt

### DIFF
--- a/src/Robo/Commands/Sync/DbCommand.php
+++ b/src/Robo/Commands/Sync/DbCommand.php
@@ -67,7 +67,8 @@ class DbCommand extends BltTasks {
       ->arg($remote_alias)
       ->arg($local_alias)
       ->option('structure-tables-key', 'lightweight')
-      ->option('create-db');
+      ->option('create-db')
+      ->assume(TRUE);
 
     if ($this->getConfigValue('drush.sanitize')) {
       $task->option('sanitize');


### PR DESCRIPTION
Fixes #1852 .

Changes proposed:
- assuming -y when prompting while executing something in blt
