### PR TITLE
BLT-1886: Fix rsync file directory.

### DIFF
--- a/src/Robo/Commands/Sync/FilesCommand.php
+++ b/src/Robo/Commands/Sync/FilesCommand.php
@@ -26,7 +26,7 @@ class FilesCommand extends BltTasks {
       ->uri('')
       ->drush('rsync')
       ->arg($remote_alias . ':%files/')
-      ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files")
+      ->arg($this->getConfigValue('docroot') . "/sites/$site_dir")
       ->option('exclude-paths', implode(':', $this->getConfigValue('sync.exclude-paths')));
 
     $result = $task->run();


### PR DESCRIPTION
Fixes #1886 .

Changes proposed:
- Change rsync file directory from `/sites/$site_dir/files` to `/sites/$site_dir`.
