### PR TITLE
BLT-1962: adding environment calls to pipelines scripts.

### DIFF
--- a/scripts/pipelines/tests
+++ b/scripts/pipelines/tests
@@ -4,6 +4,6 @@ set -ev
 
 export PATH=${COMPOSER_BIN}:${PATH}
 
-blt tests:all -D tests.run-server=true -D behat.web-driver=chrome --yes -v --ansi
+blt tests:all --define drush.alias='${drush.aliases.ci}' --define environment=ci -D tests.run-server=true -D behat.web-driver=chrome --yes -v --ansi
 
 set +v

--- a/scripts/pipelines/validate
+++ b/scripts/pipelines/validate
@@ -4,6 +4,6 @@ set -ev
 
 export PATH=${COMPOSER_BIN}:${PATH}
 
-blt validate:all --ansi
+blt validate:all --define drush.alias='${drush.aliases.ci}' --define environment=ci --ansi
 
 set +v


### PR DESCRIPTION
Fixes #1962.

Changes proposed:
- adds ci environment to tests/validate for pipelines scripts
