### PR TITLE
Clear twig caches on all web servers on deploy / update.

### DIFF
--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -45,6 +45,7 @@ acsf_deploy() {
   for uri in "${sites[@]}"; do
   #Override BLT default deploy uri.
   blt deploy:update --define environment=$target_env --define drush.uri="$uri" -v -y
+  drush @"${drush_alias}" --uri=$uri ev '\Drupal\Core\PhpStorage\PhpStorageFactory::get("twig")->deleteAll();'
   if [ $? -ne 0 ]; then
       echo "Update errored for site $uri."
       exit 1
@@ -66,6 +67,7 @@ ace_deploy() {
   cd $repo_root
 
   blt deploy:update --define environment=$target_env -v -y
+  drush @"${drush_alias}" ev '\Drupal\Core\PhpStorage\PhpStorageFactory::get("twig")->deleteAll();'
   if [ $? -ne 0 ]; then
       echo "Update errored."
       exit 1


### PR DESCRIPTION
Fixes #2228 

Changes proposed:
-  Adds support for clearing twig caches on deploy on all web servers rather than just the primary. 
