### PR TITLE
Issue #2118: Don't cache composer vendor directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ cache:
   - "$HOME/.console"
   - "$HOME/.drush/cache"
   - "$HOME/.nvm"
-  - "vendor"
 
 addons:
   ssh_known_hosts:


### PR DESCRIPTION
Fixes #2118

I've seen a cached vendor directory cause problems with composer installs on my local and on Travis as well. It's probably better to do all installs from a clean slate.

This shouldn't have much of an impact on test duration, since Composer's native cache will still be warm.