### PR TITLE
Refactor git:pre-commit to use collection builder.

### DIFF
--- a/src/Robo/Commands/Git/GitCommand.php
+++ b/src/Robo/Commands/Git/GitCommand.php
@@ -44,25 +44,41 @@ class GitCommand extends BltTasks {
    * @param string $changed_files
    *   A list of staged files, separated by \n.
    *
-   * @return int
+   * @return \Robo\Result
    */
   public function preCommitHook($changed_files) {
-    $this->invokeCommands([
-      // Passing a file list to be PHPCS will cause all specified files to
-      // be sniffed, regardless of the extensions or patterns defined in
-      // phpcs.xml. So, we do not use validate:phpcs:files.
-      'validate:phpcs' => [],
-      'validate:twig:files' => ['file_list' => $changed_files],
-      'validate:yaml:files' => ['file_list' => $changed_files],
-    ]);
+    $collection = $this->collectionBuilder();
+    $collection->setProgressIndicator(NULL);
+    $collection->addCode(
+      function () use ($changed_files) {
+        return $this->invokeCommands([
+          // Passing a file list to be PHPCS will cause all specified files to
+          // be sniffed, regardless of the extensions or patterns defined in
+          // phpcs.xml. So, we do not use validate:phpcs:files.
+          'validate:phpcs' => [],
+          'validate:twig:files' => ['file_list' => $changed_files],
+          'validate:yaml:files' => ['file_list' => $changed_files],
+        ]);
+      }
+    );
 
     $changed_files_list = explode("\n", $changed_files);
-    if (in_array(['composer.json', 'composer.lock'], $changed_files_list)) {
-      $this->invokeCommand('validate:composer', ['file_list' => $changed_files]);
+    if (in_array('composer.json', $changed_files_list)
+      || in_array('composer.lock', $changed_files_list)) {
+      $collection->addCode(
+        function () use ($changed_files) {
+          return $this->invokeCommand('validate:composer');
+        }
+      );
     }
 
-    $this->invokeHook('pre-commit');
-    $this->say("<info>Your local code has passed git pre-commit validation.</info>");
+    $result = $collection->run();
+
+    if ($result->wasSuccessful()) {
+      $this->say("<info>Your local code has passed git pre-commit validation.</info>");
+    }
+
+    return $result;
   }
 
 }


### PR DESCRIPTION
This is a re-roll of #1505 against the latest 8.x.

Hopefully this is still desired? It looks like the pre-commit validation changed somewhat in the last few months, so that it's based on exceptions instead of exit codes. I'm not sure if that affects what you're trying to do here.
