### PR TITLE
Most people should use vagrant up, not blt vm

### DIFF
--- a/readme/onboarding.md
+++ b/readme/onboarding.md
@@ -28,7 +28,7 @@ You have probably been linked to this documentation by a project that is using B
 If your project uses a virtual development environment such as DrupalVM:
 
 1. Make sure you have installed any prerequisites. For DrupalVM, see the [quick start guide](https://github.com/geerlingguy/drupal-vm#quick-start-guide).
-1. Start your virtual machine: `blt vm`
+1. Start your virtual machine: `vagrant up`
 1. Build and install the Drupal installation: `blt setup`
 
 If your project does not use a virtual development environment:


### PR DESCRIPTION
`blt vm` should only be run once per project, when the config files for the VM are first generated. Folks should subsequently just interact with Vagrant directly.