### PR TITLE
Sync db and files to ODEs automatically.

### DIFF
--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -13,7 +13,7 @@ deploy_updates() {
       ;;
     01devup|01testup|01update)
       ;;
-    ode[1-10])
+    ode[1-9])
       deploy_sync
       ;;
     *)

--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -13,6 +13,9 @@ deploy_updates() {
       ;;
     01devup|01testup|01update)
       ;;
+    ode[1-10])
+      deploy_sync
+      ;;
     *)
       ace_deploy
       ;;
@@ -65,6 +68,24 @@ ace_deploy() {
   fi
 
   echo "Finished updates for environment: $target_env"
+}
+
+deploy_sync() {
+
+  echo "Running sync refresh for environment: $target_env"
+
+  # Prep for BLT commands.
+  repo_root="/var/www/html/$site.$target_env"
+  export PATH=$repo_root/vendor/bin:$PATH
+  cd $repo_root
+
+  blt deploy:sync:refresh --define environment=$target_env -v -y
+  if [ $? -ne 0 ]; then
+      echo "Sync errored."
+      exit 1
+  fi
+
+  echo "Finished sync for environment: $target_env"
 }
 
 deploy_install() {

--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -14,7 +14,7 @@ deploy_updates() {
     01devup|01testup|01update)
       ;;
     ode[1-9])
-      deploy_sync
+      deploy_install
       ;;
     *)
       ace_deploy

--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -32,3 +32,16 @@ events:
             type: script
             script:
               - source ${BLT_DIR}/scripts/pipelines/build_artifact
+        - deploy:
+            script:
+              - pipelines-deploy
+  pr-merged:
+    steps:
+      - deploy:
+          script:
+            - pipelines-deploy
+  pre-closed:
+    steps:
+      - deploy:
+          script:
+            - pipelines-deploy

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -586,6 +586,7 @@ class DeployCommand extends BltTasks {
         $this->config->set('drush.uri', $multisite);
       }
 
+      $this->invokeCommand('sync:refresh');
       $this->invokeCommand('setup:config-import');
       $this->invokeCommand('setup:toggle-modules');
 

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -569,6 +569,31 @@ class DeployCommand extends BltTasks {
   }
 
   /**
+   * Syncs database and files and runs updates.
+   *
+   * @command deploy:sync:refresh
+   */
+  public function syncRefresh() {
+    // Disable alias since we are targeting specific uri.
+    $this->config->set('drush.alias', '');
+
+    // Sync files.
+    $this->config->set('sync.files', TRUE);
+
+    foreach ($this->getConfigValue('multisites') as $multisite) {
+      $this->say("Syncing $multisite...");
+      if (!$this->config->get('drush.uri')) {
+        $this->config->set('drush.uri', $multisite);
+      }
+
+      $this->invokeCommand('setup:config-import');
+      $this->invokeCommand('setup:toggle-modules');
+
+      $this->say("Finished syncing $multisite.");
+    }
+  }
+
+  /**
    * Installs Drupal, imports config, and executes updates.
    *
    * @command deploy:drupal:install

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -586,7 +586,8 @@ class DeployCommand extends BltTasks {
         $this->config->set('drush.uri', $multisite);
       }
 
-      $this->invokeCommand('sync');
+      $this->invokeCommand('sync:db');
+      $this->invokeCommand('sync:files');
       $this->invokeCommand('setup:config-import');
       $this->invokeCommand('setup:toggle-modules');
 

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -586,7 +586,7 @@ class DeployCommand extends BltTasks {
         $this->config->set('drush.uri', $multisite);
       }
 
-      $this->invokeCommand('sync:refresh');
+      $this->invokeCommand('sync');
       $this->invokeCommand('setup:config-import');
       $this->invokeCommand('setup:toggle-modules');
 

--- a/src/Robo/Commands/Sync/DbCommand.php
+++ b/src/Robo/Commands/Sync/DbCommand.php
@@ -52,7 +52,6 @@ class DbCommand extends BltTasks {
    * @command sync:db
    */
   public function syncDbDefault() {
-    $this->invokeCommand('setup:settings');
 
     $local_alias = '@' . $this->getConfigValue('drush.aliases.local');
     $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -19,6 +19,7 @@ class SyncCommand extends BltTasks {
   ]) {
 
     $commands = [
+      'setup:settings',
       'sync:db',
     ];
 


### PR DESCRIPTION
Currently, BLT doesn't do anything to enable CD on-demand environment (commonly "ODE") integration.

You can add these lines to your acquia-pipelines.yml:

            - deploy:
            script:
              - pipelines-deploy

... but you'll just get an empty environment (code but no db or files).

I think most projects would want to populate new ODEs with a database and files (based on `drush.aliases.remote`) and run updates.

@grasmash should I also add those deploy lines to BLT's default acquia-pipelines.yml, so that users of BLT + CD/Pipelines get ODEs for new PRs out of the box?