### PR TITLE
Composer.json suggested changes.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -48,7 +48,11 @@
       }
     },
     "enable-patching": true,
-    "patches": {}
+    "patches": {
+      "drupal/core": {
+        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-90.patch"
+      }
+    }
   },
   "scripts": {
     "blt-alias": "blt install-alias -y --ansi",

--- a/composer.required.json
+++ b/composer.required.json
@@ -8,8 +8,7 @@
   "require": {
     "drupal/core": "^8.0",
     "drupal/features": "^3.0.0",
-    "drupal/config_split": "^1.0.0-beta4",
-    "drupal/devel": "^1.0.0-alpha1"
+    "drupal/config_split": "^1.0.0"
   },
   "require-dev": {
     "cweagans/composer-patches": "^1.6.0",
@@ -49,11 +48,7 @@
       }
     },
     "enable-patching": true,
-    "patches": {
-      "drupal/core": {
-        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-90.patch"
-      }
-    }
+    "patches": {}
   },
   "scripts": {
     "blt-alias": "blt install-alias -y --ansi",

--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -3,6 +3,7 @@
     "acquia/lightning": "^2.1.4",
     "drupal/acquia_connector": "^1.5.0",
     "drupal/cog": "^1.0.0",
+    "drupal/devel": "^1.0.0",
     "drupal/qa_accounts": "^1.0.0-alpha1",
     "drupal/memcache": "^2.0-alpha3",
     "drupal/seckit": "^1.0.0-alpha2",
@@ -11,6 +12,9 @@
   },
   "extra": {
     "patches": {
+      "drupal/core": {
+        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-90.patch"
+      }
     }
   }
 }

--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -12,9 +12,6 @@
   },
   "extra": {
     "patches": {
-      "drupal/core": {
-        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-90.patch"
-      }
     }
   }
 }


### PR DESCRIPTION
Fixes #1949.

I might be overstepping here with the update to `drupal/config_split`. I see that 1.1 _just_ came out. I'm not 100% sure if my versioning update here will bring in 1.1, or if 1.1 is even required. I may need to play around with that a little bit.

As I mentioned in the issue, I'm moving the core patch into the suggested file as it doesn't seem right that _every_ user of BLT has to have that patch which is a work in progress.