### PR TITLE
ACSF init fails due to permissions.

### DIFF
--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -47,6 +47,8 @@ class AcsfCommand extends BltTasks {
   public function acsfDrushInitialize() {
     $this->say('Executing initialization command provided acsf module...');
 
+    $this->taskFilesystemStack()->chmod("{$this->getConfigValue('docroot')}/sites/default", 755);
+
     $result = $this->taskDrush()
       ->drush('acsf-init')
       ->alias("")


### PR DESCRIPTION
Out of the box, the `docroot/sites/default` directory has perms 555 (not writable by anyone). This is problematic, because the `acsf:init` command (which calls out to `drush acsf_init`) tries to copy files into that directory, producing errors.

Seems reasonable to just make that directory writeable by the user who owns it.