### PR TITLE
Updated plugin to scaffold composer include files.

### DIFF
--- a/blt-project/composer.json
+++ b/blt-project/composer.json
@@ -39,8 +39,8 @@
         },
         "merge-plugin": {
             "require": [
-                "vendor/acquia/blt/composer.required.json",
-                "vendor/acquia/blt/composer.suggested.json"
+                "blt/composer.required.json",
+                "blt/composer.suggested.json"
             ],
             "include": [
                 "blt/composer.overrides.json"

--- a/composer.required.json
+++ b/composer.required.json
@@ -32,7 +32,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Acquia\\Blt\\Custom\\": "../../../blt/src/"
+      "Acquia\\Blt\\Custom\\": "src/"
     }
   },
   "extra": {

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -8,6 +8,10 @@ box/local.config.yml
 *.local
 project.local.yml
 
+# Ignore composer includes.
+blt/composer.required.json
+blt/composer.suggested.json
+
 # Ignore drupal core.
 docroot/core
 

--- a/template/composer.json
+++ b/template/composer.json
@@ -24,8 +24,8 @@
         },
         "merge-plugin": {
             "require": [
-                "vendor/acquia/blt/composer.required.json",
-                "vendor/acquia/blt/composer.suggested.json"
+                "blt/composer.required.json",
+                "blt/composer.suggested.json"
             ],
             "include": [
                 "blt/composer.overrides.json"


### PR DESCRIPTION
Here's an initial PR for #1849

Changes proposed:
- Pre scaffolds additional composer files before merge plugin events.

This should help fix composer idempotency as all requirements defined in the root `composer.json` are available to the project.

