### PR TITLE
Travis should only exit early for docs on PRs.

### DIFF
--- a/scripts/travis/exit_early
+++ b/scripts/travis/exit_early
@@ -2,6 +2,9 @@
 
 if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)'
 then
-  echo "Only docs were updated, stopping build process."
-  exit
+  if [ "$TRAVIS_PULL_REQUEST" != "false" ]
+  then
+    echo "Only docs were updated, stopping build process."
+    exit
+  fi
 fi


### PR DESCRIPTION
On 8.9.1, when we create a new release tag on Github, Travis does not build and deploy this release to ACE because of the exit_early script.

The script should only exit early on PRs. All code merges and tags (even if they are just doc changes) should be deployed.