### PR TITLE
Fixed pass-by-reference error.

### DIFF
--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -41,7 +41,8 @@ class VmCommand extends BltTasks {
     $this->projectDrupalVmConfigFile = $this->getConfigValue('vm.config');
     $this->vmDir = dirname($this->projectDrupalVmConfigFile);
     $this->vmConfigDir = str_replace($this->getConfigValue('repo.root') . DIRECTORY_SEPARATOR, '', $this->vmDir);
-    $this->vmConfigFile = array_pop((explode(DIRECTORY_SEPARATOR, $this->projectDrupalVmConfigFile)));
+    $path_parts = explode(DIRECTORY_SEPARATOR, $this->projectDrupalVmConfigFile);
+    $this->vmConfigFile = array_pop($path_parts);
   }
 
   /**


### PR DESCRIPTION
On 8.9.1, running `blt vm` produces this error:

> PHP Fatal error:  Uncaught Error: Cannot pass parameter 1 by reference in vendor/acquia/blt/src/Robo/Commands/Vm/VmCommand.php:44