### PR TITLE
Remove the md5_file() check, which hashes contents.

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -143,7 +143,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
         $source = $package_dir . DIRECTORY_SEPARATOR . $file;
         $target = $dir . DIRECTORY_SEPARATOR . $file;
         if (file_exists($source)) {
-          if (!file_exists($target) || md5_file($source) != md5_file($target)) {
+          if (!file_exists($target)) {
             $this->io->write("Copying $source to $target");
             copy($source, $target);
           }


### PR DESCRIPTION
## Problem

In conjunction with issue #2064 , I uncovered that it is not possible to override the `composer.*.json` files which are copied into `[repo.root]/blt/` at time of install or update. This is primarily due to the `md5_file()` being invoked which hashes the contents of the files themselves. Therefore, if files are not identical, the BLT provided `composer.*.json` are copied into `[repo.root]/blt/` which overwrites existing ones.

Note: I may have overlooked something, but based on the PHP source file of [md5.c](https://github.com/php/php-src/blob/master/ext/standard/md5.c), both `md5_file` and `md5` perform the same operations _except_ where `md5_file` opens the specified file to stream and hash the contents.

## Proposed changes

* Remove the need to check content hash and simply perform a "if file does not exist" condition, then copy.

## Usefulness

* In combination with #2064 and these changes, it is possible to have a composer based installer that creates a new BLT project _without_ Lightning or additional packages while allowing for the inclusion of new ones via `composer.*.json` files specified by default in `[repo.root]/blt`. For example, see [amcgowanca/rhino-project](https://github.com/amcgowanca/rhino-project).