### PR TITLE
Pass in the site variable rather than forcing default drush alias.

### DIFF
--- a/src/Robo/Hooks/ExecuteInDrupalVmHook.php
+++ b/src/Robo/Hooks/ExecuteInDrupalVmHook.php
@@ -31,7 +31,7 @@ class ExecuteInDrupalVmHook extends BltTasks {
         $event->disableCommand();
         $command = $event->getCommand();
         $new_input = $this->createCommandInputFromCurrentParams($command, $event->getInput());
-        $new_input->setOption('define', 'drush.alias=self');
+        $new_input->setOption('define', 'site=' . $this->getConfigValue('site'));
 
         // We cannot return an exit code directly, because disabled commands
         // always return ConsoleCommandEvent::RETURN_CODE_DISABLED.


### PR DESCRIPTION
Commands passed to DrupalVM should not force the `@self` alias on the command, and they should pass the site variable so that the VM-internal command loads the correct config. 

This is dependent on https://github.com/acquia/blt/pull/2098 or some similar solution being merged, since currently site-specific config does not load correctly when passing `--define=site=example.com`.