### PR TITLE
Pr blt issue 2173 drush multisite

### DIFF
--- a/src/Robo/Config/ConfigAwareTrait.php
+++ b/src/Robo/Config/ConfigAwareTrait.php
@@ -23,6 +23,7 @@ trait ConfigAwareTrait {
    *   The config value, or else the default value if they key does not exist.
    */
   protected function getConfigValue($key, $default = NULL) {
+
     if (!$this->getConfig()) {
       return $default;
     }

--- a/src/Robo/Config/DefaultConfig.php
+++ b/src/Robo/Config/DefaultConfig.php
@@ -66,9 +66,19 @@ class DefaultConfig extends BltConfig {
    * @param string $site_name
    *   The name of a multisite. E.g., if docroot/sites/example.com is the site,
    *   $site_name would be example.com.
+   * @param string $machine_name
+   *   The machine name in a multisite environment.
+   *   E.g., @machine_name.sitename.dev
    */
-  public function setSiteConfig($site_name) {
+  public function setSiteConfig($site_name, $machine_name = NULL) {
     $this->config->set('site', $site_name);
+
+    // Adapt remote alias for the multisite.
+    if ($environment = $this->config->get('drush.aliases.remote_env')) {
+      echo ' environment:: ' . $environment;
+      $this->config->set('drush.aliases.remote', $machine_name . '.' . $site_name . '.' . $environment);
+    }
+
     if (!$this->config->get('drush.uri')) {
       $this->config->set('drush.uri', $site_name);
     }

--- a/src/Robo/Config/DefaultConfig.php
+++ b/src/Robo/Config/DefaultConfig.php
@@ -75,7 +75,6 @@ class DefaultConfig extends BltConfig {
 
     // Adapt remote alias for the multisite.
     if ($environment = $this->config->get('drush.aliases.remote_env')) {
-      echo ' environment:: ' . $environment;
       $this->config->set('drush.aliases.remote', $machine_name . '.' . $site_name . '.' . $environment);
     }
 

--- a/src/Robo/Hooks/InitHook.php
+++ b/src/Robo/Hooks/InitHook.php
@@ -31,8 +31,9 @@ class InitHook extends Tasks implements IOAwareInterface, ConfigAwareInterface, 
     // input has been processed.
     $multisites = $this->getConfigValue('multisites');
     $first_multisite = reset($multisites);
+    $machine_name = $this->getConfigValue('project.machine_name');
     $site = $this->getConfigValue('site', $first_multisite);
-    $this->getConfig()->setSiteConfig($site);
+    $this->getConfig()->setSiteConfig($site, $machine_name);
   }
 
 }


### PR DESCRIPTION
Fixes #2173 .

Changes proposed:
- initialize() sends a new parameter from project.yml, project.machine_name, 
- setSiteConfig() is now multisite aware, adapting not just site but also drush remote alias.
