### PR TITLE
Support pulling JavaScript libraries from Asset Packagist

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -349,4 +349,43 @@ class Updates {
     unset($project_yml['phpcs']['filesets']['files.php.tests']);
     $this->updater->writeProjectYml($project_yml);
   }
+
+  /**
+   * 8.9.3.
+   *
+   * @Update(
+   *    version = "8009003",
+   *    description = "Adding support for Asset Packagist."
+   * )
+   */
+  public function update_8009003() {
+    $composer_json = $this->updater->getComposerJson();
+
+    // Add the Asset Packagist repository if it does not already exist.
+    if (isset($composer_json['repositories'])) {
+      $repository_key = NULL;
+      foreach ($composer_json['repositories'] as $key => $repository) {
+        if ($repository['type'] == 'composer' && strpos($repository['url'], 'https://asset-packagist.org') === 0) {
+          $repository_key = $key;
+          break;
+        }
+      }
+      if (is_null($repository_key)) {
+        $composer_json['repositories']['asset-packagist'] = [
+          'type' => 'composer',
+          'url' => 'https://asset-packagist.org',
+        ];
+      }
+    }
+
+    unset($composer_json['require']['composer/installers']);
+    $composer_json['require']['oomphinc/composer-installers-extender'] = '^1.1';
+
+    $composer_json['extra']['installer-types'][] = 'bower-asset';
+    $composer_json['extra']['installer-types'][] = 'npm-asset';
+    $composer_json['extra']['installer-paths']['docroot/libraries/{$name}'][] = 'type:bower-asset';
+    $composer_json['extra']['installer-paths']['docroot/libraries/{$name}'][] = 'type:npm-asset';
+
+    $this->updater->writeComposerJson($composer_json);
+  }
 }

--- a/template/composer.json
+++ b/template/composer.json
@@ -5,12 +5,17 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        "asset-packagist": {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
         }
     },
     "require": {},
     "require-dev": {},
     "extra": {
         "enable-patching": true,
+        "installer-types": ["bower-asset", "npm-asset"],
         "installer-paths": {
             "docroot/core": ["type:drupal-core"],
             "docroot/modules/contrib/{$name}": ["type:drupal-module"],
@@ -19,7 +24,7 @@
             "docroot/profiles/custom/{$name}": ["type:drupal-custom-profile"],
             "docroot/themes/contrib/{$name}": ["type:drupal-theme"],
             "docroot/themes/custom/{$name}": ["type:drupal-custom-theme"],
-            "docroot/libraries/{$name}": ["type:drupal-library"],
+            "docroot/libraries/{$name}": ["type:drupal-library", "type:bower-asset", "type:npm-asset"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
         },
         "merge-plugin": {


### PR DESCRIPTION
Asset Packagist is going to be adopted by Lightning soon as the main way to pull in libraries from Bower and NPM by way of Composer. Since supporting this requires adding a few things to any composer.json which consumes Lightning as a dependency, this PR is needed for DF -- it adds Asset Packagist as a Composer package repository and configures any Bower or NPM libraries to be dropped into docroot/libraries.

Also see acquia/lightning-project#41, acquia/lightning#430, and acquia/df#58.