### PR TITLE
Add .functions to the list of dotfiles searched for blt alias. (1994)

### DIFF
--- a/src/Robo/Commands/Blt/AliasCommand.php
+++ b/src/Robo/Commands/Blt/AliasCommand.php
@@ -21,7 +21,7 @@ class AliasCommand extends BltTasks {
       $config_file = $this->getInspector()->getCliConfigFile();
       if (is_null($config_file)) {
         $this->logger->warning("Could not find your CLI configuration file.");
-        $this->logger->warning("Looked in ~/.zsh, ~/.bash_profile, ~/.bashrc, ~/.profile.");
+        $this->logger->warning("Looked in ~/.zsh, ~/.bash_profile, ~/.bashrc, ~/.profile, and ~/.functions.");
         $created = $this->createOsxBashProfile();
         if (!$created) {
           $this->logger->warning("Please create one of the aforementioned files, or create the BLT alias manually.");
@@ -55,7 +55,7 @@ class AliasCommand extends BltTasks {
     $this->say("Installing <comment>blt</comment> alias...");
     $config_file = $this->getInspector()->getCliConfigFile();
     if (is_null($config_file)) {
-      $this->logger->error("Could not install blt alias. No profile found. Tried ~/.zshrc, ~/.bashrc, ~/.bash_profile and ~/.profile.");
+      $this->logger->error("Could not install blt alias. No profile found. Tried ~/.zshrc, ~/.bashrc, ~/.bash_profile, ~/.profile, and ~/.functions.");
     }
     else {
       $canonical_alias = file_get_contents($this->getConfigValue('blt.root') . '/scripts/blt/alias');

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -433,6 +433,9 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
     elseif (file_exists($home_dir . '/.profile')) {
       $file = $home_dir . '/.profile';
     }
+    elseif (file_exists($home_dir . '/.functions')) {
+      $file = $home_dir . '/.functions';
+    }
 
     return $file;
   }


### PR DESCRIPTION
Fixes #1994.

Changes proposed:
- Add .functions to the list of dotfiles searched for blt alias.