### PR TITLE
POC: Optionally isolate configs per site (8.x branch)

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -35,23 +35,27 @@ class ConfigCommand extends BltTasks {
       // If using core-only or config-split strategies, first check to see if
       // required config is exported.
       if (in_array($strategy, ['core-only', 'config-split'])) {
-        $core_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("cm.core.dirs.$cm_core_key.path") . '/core.extension.yml';
+        // Read the config from the default folder (/config/default). This will
+        // Also be the fallback option, so some domains can still use default.
+        $core_config_file = $this->getConfigValue('docroot') . '/' .
+          $this->getConfigValue("cm.core.dirs.$cm_core_key.path") .
+          '/core.extension.yml';
 
+        // We don't want configs to be shared between multisites.
+        if ($this->getConfigValue('cm.share-configs') == FALSE) {
+          $drush_uri = $this->getConfigValue('drush.uri');
+
+          // Read the config from the site folder (/config/URI/).
+          $core_config_file = $this->getConfigValue('docroot') . '/' .
+            $this->getConfigValue("cm.core.dirs.$cm_core_key.path") . '/../' .
+            $drush_uri . '/core.extension.yml';
+        }
+
+        // If we still don't have core_config_file.
         if (!file_exists($core_config_file)) {
-          if ($this->getConfigValue('cm.share-configs') == FALSE) {
-            $drush_uri = $this->getConfigValue('drush.uri');
-            // Is there a multisite config?
-            $core_config_file = $this->getConfigValue('docroot') . '/' .
-              $this->getConfigValue("cm.core.dirs.$cm_core_key.path") . '/../' .
-              $drush_uri . '/core.extension.yml';
-          }
-
-          // If we still don't have core_config_file.
-          if (!file_exists($core_config_file)) {
-            $this->logger->warning("BLT will NOT import configuration, $core_config_file was not found.");
-            // This is not considered a failure.
-            return 0;
-          }
+          $this->logger->warning("BLT will NOT import configuration, $core_config_file was not found.");
+          // This is not considered a failure.
+          return 0;
         }
       }
 

--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -38,9 +38,20 @@ class ConfigCommand extends BltTasks {
         $core_config_file = $this->getConfigValue('docroot') . '/' . $this->getConfigValue("cm.core.dirs.$cm_core_key.path") . '/core.extension.yml';
 
         if (!file_exists($core_config_file)) {
-          $this->logger->warning("BLT will NOT import configuration, $core_config_file was not found.");
-          // This is not considered a failure.
-          return 0;
+          if ($this->getConfigValue('cm.share-configs') == FALSE) {
+            $drush_uri = $this->getConfigValue('drush.uri');
+            // Is there a multisite config?
+            $core_config_file = $this->getConfigValue('docroot') . '/' .
+              $this->getConfigValue("cm.core.dirs.$cm_core_key.path") . '/../' .
+              $drush_uri . '/core.extension.yml';
+          }
+
+          // If we still don't have core_config_file
+          if (!file_exists($core_config_file)) {
+            $this->logger->warning("BLT will NOT import configuration, $core_config_file was not found.");
+            // This is not considered a failure.
+            return 0;
+          }
         }
       }
 

--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -46,7 +46,7 @@ class ConfigCommand extends BltTasks {
               $drush_uri . '/core.extension.yml';
           }
 
-          // If we still don't have core_config_file
+          // If we still don't have core_config_file.
           if (!file_exists($core_config_file)) {
             $this->logger->warning("BLT will NOT import configuration, $core_config_file was not found.");
             // This is not considered a failure.


### PR DESCRIPTION
Fixes #2242

Changes proposed:
- Isolate configs between multisites

Here is something it can be useful for someone else, but happy to received feedback if this is an awful, terrible, bad idea. 

Sometimes, due to complexity or some other factors, you want to keep your sites configurations isolated. With this PR, you can have:

```
config/site1/
config/site2/
config/SITE1/
...
```

and then your splits:

```
config/dev
config/test
...
```

When doing a 

```
blt setup:config-import -D site=SITE1
```

What happens is this:

```
...[]/drush @machinename.local pm-enable config_split --uri=SITE1 --yes ...[]
...[]drush @machinename.local config-import sync --uri=SITE1 --yes ...[]
```

so, effectively, it will be importing the configs using uri as the folder, and applying the splits.