### PR TITLE
Fixes #2194: Refactor YAML functions.

### DIFF
--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -3,9 +3,9 @@
 namespace Acquia\Blt\Robo\Commands\Acsf;
 
 use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Defines commands in the "acsf" namespace.
@@ -54,11 +54,11 @@ class AcsfCommand extends BltTasks {
     $this->say('<comment>See /drush/contrib/acsf-tools/README.md. </comment>');
     $this->say('<info>ACSF was successfully initialized.</info>');
     $project_yml = $this->getConfigValue('blt.config-files.project');
-    $project_config = Yaml::parse(file_get_contents($project_yml));
+    $project_config = YamlMunge::parseFile($project_yml);
     if (!empty($project_config['modules'])) {
       $project_config['modules']['local']['uninstall'][] = 'acsf';
     }
-    file_put_contents($project_yml, Yaml::dump($project_config, 3, 2));
+    YamlMunge::writeFile($project_yml, $project_config);
   }
 
   /**

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -355,7 +355,7 @@ class UpdateCommand extends BltTasks {
     $template_project_yml = $this->getConfigValue('blt.root') . '/template/blt/project.yml';
     $munged_yml = YamlMunge::munge($template_project_yml, $repo_project_yml);
     try {
-      YamlMunge::writeFile($this->getConfigValue('blt.config-files.project'), $munged_yml);
+      YamlMunge::writeFile($repo_project_yml, $munged_yml);
     }
     catch (\Exception $e) {
       throw new BltException("Could not update $repo_project_yml.");

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -352,9 +352,12 @@ class UpdateCommand extends BltTasks {
     // Values in the project's existing project.yml file will be preserved and
     // not overridden.
     $repo_project_yml = $this->getConfigValue('blt.config-files.project');
-    $munged_yaml = YamlMunge::munge($this->getConfigValue('blt.root') . '/template/blt/project.yml', $repo_project_yml);
-    $bytes = file_put_contents($this->getConfigValue('blt.config-files.project'), $munged_yaml);
-    if (!$bytes) {
+    $template_project_yml = $this->getConfigValue('blt.root') . '/template/blt/project.yml';
+    $munged_yml = YamlMunge::munge($template_project_yml, $repo_project_yml);
+    try {
+      YamlMunge::writeFile($this->getConfigValue('blt.config-files.project'), $munged_yml);
+    }
+    catch (\Exception $e) {
       throw new BltException("Could not update $repo_project_yml.");
     }
   }

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -369,13 +369,10 @@ class UpdateCommand extends BltTasks {
    */
   protected function setProjectName() {
     $project_name = basename($this->getConfigValue('repo.root'));
-    $result = $this->taskExecStack()
-      ->exec("{$this->getConfigValue('composer.bin')}/yaml-cli update:value {$this->getConfigValue('blt.config-files.project')} project.machine_name '$project_name'")
-      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-      ->run();
-    if (!$result->wasSuccessful()) {
-      throw new BltException("Could not set value for project.machine_name in {$this->getConfigValue('blt.config-files.project')}.");
-    }
+    $project_yml = $this->getConfigValue('blt.config-files.project');
+    $project_config = YamlMunge::parseFile($project_yml);
+    $project_config['project']['machine_name'] = $project_name;
+    YamlMunge::writeFile($project_yml, $project_config);
   }
 
 }

--- a/src/Robo/Commands/Saml/SimpleSamlPhpCommand.php
+++ b/src/Robo/Commands/Saml/SimpleSamlPhpCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Blt\Robo\Commands\Saml;
 
 use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -132,21 +133,16 @@ class SimpleSamlPhpCommand extends BltTasks {
    * Sets value in project.yml to let targets know simplesamlphp is installed.
    */
   protected function setSimpleSamlPhpInstalled() {
-    $composerBin = $this->getConfigValue('composer.bin');
-    $project_yml = $this->getConfigValue('blt.config-files.project');
     $this->say("Updating ${project_yml}...");
 
-    $result = $this->taskExec("{$composerBin}/yaml-cli update:value")
-      ->arg($project_yml)
-      ->arg('simplesamlphp')
-      ->arg('TRUE')
-      ->printOutput(TRUE)
-      ->detectInteractive()
-      ->dir($this->getConfigValue('repo.root'))
-      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-      ->run();
+    $project_yml = $this->getConfigValue('blt.config-files.project');
+    $project_config = YamlMunge::parseFile($project_yml);
+    $project_config['simplesamlphp'] = TRUE;
 
-    if (!$result->wasSuccessful()) {
+    try {
+      YamlMunge::writeFile($project_yml, $project_config);
+    }
+    catch (\Exception $e) {
       throw new BltException("Unable to update $project_yml.");
     }
   }

--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -102,7 +102,7 @@ class VmCommand extends BltTasks {
         ->remove($this->projectDrupalVmVagrantfile)
         // @todo More surgically remove drush.default_alias and drush.aliases.local values from this file
         // rather than overwriting it.
-        ->remove($this->getConfigValue('repo.root') . '/blt/project.local.yml')
+        ->remove($this->getConfigValue('blt.config-file.local'))
         ->copy($this->defaultDrushAliasesFile, $this->projectDrushAliasesFile, TRUE)
         ->run();
       $this->say("Your Drupal VM instance has been obliterated.");

--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -102,7 +102,7 @@ class VmCommand extends BltTasks {
         ->remove($this->projectDrupalVmVagrantfile)
         // @todo More surgically remove drush.default_alias and drush.aliases.local values from this file
         // rather than overwriting it.
-        ->remove($this->getConfigValue('blt.config-file.local'))
+        ->remove($this->getConfigValue('blt.config-files.local'))
         ->copy($this->defaultDrushAliasesFile, $this->projectDrushAliasesFile, TRUE)
         ->run();
       $this->say("Your Drupal VM instance has been obliterated.");

--- a/src/Robo/Common/YamlMunge.php
+++ b/src/Robo/Common/YamlMunge.php
@@ -19,15 +19,13 @@ class YamlMunge {
    *   The file path of the second file.
    *
    * @return string
-   *   The merged arrays, in yaml format.
+   *   The merged arrays.
    */
   public static function munge($file1, $file2) {
     $file1_contents = (array) self::parseFile($file1);
     $file2_contents = (array) self::parseFile($file2);
 
-    $munged_contents = self::arrayMergeRecursiveExceptEmpty($file1_contents, $file2_contents);
-
-    return Yaml::dump($munged_contents, 3, 2);
+    return self::arrayMergeRecursiveExceptEmpty($file1_contents, $file2_contents);
   }
 
   /**

--- a/src/Robo/Common/YamlMunge.php
+++ b/src/Robo/Common/YamlMunge.php
@@ -41,7 +41,7 @@ class YamlMunge {
    *
    * @throws \Symfony\Component\Yaml\Exception\ParseException
    */
-  protected static function parseFile($file) {
+  public static function parseFile($file) {
     try {
       $value = Yaml::parse(file_get_contents($file));
     }
@@ -50,6 +50,12 @@ class YamlMunge {
     }
 
     return $value;
+  }
+
+  public static function writeFile($file, $contents) {
+    if (!file_put_contents($file_path, Yaml::dump($contents, 3, 2))) {
+      throw new BltException('Unable to write file.');
+    }
   }
 
   /**

--- a/src/Robo/Common/YamlMunge.php
+++ b/src/Robo/Common/YamlMunge.php
@@ -2,8 +2,8 @@
 
 namespace Acquia\Blt\Robo\Common;
 
+use Acquia\Blt\Robo\Exceptions\BltException;
 use Symfony\Component\Yaml\Yaml;
-use Symfony\Component\Yaml\Exception\ParseException;
 
 /**
  * Munges two yaml files.
@@ -42,18 +42,11 @@ class YamlMunge {
    * @throws \Symfony\Component\Yaml\Exception\ParseException
    */
   public static function parseFile($file) {
-    try {
-      $value = Yaml::parse(file_get_contents($file));
-    }
-    catch (ParseException $e) {
-      printf("Unable to parse the YAML string: %s", $e->getMessage());
-    }
-
-    return $value;
+    return Yaml::parse(file_get_contents($file));
   }
 
   public static function writeFile($file, $contents) {
-    if (!file_put_contents($file_path, Yaml::dump($contents, 3, 2))) {
+    if (!file_put_contents($file, Yaml::dump($contents, 3, 2))) {
       throw new BltException('Unable to write file.');
     }
   }

--- a/src/Update/Updater.php
+++ b/src/Update/Updater.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Blt\Update;
 
+use Acquia\Blt\Robo\Common\YamlMunge;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\IndexedReader;
@@ -13,7 +14,6 @@ use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  *
@@ -444,32 +444,28 @@ class Updater {
    * @return mixed
    */
   public function getProjectYml() {
-    $project_yml = Yaml::parse(file_get_contents($this->projectYmlFilepath));
-
-    return $project_yml;
+    return YamlMunge::parseFile($this->projectYmlFilepath);
   }
 
   /**
    * @return mixed
    */
   public function getProjectLocalYml() {
-    $project_yml = Yaml::parse(file_get_contents($this->projectLocalYmlFilepath));
-
-    return $project_yml;
+    return YamlMunge::parseFile($this->projectLocalYmlFilepath);
   }
 
   /**
    * @param $contents
    */
   public function writeProjectYml($contents) {
-    file_put_contents($this->projectYmlFilepath, Yaml::dump($contents, 3, 2));
+    YamlMunge::writeFile($this->projectYmlFilepath, $contents);
   }
 
   /**
    * @param $contents
    */
   public function writeProjectLocalYml($contents) {
-    file_put_contents($this->projectLocalYmlFilepath, Yaml::dump($contents, 3, 2));
+    YamlMunge::writeFile($this->projectLocalYmlFilepath, $contents);
   }
 
   /**


### PR DESCRIPTION
Fixes #2194 

I add a write method to YamlMunge since it already does very similar things. The main benefit here is making sure that we write yaml files in consistent format (spacing and indentation)

It seems like Acquia\Blt\Update\Updater makes a point of not invoking any other BLT-provided methods or classes, hopefully adding a dependency on YamlMunge isn't a problem?
