### PR TITLE
Include settings in Acquia Cloud multisite setup.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -59,8 +59,14 @@ if ($is_acsf) {
  ******************************************************************************/
 
 if ($is_ah_env) {
-  if (!$is_acsf && file_exists('/var/www/site-php') && $site_dir == 'default') {
-    require "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/{$_ENV['AH_SITE_GROUP']}-settings.inc";
+  if (!$is_acsf && file_exists('/var/www/site-php')) {
+    if ($site_dir == 'default') {
+      require "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/{$_ENV['AH_SITE_GROUP']}-settings.inc";
+    }
+    // Includes multisite settings for given site.
+    elseif (file_exists("/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/$site_dir-settings.inc")) {
+      require "/var/www/site-php/{$_ENV['AH_SITE_GROUP']}/$site_dir-settings.inc";
+    }
   }
 
   // Store API Keys and things outside of version control.


### PR DESCRIPTION
Fixes: no specific issue #

Changes proposed:
- Adds support for multisite settings includes on Acquia Cloud

BLT prepares some useful includes in settings.php. This PR adds support for multisites on Acquia Cloud. This removes the need to manually copy&paste snippets provided in Acquia Cloud UI for each database ( https://docs.acquia.com/acquia-cloud/manage/database#use )