### PR TITLE
Fixes #2233: CLI definitions not passed to DrupalVM.

### DIFF
--- a/src/Robo/Hooks/CommandEventHook.php
+++ b/src/Robo/Hooks/CommandEventHook.php
@@ -53,7 +53,9 @@ class CommandEventHook extends BltTasks {
         $event->disableCommand();
         $command = $event->getCommand();
         $new_input = $this->createCommandInputFromCurrentParams($command);
-        $new_input->setOption('define', 'drush.alias=self');
+        $defines = $new_input->getOption('define');
+        $defines[] = 'drush.alias=self';
+        $new_input->setOption('define', $defines);
 
         // We cannot return an exit code directly, because disabled commands
         // always return ConsoleCommandEvent::RETURN_CODE_DISABLED.
@@ -90,7 +92,9 @@ class CommandEventHook extends BltTasks {
     foreach ($new_input->getOptions() as $name => $value) {
       if ($new_input->getOption($name)) {
         if ($command_definition->getOption($name)->acceptValue()) {
-          $command_string .= " --$name=$value";
+          foreach ($value as $sub_value) {
+            $command_string .= " --$name=$sub_value";
+          }
         }
         else {
           $command_string .= " --$name";


### PR DESCRIPTION
Fixes #2233 

Fixes two problems for commands executed inside the VM:
1. Any existing CLI defines were getting clobbered by the `drush.alias=self` definition
2. Multi-value options (such as `--define`) were not cast correctly when building the new command

If this works, also port to 9.x/9.1.x