### PR TITLE
BLT-1523: allowing behat php files to be sniffed by phpcs.

### DIFF
--- a/template/phpcs.xml.dist
+++ b/template/phpcs.xml.dist
@@ -24,6 +24,5 @@
 
   <exclude-pattern>*/vendor</exclude-pattern>
   <exclude-pattern>*/node_modules</exclude-pattern>
-  <exclude-pattern>*/behat</exclude-pattern>
 
 </ruleset>


### PR DESCRIPTION
Fixes #1523.

Changes proposed:
- have behat php files sniffed by default
-
