### PR TITLE
Quote ROOT_DIR

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -5,7 +5,7 @@ LIST=$( git diff --name-only --cached --diff-filter=ACM )
 PHPCS_BIN=vendor/bin/phpcs
 
 echo "Executing .git/hooks/pre-commit..."
-${ROOT_DIR}/vendor/bin/blt git:pre-commit "$LIST"
+"${ROOT_DIR}"/vendor/bin/blt git:pre-commit "$LIST"
 
 # Return the status of the last run command.
 exit $?


### PR DESCRIPTION
ROOT_DIR may contain spaces so it must be quoted.

Without the quotes, if ROOT_DIR contains a space, the user will receive a "No such file or directory" error.

Fixes # .

Changes proposed:
-
-
