### PR TITLE
Remove stale DrupalVM config option

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -89,8 +89,6 @@ php_packages_extra:
 # Change this value to 1 in order to enable xdebug by default.
 php_xdebug_default_enable: 0
 php_xdebug_coverage_enable: 0
-# Change this value to 1 in order to enable xdebug on the cli.
-php_xdebug_cli_enable: 0
 php_xdebug_remote_enable: 1
 php_xdebug_remote_connect_back: 1
 # Use PHPSTORM for PHPStorm, sublime.xdebug for Sublime Text.


### PR DESCRIPTION
As documented upstream, this config option has no effect and should be removed: https://github.com/geerlingguy/ansible-role-php-xdebug/pull/47