### PR TITLE
Use the correct command for setup.strategy = sync

### DIFF
--- a/src/Robo/Commands/Setup/AllCommand.php
+++ b/src/Robo/Commands/Setup/AllCommand.php
@@ -33,7 +33,7 @@ class AllCommand extends BltTasks {
         break;
 
       case 'sync':
-        $commands[] = 'setup:refresh';
+        $commands[] = 'sync:refresh';
         break;
 
       case 'import':


### PR DESCRIPTION
What it says; in Setup/AllCommand.php, the command used when `setup.strategy` is `sync` is given as `setup:refresh`. `sync:refresh` exists.

If something larger is intended for later, ignore this.
