### PR TITLE
Improve support for multisites in DrupalVM.

### DIFF
--- a/config/example.multisite.yml
+++ b/config/example.multisite.yml
@@ -17,14 +17,12 @@ tests:
     port: 8888
     url: http://127.0.0.1:${tests.server.port}
 
-multisite:
-  # This should correspond the directory name in docroot/sites. E.g.,
-  # docroot/sites/example-multisite.com.
-  name: example-multisite.com
-
 project:
   profile:
     name: example_multisite_profile
-  # The acquia cloud alias for the site group. This will be used to execute
-  # against *.dev and *.test aliases for upstream db syncs.
-  cloud_alias: @example-multisite
+
+# Drush aliases to be used for syncs and setups.
+drush:
+  aliases:
+    local: mysite.local
+    remote: mysite.test

--- a/readme/acsf-setup.md
+++ b/readme/acsf-setup.md
@@ -20,4 +20,4 @@ To configure a project to run on ACSF, perform the following steps after initial
 1. Use ACSF's "update code" feature to push the artifact out to sites.
 1. When creating a new site, select your custom profile as the profile.
 
-**Note:** The above process will not work for updating existing ACSF sites using lightning.
+To set up a local development environment for your ACSF project, follow the steps in the [multisite readme](multisite.md).

--- a/readme/multisite.md
+++ b/readme/multisite.md
@@ -19,12 +19,11 @@ Start by following the [Acquia Cloud multisite instructions](https://docs.acquia
 
 ## BLT setup
 
-You have the option to define your multisites in `blt/project.yml` by creating a `multisite.name` variable. This allows BLT to run setup and deployment tasks for each site in the codebase. If you don't manually define this variable, BLT will automatically set it based on discovered multisite directories.
+You have the option to define your multisites in `blt/project.yml` by creating a `multisites` array. This allows BLT to run setup and deployment tasks for each site in the codebase. If you don't manually define this variable, BLT will automatically set it based on discovered multisite directories.
 
-    multisite:
-      name:
-        - default
-        - example.com
+    multisites:
+      - default
+      - example.com
 
 Ensure that your new project has `$settings['install_profile']` set, or Drupal core will attempt (unsuccessfully) to write it to disk!
 
@@ -39,7 +38,7 @@ It's recommended to copy the aliases file provided by Acquia Cloud or Club to cr
 
 ## Multisite tasks
 
-You may override BLT variables on a per-site basis by creating a `site.yml` file in `docroot/sites/[site-name]/`. You may then run BLT with the `multisite.name` variable set at the command line to load the site's properties.
+You may override BLT variables on a per-site basis by creating a `site.yml` file in `docroot/sites/[site-name]/`. You may then run BLT with the `site` variable set at the command line to load the site's properties.
 
 For instance, if the `drush` aliases for your site in `docroot/sites/mysite` were `@mysite.local` and `@mysite.test`, you could define these in `docroot/sites/mysite/site.yml` as:
 
@@ -50,10 +49,10 @@ drush:
     remote: mysite.test
 ```
 
-Then, to refresh your local site, you could run: `blt sync:refresh -Dmultisite.name=mysite`.
+Then, to refresh your local site, you could run: `blt sync:refresh -D site=mysite`.
 
 ## DrupalVM
 
-BLT by default only runs a single site at a time inside of DrupalVM. You can change which site is running locally at any given time using the `multisite` parameter described above.
+BLT by default only runs a single site at a time inside of DrupalVM. You can change which site is running locally at any given time using the `site` parameter described above.
 
 To run multiple sites simultaneously (on a single docroot) inside of DrupalVM, you should modify the `box/config.yml` file to add an additional virtual host and database for each site. Make sure to reprovision the VM afterwards (`vagrant provision`).

--- a/readme/multisite.md
+++ b/readme/multisite.md
@@ -36,7 +36,6 @@ The default Drush site aliases provided by [Acquia Cloud](https://docs.acquia.co
 
 It's recommended to copy the aliases file provided by Acquia Cloud or Club to create a separate aliases file for each site. Simply modify the `uri` and `parent` keys for the aliases within each file to match the correct database / site.
 
-TODO: Add instructions for integration with BLT development workflows and DrupalVM.
 
 ## Multisite tasks
 
@@ -52,3 +51,9 @@ drush:
 ```
 
 Then, to refresh your local site, you could run: `blt sync:refresh -Dmultisite.name=mysite`.
+
+## DrupalVM
+
+BLT by default only runs a single site at a time inside of DrupalVM. You can change which site is running locally at any given time using the `multisite` parameter described above.
+
+To run multiple sites simultaneously (on a single docroot) inside of DrupalVM, you should modify the `box/config.yml` file to add an additional virtual host and database for each site. Make sure to reprovision the VM afterwards (`vagrant provision`).

--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -28,9 +28,31 @@ drupal_composer_install_dir: "/var/www/${project.machine_name}"
 drupal_core_path: "/var/www/${project.machine_name}/docroot"
 ssh_home: /var/www/${project.machine_name}
 
-drupal_db_user: drupal
-drupal_db_password: drupal
-drupal_db_name: drupal
+# Multisite installations should configure additional domains here.
+apache_vhosts:
+  # Drupal VM's default domain, evaluating to whatever `vagrant_hostname` is set to (drupalvm.dev by default).
+  - servername: "{{ drupal_domain }}"
+    serveralias: "www.{{ drupal_domain }}"
+    documentroot: "{{ drupal_core_path }}"
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
+#  - servername: "local.second-drupal-site.com"
+#    documentroot: "{{ drupal_core_path }}"
+#    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
+
+# Multisite installations should configure additional databases here.
+mysql_databases:
+  - name: drupal
+    encoding: utf8
+    collation: utf8_general_ci
+#  - name: drupal_two
+#    encoding: utf8
+#    collation: utf8_general_ci
+
+mysql_users:
+  - name: drupal
+    host: "%"
+    password: drupal
+    priv: "drupal.*:ALL"
 
 # Set this to 'false' if you don't need to install drupal (using the drupal_*
 # settings below), but instead copy down a database (e.g. using drush sql-sync).


### PR DESCRIPTION
This is the first of many PRs to support #1816

This just changes the default DrupalVM config file to be in a format that's more easily extensible for multisite projects, and adds related documentation.

This should have no effect on existing single-site installs, and doesn't require projects to nuke and rebuild their vm (unless they want to take advantage of local multisites, in which case they can just reprovision).