### PR TITLE
Add back vagrantfile property expansion removed in #2039

### DIFF
--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -300,6 +300,7 @@ class VmCommand extends BltTasks {
     $config = clone $this->getConfig();
 
     $config->set('drupalvm.config.dir', $this->vmConfigDir);
+    $config->expandFileProperties($this->projectDrupalVmVagrantfile);
 
     // Generate a Random IP address for the new VM.
     $random_local_ip = "192.168." . rand(0, 255) . '.' . rand(0, 255);


### PR DESCRIPTION
Fixes removal of https://github.com/acquia/blt/pull/2039/files#diff-230747b7bce089cf23649b106a2ec653L285

If this is in error, apologies for the noise and close the PR, but I'm pretty sure this wants to be there.