### PR TITLE
BLT-2322: Checks if db config matches codebase config.

### DIFF
--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -85,6 +85,8 @@ class BuildCommand extends BltTasks {
    * Generates all required files for a full build.
    *
    * @command setup:build
+   *
+   * @interactConfigIdentical
    */
   public function build() {
     $this->invokeCommands([

--- a/src/Robo/Hooks/InteractHook.php
+++ b/src/Robo/Hooks/InteractHook.php
@@ -100,7 +100,7 @@ class InteractHook extends BltTasks {
   }
 
   /**
-   * Confirms active config matches config in sync directory.
+   * Prompts user to confirm overwrite of active config on blt setup.
    *
    * @hook interact @interactConfigIdentical
    */
@@ -109,17 +109,19 @@ class InteractHook extends BltTasks {
     OutputInterface $output,
     AnnotationData $annotationData
   ) {
-    if ($this->getConfigValue('cm.strategy') == 'config-split') {
-      $drupal_installed = $this->getInspector()->isDrupalInstalled();
-      $config_identical = $this->getInspector()->isActiveConfigIdentical();
-      if (!$config_identical) {
-        $this->logger->warning("The site's active config does not match the config in the sync directory.");
+    $cm_strategies = [
+      'config-split',
+      'core-only',
+    ];
+    if (in_array($this->getConfigValue('cm.strategy'), $cm_strategies)) {
+      if (!$this->getInspector()->isActiveConfigIdentical()) {
+        $this->logger->warning("The active configuration is not identical to the configuration in the export directory.");
         if (!$input->isInteractive()) {
           $this->logger->warning("Run `drush cex` to export the active config to the sync directory.");
         }
         $confirm = $this->confirm("Would you like to proceed anyway?");
         if (!$confirm) {
-          throw new BltException("The site's active config does not match the config in the sync directory.");
+          throw new BltException("The active configuration is not identical to the configuration in the export directory.");
         }
 
       }

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -768,12 +768,14 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    *   TRUE if config is identical.
    */
   public function isActiveConfigIdentical() {
+    $identical = FALSE;
     $result = $this->executor->drush("cex --no")
       ->run();
     $message = trim($result->getMessage());
     if (strpos($message, 'The active configuration is identical to the configuration in the export directory')) {
-      return TRUE;
+      $identical = TRUE;
     }
+    return $identical;
   }
 
 }

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -761,4 +761,19 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
     }
   }
 
+  /**
+   * Determines if the active config is identical to sync directory.
+   *
+   * @return bool
+   *   TRUE if config is identical.
+   */
+  public function isActiveConfigIdentical() {
+    $result = $this->executor->drush("cex --no")
+      ->run();
+    $message = trim($result->getMessage());
+    if (strpos($message, 'The active configuration is identical to the configuration in the export directory')) {
+      return TRUE;
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes #2322 .

Changes proposed:
- Adds an interact hook to prevent users from accidentally overwriting their active config when running a setup command.
