### PR TITLE
Issue 1543

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "license": "GPL-2.0",
     "require": {
         "php": ">=5.6",
-        "asm89/twig-lint": "^1.0.2",
         "composer-plugin-api": "^1.0.0",
         "composer/installers": "^1.2.0",
         "composer/semver": "^1.4",
@@ -35,6 +34,7 @@
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.7",
         "symfony/console": "^3.2",
+        "symfony/twig-bridge": "^3.3",
         "symfony/yaml": "^3.2",
         "tivie/php-os-detector": "^1.0",
         "wikimedia/composer-merge-plugin": "^1.4.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,59 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "08938fe475c403ef8fcff82ae53b1b38",
+    "content-hash": "15b12d1dae0fce79c8e75ac143388dbd",
     "packages": [
-        {
-            "name": "asm89/twig-lint",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/asm89/twig-lint.git",
-                "reference": "bbf7bc49689ed55d2900de7528c528c93db19431"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/asm89/twig-lint/zipball/bbf7bc49689ed55d2900de7528c528c93db19431",
-                "reference": "bbf7bc49689ed55d2900de7528c528c93db19431",
-                "shasum": ""
-            },
-            "require": {
-                "symfony/console": "^2.1 || ^3.0",
-                "symfony/finder": "^2.1 || ^3.0",
-                "twig/twig": "^1.16.2"
-            },
-            "bin": [
-                "bin/twig-lint"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Asm89\\Twig\\Lint\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Alexander",
-                    "email": "iam.asm89@gmail.com"
-                }
-            ],
-            "description": "Standalone twig linter.",
-            "homepage": "https://github.com/asm89/twig-lint",
-            "keywords": [
-                "lint",
-                "twig"
-            ],
-            "time": "2016-07-25T21:02:13+00:00"
-        },
         {
             "name": "chi-teck/drupal-code-generator",
             "version": "1.19.0",
@@ -3382,6 +3331,93 @@
                 }
             ],
             "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-02T06:42:24+00:00"
+        },
+        {
+            "name": "symfony/twig-bridge",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bridge.git",
+                "reference": "cc40b1ea0efd030d422c762328345883a0404de4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/cc40b1ea0efd030d422c762328345883a0404de4",
+                "reference": "cc40b1ea0efd030d422c762328345883a0404de4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "twig/twig": "~1.34|~2.4"
+            },
+            "conflict": {
+                "symfony/form": "<3.2.10|~3.3,<3.3.3"
+            },
+            "require-dev": {
+                "fig/link-util": "^1.0",
+                "symfony/asset": "~2.8|~3.0",
+                "symfony/console": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/finder": "~2.8|~3.0",
+                "symfony/form": "^3.2.10|^3.3.3",
+                "symfony/http-kernel": "~3.2",
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/routing": "~2.8|~3.0",
+                "symfony/security": "~2.8|~3.0",
+                "symfony/security-acl": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0",
+                "symfony/templating": "~2.8|~3.0",
+                "symfony/translation": "~2.8|~3.0",
+                "symfony/var-dumper": "~2.8.10|~3.1.4|~3.2",
+                "symfony/web-link": "~3.3",
+                "symfony/yaml": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/asset": "For using the AssetExtension",
+                "symfony/expression-language": "For using the ExpressionExtension",
+                "symfony/finder": "",
+                "symfony/form": "For using the FormExtension",
+                "symfony/http-kernel": "For using the HttpKernelExtension",
+                "symfony/routing": "For using the RoutingExtension",
+                "symfony/security": "For using the SecurityExtension",
+                "symfony/stopwatch": "For using the StopwatchExtension",
+                "symfony/templating": "For using the TwigEngine",
+                "symfony/translation": "For using the TranslationExtension",
+                "symfony/var-dumper": "For using the DumpExtension",
+                "symfony/web-link": "For using the WebLinkExtension",
+                "symfony/yaml": "For using the YamlExtension"
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Twig\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
             "time": "2017-10-02T06:42:24+00:00"
         },

--- a/config/build.yml
+++ b/config/build.yml
@@ -209,6 +209,10 @@ validate:
   twig:
     filesets:
       - files.twig
+    # Add any custom Twig filters for linter to ignore.
+    filters: { }
+    # Add any custom Twig functions for linter to ignore.
+    functions: { }
   yaml:
     filesets:
       - files.yaml

--- a/readme/extending-blt.md
+++ b/readme/extending-blt.md
@@ -188,3 +188,16 @@ To modify the behavior of the tests:behat target, you may override BLT's `behat`
 #### validate:phpcs
 
 To modify the behavior of the validate:phpcs target, you may copy `phpcs.xml.dist` to `phpcs.xml` in your repository root directory and modify the XML. Please see the [official PHPCS documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file) for more information.
+
+#### validate:twig
+
+To prevent validation failures on any Twig filters or functions created in custom or contrib module `twig.extension` services, add `filters` and `functions` like so:
+
+        validate:
+          twig:
+            filters:
+              - my_filter_1
+              - my_filter_2
+            functions:
+              - my_function_1
+              - my_function_2

--- a/src/Robo/Commands/Input/ArrayInput.php
+++ b/src/Robo/Commands/Input/ArrayInput.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Acquia\Blt\Robo\Commands\Input;
+
+use Symfony\Component\Console\Input\ArrayInput as ArrayInputBase;
+
+/**
+ * ArrayInput class.
+ */
+class ArrayInput extends ArrayInputBase {
+
+  /**
+   * Escapes a token through escapeshellarg if it contains unsafe chars.
+   *
+   * @param array|string $token
+   *
+   * @return string
+   */
+  public function escapeToken($token) {
+    // Account for ArrayInput arguments possibly being arrays to prevent
+    // warning when casting to string.
+    // @todo Remove when Drupal allows upgrade to Symfony Console 3.3.9+.
+    // @see https://github.com/symfony/symfony/issues/24087.
+    if (is_array($token)) {
+      foreach ($token as $key => $value) {
+        $token[$key] = preg_match('{^[\w-]+$}', $value) ? $value : escapeshellarg($value);
+      }
+      return implode(' ', $token);
+    }
+    return preg_match('{^[\w-]+$}', $token) ? $token : escapeshellarg($token);
+  }
+
+}

--- a/src/Robo/Commands/Validate/TwigCommand.php
+++ b/src/Robo/Commands/Validate/TwigCommand.php
@@ -3,6 +3,11 @@
 namespace Acquia\Blt\Robo\Commands\Validate;
 
 use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Commands\Input\ArrayInput;
+use Acquia\Blt\Robo\Exceptions\BltException;
+use Symfony\Bridge\Twig\Command\LintCommand;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 /**
  * Defines commands in the "validate:twig*" namespace.
@@ -13,10 +18,6 @@ class TwigCommand extends BltTasks {
    * Executes Twig validator against all validate.twig.filesets files.
    *
    * @command validate:twig
-   *
-   * @return int
-   *   The exit code of the last executed command in
-   *   $this->executeCommandAgainstFilesets().
    */
   public function lintFileSets() {
     $this->say("Validating twig syntax for all custom modules and themes...");
@@ -25,9 +26,7 @@ class TwigCommand extends BltTasks {
     $fileset_manager = $this->getContainer()->get('filesetManager');
     $fileset_ids = $this->getConfigValue('validate.twig.filesets');
     $filesets = $fileset_manager->getFilesets($fileset_ids);
-    $bin = $this->getConfigValue('composer.bin');
-    $command = "'$bin/twig-lint' lint --only-print-errors '%s'";
-    $this->executeCommandAgainstFilesets($filesets, $command, TRUE);
+    $this->executeTwigLintCommandAgainstFilesets($filesets);
   }
 
   /**
@@ -47,14 +46,94 @@ class TwigCommand extends BltTasks {
     $fileset_manager = $this->getContainer()->get('filesetManager');
     $fileset_ids = $this->getConfigValue('validate.twig.filesets');
     $filesets = $fileset_manager->getFilesets($fileset_ids);
-
-    $bin = $this->getConfigValue('composer.bin');
-    $command = "'$bin/twig-lint' lint --only-print-errors '%s'";
     foreach ($filesets as $fileset_id => $fileset) {
       $filesets[$fileset_id] = $fileset_manager->filterFilesByFileset($files, $fileset);
     }
+    $this->executeTwigLintCommandAgainstFilesets($filesets);
+  }
 
-    $this->executeCommandAgainstFilesets($filesets, $command);
+  /**
+   * Lints twig against multiple filesets.
+   *
+   * @param \Symfony\Component\Finder\Finder[] $filesets
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  protected function executeTwigLintCommandAgainstFilesets(array $filesets) {
+    $command = $this->createTwigLintCommand();
+
+    /** @var \Acquia\Blt\Robo\Application $application */
+    $application = $this->getContainer()->get('application');
+    $application->add($command);
+
+    $passed = TRUE;
+    $failed_filesets = [];
+    foreach ($filesets as $fileset_id => $fileset) {
+      if (!is_null($fileset) && iterator_count($fileset)) {
+        $this->say("Iterating over fileset $fileset_id...");
+        $files = iterator_to_array($fileset);
+        $input = new ArrayInput(['filename' => $files]);
+        $exit_code = $application->runCommand($command, $input, $this->output());
+        if ($exit_code) {
+          // We iterate over all filesets before throwing an exception.
+          $passed = FALSE;
+          $failed_filesets[] = $fileset_id;
+        }
+      }
+      else {
+        $this->logger->info("No files were found in fileset $fileset_id. Skipped.");
+      }
+    }
+
+    if (!$passed) {
+      throw new BltException("Linting twig against fileset(s) " . implode(', ', $failed_filesets) . " returned a non-zero exit code.`");
+    }
+
+    // If exception wasn't thrown, checks were successful.
+    $this->say("All Twig files contain valid syntax.");
+  }
+
+  /**
+   * Creates the Twig lint command.
+   *
+   * @return \Symfony\Bridge\Twig\Command\LintCommand
+   */
+  protected function createTwigLintCommand() {
+    $twig = new Environment(new FilesystemLoader());
+
+    $repo_root = $this->getConfigValue('repo.root');
+    $extension_file_contents = file_get_contents($repo_root . '/docroot/core/lib/Drupal/Core/Template/TwigExtension.php');
+
+    // Get any custom defined Twig filters to be ignored by linter.
+    $twig_filters = (array) $this->getConfigValue('validate.twig.filters');
+
+    // Add Twig filters from Drupal TwigExtension to be ignored.
+    $drupal_filters = [];
+    if ($matches_count = preg_match_all("#new \\\\Twig_SimpleFilter\('([^']+)',#", $extension_file_contents, $matches)) {
+      $drupal_filters = $matches[1];
+    }
+    $twig_filters = array_merge($twig_filters, $drupal_filters);
+    foreach ($twig_filters as $filter) {
+      $twig->addFilter(new \Twig_SimpleFilter($filter, function () {}));
+    }
+
+    // Get any custom defined Twig functions to be ignored by linter.
+    $twig_functions = (array) $this->getConfigValue('validate.twig.functions');
+
+    // Add Twig functions from Drupal TwigExtension to be ignored.
+    $drupal_functions = [];
+    if ($matches_count = preg_match_all("#new \\\\Twig_SimpleFunction\('([^']+)',#", $extension_file_contents, $matches)) {
+      $drupal_functions = $matches[1];
+    }
+    $twig_functions = array_merge($twig_functions, $drupal_functions);
+    foreach ($twig_functions as $function) {
+      $twig->addFunction(new \Twig_SimpleFunction($function, function () {}));
+    }
+
+    $command = new LintCommand();
+    $command->setTwigEnvironment($twig);
+
+    return $command;
   }
 
 }


### PR DESCRIPTION
Fixes #1543.

Changes proposed:
- Remove asm89/twig-lint and use Symfony twig linter
- Run twig lint command procedurally instead of in parallel, otherwise error messages are suppressed.
- Account for Twig functions and filters added by Drupal, so that linter does not flag as invalid.
- Provide config for users to add custom Twig filters and functions that can be specified in project.yml
- Reorder precommit lint commands so that PHPUnit tests do not fail on Travis.
