### PR TITLE
Change behat version restrictions to work with lightning.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -13,7 +13,7 @@
   "require-dev": {
     "cweagans/composer-patches": "^1.6.0",
     "oomphinc/composer-installers-extender": "^1.1",
-    "behat/behat": "~3.3.1",
+    "behat/behat": ">=3.1 <3.4",
     "behat/mink": "~1.7",
     "behat/mink-selenium2-driver": "^1.3.1",
     "bex/behat-screenshot": "^1.2",


### PR DESCRIPTION
Fixes behat version constraint to work with Lightning 2.1.7