### PR TITLE
Site inspector should use Drush 9 commands.

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -257,7 +257,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    *   TRUE if alias is valid.
    */
   public function isDrushAliasValid($alias) {
-    return $this->executor->drush("site-alias $alias --format=json")->run()->wasSuccessful();
+    return $this->executor->drush("site:alias $alias --format=json")->run()->wasSuccessful();
   }
 
   /**


### PR DESCRIPTION
Also port to 9.x.

Think if this can be combined with the alias checks in the doctor command, which seem to duplicate this.