### PR TITLE
Allow config override for sync:refresh.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -141,6 +141,11 @@ sync:
     - styles
     - css
     - js
+  commands:
+    - setup:composer:install
+    - sync
+    - setup:update
+    - frontend
 
 # Custom tasks that are triggered at pre-defined times in the build process.
 # The tasks hook into BLT's existing commands.

--- a/src/Robo/Commands/Sync/RefreshCommand.php
+++ b/src/Robo/Commands/Sync/RefreshCommand.php
@@ -56,12 +56,7 @@ class RefreshCommand extends BltTasks {
    * @command sync:refresh
    */
   public function refreshDefault() {
-    $this->invokeCommands([
-      'setup:composer:install',
-      'sync',
-      'setup:update',
-      'frontend',
-    ]);
+    $this->invokeCommands($this->getConfigValue('sync.commands'));
   }
 
 }

--- a/src/Robo/Commands/Sync/RefreshCommand.php
+++ b/src/Robo/Commands/Sync/RefreshCommand.php
@@ -54,6 +54,8 @@ class RefreshCommand extends BltTasks {
    * local db, re-imports config, and executes db updates.
    *
    * @command sync:refresh
+   *
+   * @aliases sync
    */
   public function refreshDefault() {
     $this->invokeCommands($this->getConfigValue('sync.commands'));


### PR DESCRIPTION
Changes proposed:

Allow you to override the specific steps of `sync:refresh`.

Would be nice to be able to do this for any command which calls subcommands.