### PR TITLE
Adds template for allowing warnings/errors to succeed.

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,6 +2,10 @@
 <ruleset name="blt">
   <description>BLT PHP_CodeSniffer standards.</description>
 
+  <!-- By default, warnings and errors cause an exception. -->
+  <config name="ignore_warnings_on_exit" value="0" />
+  <config name="ignore_errors_on_exit" value="0" />
+
   <!-- Set ignore extensions. -->
   <!-- @see https://www.drupal.org/node/2867601#comment-12075633 -->
   <arg name="ignore" value="*.css,*.md,*.txt"/>


### PR DESCRIPTION
Hi

The syntax and  config variable which is documented in #1889 is a bit hard to dig up, if you don't know the exact wording. Having them in the template stops me from having to search for them.

Changes proposed:
- Provide (redundant) default configuration values for warnings and errors on exit