### PR TITLE
Sort composer dependencies by default

### DIFF
--- a/template/composer.json
+++ b/template/composer.json
@@ -7,6 +7,9 @@
             "url": "https://packages.drupal.org/8"
         }
     },
+    "config": {
+        "sort-packages": true
+    },
     "require": {},
     "require-dev": {},
     "extra": {


### PR DESCRIPTION
Currently, if you run `composer require drupal/my_module` on a BLT-generated project, the module just gets added to the last line of the require array in composer.json. This is annoying because it makes it more difficult to scan for modules in `composer.json` and generally keep it organized, and it's also more likely to cause merge conflicts, compared to if the require array were sorted alphabetically.

Fortunately, just adding this config option will cause composer require to inject dependencies alphabetically.