### PR TITLE
Fixed setup for high-number ODEs.

### DIFF
--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -13,7 +13,7 @@ deploy_updates() {
       ;;
     01devup|01testup|01update)
       ;;
-    ode[1-9])
+    ode[[:digit:]]*)
       deploy_install
       ;;
     *)


### PR DESCRIPTION
If you have more than 10 ODEs, they stop getting installed automatically because the pattern matching in our cloud scripts only supports ode1-ode9