### PR TITLE
Fix BLT version constant.

### DIFF
--- a/src/Robo/Blt.php
+++ b/src/Robo/Blt.php
@@ -37,7 +37,7 @@ class Blt implements ContainerAwareInterface, LoggerAwareInterface {
   /**
    * The BLT version.
    */
-  const VERSION = '8.9.0';
+  const VERSION = '8.9.1';
 
   /**
    * The Robo task runner.


### PR DESCRIPTION
On BLT 8.9.1, when I run `blt --version`, it returns `8.9.0`.

Related: when I run `blt doctor`, it returns the correct version. These commands should probably get their info from the same place, ideally in a way that doesn't require manual updating constants with every release.