### PR TITLE
Exclude the NamespacedDependency sniff.

### DIFF
--- a/template/phpcs.xml.dist
+++ b/template/phpcs.xml.dist
@@ -23,7 +23,7 @@
   <rule ref="Drupal"/>
   <rule ref="DrupalPractice">
     <!-- Ignore specific sniffs. -->
-    <!-- <exclude name="DrupalPractice.CodeAnalysis.VariableAnalysis.UnusedVariable"/> -->
+    <exclude name="DrupalPractice.InfoFiles.NamespacedDependency"/>
   </rule>
 
   <file>blt</file>


### PR DESCRIPTION
Changes proposed:
- exclude the NamespacedDependency sniff from PHPCS checks.

Justification:
1. Core does not do namespacing, currently. e.g. http://cgit.drupalcode.org/drupal/tree/core/modules/views_ui/views_ui.info.yml (8.5.x)
2. The practice is recommended, rather than required, and only for contrib modules. https://www.drupal.org/node/2299747
3. It was moved into 'DrupalPractice' sniffs specifically because it results in false postives on custom modules. https://www.drupal.org/node/2854781
4. The `project:module` form does not work with install profiles. https://www.drupal.org/node/2855026
5. People are most likely using BLT as a base for custom projects, which means that the only code that would be subject to this check would be custom, which means it shouldn't be subject to this check (see 2).
6. People who are using BLT as a testbed for writing their contrib modules should already know what they're doing, and can remove the exclusion if they desire. 