### PR TITLE
Uses array_key_exists to check $SERVER for HTTPS key.

### DIFF
--- a/settings/simplesamlphp.settings.php
+++ b/settings/simplesamlphp.settings.php
@@ -8,7 +8,7 @@ if (isset($_ENV['AH_SITE_NAME']) && is_dir('/var/www/html/' . $_ENV['AH_SITE_NAM
   // Force server port to 443 with HTTPS environments when behind a load balancer
   // which is a requirement for SimpleSAML with ADFS when providing a redirect path.
   // @see https://github.com/simplesamlphp/simplesamlphp/issues/450
-  if ($_SERVER['HTTPS'] && $_SERVER['HTTPS'] === 'on') {
+  if (array_key_exists('HTTPS', $_SERVER) && $_SERVER['HTTPS'] === 'on') {
     $_SERVER['SERVER_PORT'] = 443;
   }
 }


### PR DESCRIPTION
I was getting a notice with the previous method, this should be more robust.