### PR TITLE
Remove xdebug warnings

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -685,7 +685,6 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
     if (!$this->warningsIssued) {
       $this->warnIfPhpOutdated();
       $this->warnIfDrupalVmNotRunning();
-      $this->warnIfXdebugLoaded();
       $this->warningsIssued = TRUE;
     }
   }
@@ -700,16 +699,6 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
     $current_php_version = phpversion();
     if ($current_php_version < $minimum_php_version) {
       throw new BltException("BLT requires PHP $minimum_php_version or greater. You are using $current_php_version.");
-    }
-  }
-
-  /**
-   * Warns the user if the xDebug extension is loaded.
-   */
-  protected function warnIfXdebugLoaded() {
-    $xdebug_loaded = extension_loaded('xdebug');
-    if ($xdebug_loaded) {
-      $this->logger->warning("The xDebug extension is loaded. This will significantly decrease performance.");
     }
   }
 


### PR DESCRIPTION
On 8.9.2 using DrupalVM, any BLT command executed in the VM produces a warning about the xdebug extension being enabled.

I'm not even sure why BLT issues this warning. I looked through the Git logs and there's no clear reasoning for it. I'm assuming it's based on the old Composer warnings about xdebug impacting performance, but this is [no longer an issue with Composer](https://getcomposer.org/doc/articles/troubleshooting.md#xdebug-impact-on-composer).

So unless there's clear evidence of a performance impact, I'm thinking we should just remove the warning.