### PR TITLE
Fixes #2173: Automatic ACSF remote aliases based on site name

### DIFF
--- a/src/Robo/Config/DefaultConfig.php
+++ b/src/Robo/Config/DefaultConfig.php
@@ -62,6 +62,12 @@ class DefaultConfig extends BltConfig {
     $first_multisite = reset($multisites);
     $site = $this->get('site', $first_multisite);
     $this->setSite($site);
+
+    // Adapt remote alias for the multisite (as --uri is not supported in drush).
+    if ($environment = $this->get('drush.aliases.remote_env')) {
+      $machine_name = $this->get('project.machine_name');
+      $this->config->set('drush.aliases.remote', $machine_name . '.' . $site . '.' . $environment);
+    }
   }
 
   public function setSite($site) {

--- a/src/Robo/Config/DefaultConfig.php
+++ b/src/Robo/Config/DefaultConfig.php
@@ -63,7 +63,7 @@ class DefaultConfig extends BltConfig {
     $site = $this->get('site', $first_multisite);
     $this->setSite($site);
 
-    // Adapt remote alias for the multisite (as --uri is not supported in drush).
+    // Adapt remote alias for the multisite.
     if ($environment = $this->get('drush.aliases.remote_env')) {
       $machine_name = $this->get('project.machine_name');
       $this->config->set('drush.aliases.remote', $machine_name . '.' . $site . '.' . $environment);


### PR DESCRIPTION
There is an issue (my own machine maybe) blocking me testing this in 9.1.x (frozen composer)

Fixes #2173 .

Changes proposed:

initialize() sends a new parameter from project.yml, project.machine_name,
setSiteConfig() is now multisite aware, adapting not just site but also drush remote alias.

see for the 8.x branch: https://github.com/acquia/blt/pull/2187