### PR TITLE
#2332 include setup:toggle-modules command in sync commands.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -154,6 +154,7 @@ sync:
     - setup:composer:install
     - sync
     - setup:update
+    - setup:toggle-modules
     - frontend
 
 # Custom tasks that are triggered at pre-defined times in the build process.


### PR DESCRIPTION
Fixes #2332, if it's decided that this is appropriate.

Changes proposed:
- fires `setup:toggle-modules` as part of `sync:refresh`
