### PR TITLE
Fixed BLT doctor VM errors.

### DIFF
--- a/src/Drush/Command/BltDoctorCommand.php
+++ b/src/Drush/Command/BltDoctorCommand.php
@@ -796,7 +796,7 @@ class BltDoctor {
    * @return array|mixed
    */
   protected function setDrupalVmConfig() {
-    $this->drupalVmConfig = Yaml::parse(file_get_contents($this->repoRoot . $this->getDrupalVmConfigFile()));
+    $this->drupalVmConfig = Yaml::parse(file_get_contents($this->repoRoot . '/' . $this->getDrupalVmConfigFile()));
 
     return $this->drupalVmConfig;
   }


### PR DESCRIPTION
On 8.9.1, running `blt doctor` with a VM produces spurious errors for checkDrupalVm, because the path to the vm config file is not being built correctly.

> file_get_contents(docroot/..box/config.yml): failed to open stream: No such file or directory BltDoctorCommand.php:800

> checkDrupalVm:uri | uri for @foo.local drush alias does not match vagrant_hostname for DrupalVM.  uri is set to http://local.foo.com for @foo.local vagrant_hostname is set to  for DrupalVM.  http://local.foo.com != 