### PR TITLE
Clear drush cache before running acsf commands.

### DIFF
--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -26,6 +26,10 @@ acsf_deploy() {
   export PATH=$repo_root/vendor/bin:$PATH
   cd $repo_root
 
+  # Clear drush cache to make sure it can find ACSF tools.
+  echo "Clearing Drush cache"
+  drush cc drush
+
   echo "Running updates for environment: $target_env"
 
   # Generate an array of all site URIs on the Factory from parsed output of Drush utility.


### PR DESCRIPTION
When you deploy to ACSF, the cloud hooks that call acsf-tools can fail because they can't find the contrib package. A cache clear is required to pick up the commands for the first time.

This probably only needs to be run once per project, it would be nice if there was a way to only run it when necessary. But it only takes a second to run, so it's not that bad to run it every time.