### PR TITLE
Add to phpunit command support for testsuite option (#1787).

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -113,6 +113,8 @@ phpcbf:
 # @todo Move to subkey of tests.
 phpunit:
   - path: '${repo.root}/tests/phpunit'
+    class: 'ExampleTest'
+    file: 'ExampleTest.php'
     config: null
   # Customization for one or more custom phpunit test locations
   # and if the core (or custom) config file should be included as a -c parameter.

--- a/readme/testing.md
+++ b/readme/testing.md
@@ -130,7 +130,6 @@ Note that Cucumber is simply a Ruby based BDD library, whereas Behat is a
 PHP based BDD library. Best practices for tests writing apply to both
 * [The training wheels came off](http://aslakhellesoy.com/post/11055981222/the-training-wheels-came-off)
 
-
 ## PHPUnit
 
 Project level, functional PHPUnit tests are included in `tests/phpunit`. Any PHPUnit tests that affect specific modules or application level features should be placed in the same directory as that module, not in this directory.
@@ -155,7 +154,6 @@ Project level, functional PHPUnit tests are included in `tests/phpunit`. Any PHP
 * [xUnit Test Patterns: Refactoring Test Code (book for the really serious)](http://amazon.com/dp/0131495054)
 * [Unit testing: Why bother?](http://soundsoftware.ac.uk/unit-testing-why-bother/)
 
-
 ### Configuration
 
 You can customize the `tests:phpunit` command by [customize the configuration values](extending-blt.md#modifying-blt-configuration) for the `phpunit` key.
@@ -164,24 +162,43 @@ Each row under the `phpunit` key should contain a combination of the following p
 
  * config: path to either the Core phpunit configuration file (docroot/core/phpunit.xml.dist) or a custom one. If left blank, no configuration will be loaded with the unit test.
  * path: the path to the custom phpunit test
+ * class: the class name for the test
+ * file: the sourcefile that declares the class provided in `class`
+ * testsuite: run tests that are part of a specific `@testsuite`
  * group: run tests only tagged with a specific `@group`
  * exclude: run tests excluding any tagged with this `@group`
- * filter: allows text filter for tests see [documentation](https://phpunit.de/manual/current/en/textui.htm) for more
+ * filter: allows text filter for tests
+
+ See PHPUnit's [documentation](https://phpunit.de/manual/current/en/textui.htm) for additional information.
 
 ```yml
 phpunit:
+  - path: '${repo.root}/tests/phpunit'
+    class: 'ExampleTest'
+    file: 'ExampleTest.php'
   -
     config: ${docroot}/core/phpunit.xml.dist
     group: 'example'
+    class: null
+    file: null
   -
     config: ${docroot}/core/phpunit.xml.dist
     exclude: 'mylongtest'
     group: 'example'
+    class: null
+    file: null
   -
-    config: ${docroot}/core/phpunit.xml.dist
-    path: ${docroot}/modules/custom/example
+    config: ${docroot}/core/phpunit.xml
+    path: '${docroot}/core'
+    testsuite: 'functional'
+    class: null
+    file: null
+   -
+    config: ${docroot}/core/phpunit.xml
+    path: ${docroot}/modules/custom/my_module
+    class: ExampeleTest
+    file: tests/src/Unit/ExampeleTest.php
 ```
-
 
 ## Frontend Testing
 

--- a/src/Robo/Commands/Tests/PhpUnitCommand.php
+++ b/src/Robo/Commands/Tests/PhpUnitCommand.php
@@ -54,7 +54,6 @@ class PhpUnitCommand extends BltTasks {
     foreach ($this->phpunitConfig as $test) {
       $task = $this->taskPHPUnit()
         ->xml($this->reportFile)
-        ->arg('.')
         ->printOutput(TRUE)
         ->printMetadata(FALSE);
 
@@ -69,9 +68,10 @@ class PhpUnitCommand extends BltTasks {
 
       $supported_options = [
         'config' => 'configuration',
-        'group' => 'group',
         'exclude-group' => 'exclude-group',
         'filter' => 'filter',
+        'group' => 'group',
+        'testsuite' => 'testsuite',
       ];
 
       foreach ($supported_options as $yml_key => $option) {

--- a/src/Robo/Commands/Tests/PhpUnitCommand.php
+++ b/src/Robo/Commands/Tests/PhpUnitCommand.php
@@ -57,6 +57,18 @@ class PhpUnitCommand extends BltTasks {
         ->printOutput(TRUE)
         ->printMetadata(FALSE);
 
+      if (isset($test['class'])) {
+        $task->arg($test['class']);
+        if (isset($test['file'])) {
+          $task->arg($test['file']);
+        }
+      }
+      else {
+        if (isset($test['path'])) {
+          $task->arg($test['path']);
+        }
+      }
+
       if (isset($test['path'])) {
         $task->dir($test['path']);
       }


### PR DESCRIPTION
Improves #1787 .

Changes proposed:
- Remove hardcoded <directory> arg `.` and add support for `name` and `file`.
- Add support for `testsuite` option.
- Update docs.