### PR TITLE
Spaces in filepath for drush alias private key sets everything on fire.

### DIFF
--- a/scripts/drupal-vm/drupal-vm.aliases.yml
+++ b/scripts/drupal-vm/drupal-vm.aliases.yml
@@ -3,4 +3,4 @@ local:
   uri: ${project.local.uri}
   host: ${project.local.hostname}
   user: vagrant
-  ssh-options: -o PasswordAuthentication=no -i ' . drush_server_home() . '/.vagrant.d/insecure_private_key
+  ssh-options: -o PasswordAuthentication=no -i \'' . drush_server_home() . '/.vagrant.d/insecure_private_key\'


### PR DESCRIPTION
If OSX username is something like "employee 1" drush will fail to connect to the remote as the private key is not quoted causing the space to be interpreted as a delimiter.

Yes, while this is really a best practices issue on username usage, we could workaround it pretty easily here.