### PR TITLE
Fixed failing npm installs in Pipelines.

### DIFF
--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -16,6 +16,8 @@ events:
               - composer validate --no-check-all --ansi
               - composer install --ansi
               - source ${BLT_DIR}/scripts/pipelines/setup_env
+              - nvm install v8.1.4
+              - npm install -g npm
         - validate:
             type: script
             script:


### PR DESCRIPTION
If you run `npm install` on a vanilla BLT + Cog install in Pipelines, it will fail about 80% of the time. The problem seems to be that older versions of npm are less memory/cpu efficient and exhaust some sort of container resource, causing the process to be killed.

Upgrading to a later version of npm seems to be an adequate workaround.