### PR TITLE
Set config dir to fix site install on ACSF.

### DIFF
--- a/settings/acsf/post-settings-php/includes.php
+++ b/settings/acsf/post-settings-php/includes.php
@@ -1,0 +1,3 @@
+<?php
+$config_directories['vcs'] = '../config/default';
+$config_directories['sync'] = '../config/default';

--- a/settings/acsf/post-settings-php/includes.php
+++ b/settings/acsf/post-settings-php/includes.php
@@ -1,3 +1,12 @@
 <?php
+
+/**
+ * @file
+ * Example implementation of ACSF post-settings-php hook.
+ *
+ * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
+ */
+
+// Set config directories to default location.
 $config_directories['vcs'] = '../config/default';
 $config_directories['sync'] = '../config/default';


### PR DESCRIPTION
Partially fixes #2159

Currently, if you use the core "install profile from config" patch and try to create a new site from the ACSF UI, the install will fail because ACSF tries to look in some non-standard configuration directory.

With this patch, you will be able to spin up new sites directly from the ACSF UI and they will even respect your config splits (hubba hubba!)