### PR TITLE
Leverage "extra" to determine if BLT this is a "new" project

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -255,7 +255,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    */
   protected function isNewProject() {
     $composer_json = json_decode(file_get_contents($this->getRepoRoot() . '/composer.json'), TRUE);
-    if (!empty($composer_json['name'] && $composer_json['name'] == 'acquia/blt-project')) {
+    if (isset($composer_json['extra']['blt']['new']) && $composer_json['extra']['blt']['new']) {
       return TRUE;
     }
     return FALSE;

--- a/src/Robo/Common/ComposerMunge.php
+++ b/src/Robo/Common/ComposerMunge.php
@@ -33,6 +33,12 @@ class ComposerMunge {
       $output['require-dev'] = (object) $output['require-dev'];
     }
 
+    // Remove the existence of the new project identifier from invoking the
+    // create-project again in subsequent update calls.
+    if (isset($output['extra']['blt']['new'])) {
+      unset($output['extra']['blt']['new']);
+    }
+
     $output_json = json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
     return $output_json;


### PR DESCRIPTION
## Problem

Only project's whose `composer.json` specify the `"name"` property as `"acquia/blt-project"` can indicate a new project is being created for the first time.

## Proposed changes

Use the `"extra"` property in the following schema structure:

```
"extra": {
  "blt": {
    "new": true
  }
}
```

to identify whether or not BLT being installed and therefore the `internal:create-project` command should be invoked verse `internal:add-to-project`. When a project is being created for the first time and the `internal:add-to-project` is invoked, the following errors are received:

```
$ Creating BLT templated files...
 > /[project-dir]/vendor/acquia/blt/bin/blt internal:add-to-project --ansi -y
Installing new Composer dependencies provided by BLT. This make take a while...
PHP Fatal error:  Class 'Robo\Collection\CompletionWrapper' not found in /[project-dir]/vendor/consolidation/robo/src/Collection/Collection.php on line 89
```

This, I suspect (but have not confirmed in anyway), is the result of the autoloader not being ready for use.

## Additional changes

Additional changes to the [BLT Project](https://github.com/acquia/blt-project)'s `composer.json` would also be needed so that these changes would be effective for additional projects which may start from the `acquia/blt-project` repository.