### PR TITLE
Scrub user passwords so their accounts cannot be compromised.

### DIFF
--- a/scripts/cloud-hooks/hooks/common/post-db-copy/db-scrub.sh
+++ b/scripts/cloud-hooks/hooks/common/post-db-copy/db-scrub.sh
@@ -16,7 +16,7 @@ source_env="$4"
 acsf_file="/mnt/files/$AH_SITE_GROUP.$AH_SITE_ENVIRONMENT/files-private/sites.json"
 if [ ! -f $acsf_file ]; then
   echo "$site.$target_env: Scrubbing database $db_name"
-  drush @$site.$target_env sql-sanitize --yes
+  drush @$site.$target_env sql-sanitize --sanitize-password="$(openssl rand -base64 32)" --yes
   drush @$site.$target_env cache-rebuild
 fi
 


### PR DESCRIPTION
Changes proposed:
- scrub user passwords to something unknowable during sql-sanitize

In Drush 8 at least, `drush sql-sanitize` allows the user flag `--sanitize-password`, if you want to specify a password to set all user accounts to during the sanitization process.

If you do not specify this, it changes all passwords for all system users to literally the word "password". This means that on the sanitized database, anyone can log in as any user using the password "password". This applies to all accounts, including admin.

This is potentially a security risk for environments using these sanitized databases because:

1) users who should not have access to are able to log in as admin users, exposing site configuration which could then potentially be used to compromise a production site
2) users who should not have access to do so can log in as other users, potentially seeing data that they have access to as authenticated users with specific roles.

The proposed fix passes a randomized string to `--sanitize-password`. The string is generated in a subshell command, and so is not printed to log unless the debug flag is set globally. 

This means the password is set to something unknowable and undiscoverable. Users with admin capabilities can still use `drush uli` to log in as any user they need to.

