### PR TITLE
BLT-000: drush8 compatibility issue with --config

### DIFF
--- a/src/Robo/Tasks/DrushTask.php
+++ b/src/Robo/Tasks/DrushTask.php
@@ -286,7 +286,7 @@ class DrushTask extends CommandStack {
       $this->option('include', $this->include);
     }
 
-    $this->option('config', $this->getConfig()->get('repo.root') . '/drush/drushrc.php');
+    $this->option('--include-conf', $this->getConfig()->get('repo.root') . '/drush/drushrc.php');
   }
 
   /**


### PR DESCRIPTION
Fixes sync:files broken for drush8.

Changes proposed:
- drush conf parameter should be --include-conf

