### PR TITLE
#2332 include setup:toggle-modules command in sync commands (8.9 version).

### DIFF
--- a/src/Robo/Commands/Sync/RefreshCommand.php
+++ b/src/Robo/Commands/Sync/RefreshCommand.php
@@ -60,6 +60,7 @@ class RefreshCommand extends BltTasks {
       'setup:composer:install',
       'sync',
       'setup:update',
+      'setup:toggle-modules',
       'frontend',
     ]);
   }


### PR DESCRIPTION
Fixes #2332 (for 8.9.x branch, which is what we ourselves are currently using).

Changes proposed:
- fire `setup:toggle-modules` as part of `sync:refresh`
