### PR TITLE
Check if server['USER'] is defined.

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -368,7 +368,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    *   TRUE if current PHP process is being executed inside of VM.
    */
   public function isVmCli() {
-    return $_SERVER['USER'] == 'vagrant';
+    return (isset($_SERVER['USER']) && $_SERVER['USER'] == 'vagrant');
   }
 
   /**


### PR DESCRIPTION
Fixes Undefined index error when running BLT inside a docker container where `$_SERVER['USER']` is not set.

```
PHP Notice:  Undefined index: USER in /src/vendor/acquia/blt/src/Robo/Inspector/Inspector.php on line 371
```
