### PR TITLE
BLT-1888: defining platform as PHP 5.6 by default.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -50,6 +50,11 @@
       }
     }
   },
+  "config": {
+    "platform": {
+      "php": "5.6"
+    }
+  },
   "scripts": {
     "blt-alias": "blt install-alias -y --ansi",
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",


### PR DESCRIPTION
Fixes #1888 .

Changes proposed:
- defines platform as php 5.6 by default
-
