### PR TITLE
Fix blt sync:files command so it runs outside VM

### DIFF
--- a/src/Robo/Commands/Sync/FilesCommand.php
+++ b/src/Robo/Commands/Sync/FilesCommand.php
@@ -13,7 +13,6 @@ class FilesCommand extends BltTasks {
    * Copies remote files to local machine.
    *
    * @command sync:files
-   * @executeInDrupalVm
    */
   public function syncFiles() {
     $local_alias = '@' . $this->getConfigValue('drush.aliases.local');


### PR DESCRIPTION
Additional fix for issue #1875

Changes proposed:
- Make blt sync:files run outside the VM
