### PR TITLE
Adds manual port information for SimpleSAML when on Acquia Cloud.

### DIFF
--- a/settings/simplesamlphp.settings.php
+++ b/settings/simplesamlphp.settings.php
@@ -4,6 +4,13 @@
 # Provide universal absolute path to the installation.
 if (isset($_ENV['AH_SITE_NAME']) && is_dir('/var/www/html/' . $_ENV['AH_SITE_NAME'] . '/vendor/simplesamlphp/simplesamlphp')) {
   $settings['simplesamlphp_dir'] = '/var/www/html/' . $_ENV['AH_SITE_NAME'] . '/vendor/simplesamlphp/simplesamlphp';
+
+  // Force server port to 443 with HTTPS environments when behind a load balancer
+  // which is a requirement for SimpleSAML with ADFS when providing a redirect path.
+  // @see https://github.com/simplesamlphp/simplesamlphp/issues/450
+  if ($_SERVER['HTTPS'] && $_SERVER['HTTPS'] === 'on') {
+    $_SERVER['SERVER_PORT'] = 443;
+  }
 }
 else {
   // Local SAML path.


### PR DESCRIPTION
Changes proposed:
- Manually sets port to 443 when using SimpleSAML on Acquia Cloud with HTTPS

See https://github.com/simplesamlphp/simplesamlphp/issues/450