### PR TITLE
Fixes #2026: Support profile installation from config.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -130,6 +130,9 @@ setup:
   strategy: install
   # If setup.strategy is import, this file will be imported.
   dump-file: null
+  drupal:
+    install:
+      import-config: true
 
 sync:
   # By default, files are not synced during sync:refresh.

--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -50,7 +50,7 @@ class DrupalCommand extends BltTasks {
     $config_strategy = $this->getConfigValue('cm.strategy');
 
     // --config-dir is not valid for Drush 9.
-    if ($config_strategy != 'none' && $this->getInspector()->getDrushMajorVersion() == 8) {
+    if ($config_strategy != 'none' && $this->getInspector()->getDrushMajorVersion() == 8 && $this->getConfigValue('setup.drupal.install.import-config')) {
       $cm_core_key = $this->getConfigValue('cm.core.key');
       $task->option('config-dir', $this->getConfigValue("cm.core.dirs.$cm_core_key.path"));
     }


### PR DESCRIPTION
Config imports at install time cause crazy amounts of pain, I think this is worth supporting for Drush 8 users until 9 is more stable.