### PR TITLE
Adding site name to local private files path to support multisite.

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -111,7 +111,7 @@ $settings['extension_discovery_scan_tests'] = FALSE;
  * Note: you should test with the config, bootstrap, and discovery caches enabled to
  * test that metadata is cached as expected. However, in the early stages of development,
  * you may want to disable them. Overrides to these bins must be explicitly set for each
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * bin to change the default configuration provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 
@@ -142,6 +142,15 @@ $settings['rebuild_access'] = FALSE;
  * about global configuration override.
  */
 $config['system.file']['path']['temporary'] = '/tmp';
+
+/**
+ * Private file path.
+ */
+$settings['file_private_path'] = "$dir/files-private/$site_dir";
+if (isset($acsf_site_name)) {
+  $settings['file_public_path'] = "sites/default/files/$acsf_site_name";
+  $settings['file_private_path'] = "$repo_root/files-private/$acsf_site_name";
+}
 
 /**
  * Trusted host configuration.

--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -108,9 +108,9 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
+ * Note: you should test with the config, bootstrap, and discovery caches enabled to
  * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
+ * you may want to disable them. Overrides to these bins must be explicitly set for each
  * bin to change the default configuration provided by Drupal core in core.services.yml. 
  * See https://www.drupal.org/node/2754947
  */
@@ -142,15 +142,6 @@ $settings['rebuild_access'] = FALSE;
  * about global configuration override.
  */
 $config['system.file']['path']['temporary'] = '/tmp';
-
-/**
- * Private file path.
- */
-$settings['file_private_path'] = $dir . '/files-private';
-if (isset($acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$acsf_site_name";
-}
 
 /**
  * Trusted host configuration.

--- a/settings/filesystem.settings.php
+++ b/settings/filesystem.settings.php
@@ -5,7 +5,13 @@
  * Contains filesystem settings.
  */
 
+// Local file paths.
 $settings['file_public_path'] = "sites/$site_dir/files";
+$settings['file_private_path'] = "$repo_root/files-private/$site-dir";
+if (isset($acsf_site_name)) {
+  $settings['file_public_path'] = "sites/default/files/$acsf_site_name";
+  $settings['file_private_path'] = "$repo_root/files-private/$acsf_site_name";
+}
 
 // ACSF file paths.
 if ($is_acsf_env) {

--- a/settings/filesystem.settings.php
+++ b/settings/filesystem.settings.php
@@ -5,13 +5,7 @@
  * Contains filesystem settings.
  */
 
-// Local file paths.
 $settings['file_public_path'] = "sites/$site_dir/files";
-$settings['file_private_path'] = "$repo_root/files-private/$site-dir";
-if (isset($acsf_site_name)) {
-  $settings['file_public_path'] = "sites/default/files/$acsf_site_name";
-  $settings['file_private_path'] = "$repo_root/files-private/$acsf_site_name";
-}
 
 // ACSF file paths.
 if ($is_acsf_env) {


### PR DESCRIPTION
Changes proposed:
- ~~Move `$settings['file_private_path']` to `filesystem.settings.php`, alongside `file_public_path`~~
- In default local settings: add site_dir as a sub-folder under `/files-private` to support multisite. Prevents private file/sub-folder collisions between sites. No adjustments needed for deploy-exclude, gitignore, etc.
