### PR TITLE
BLT-2072: temporarily disabling checking of features overrides.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -85,7 +85,9 @@ class ConfigCommand extends BltTasks {
         throw new BltException("Failed to import configuration!");
       }
 
-      $this->checkFeaturesOverrides();
+      if ($this->getInspector()->getDrushMajorVersion() == 8) {
+        $this->checkFeaturesOverrides();
+      }
       $this->checkConfigOverrides($cm_core_key);
 
       $result = $this->invokeHook('post-config-import');


### PR DESCRIPTION
Fixes #2072  .

Changes proposed:
- comment out the check features override function to prevent potential fatal errors due to Drush 9 incompatibility

