### PR TITLE
Update to Lightning 3.

### DIFF
--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "acquia/lightning": "^2.2.2-alpha2",
+    "acquia/lightning": "^3.0.1",
     "drupal/acquia_connector": "^1.5.0",
     "drupal/cog": "^1.0.0",
     "drupal/qa_accounts": "^1.0.0-alpha1",


### PR DESCRIPTION
Lightning 2 is basically completely broken because it provides a core patch that conflicts with Drupal 8.4.4. Normal downstream projects can work around this by pinning core to 8.4.3, but it breaks BLT project creation without any suitable workaround that I'm aware of.

Seems like we should suggest Lightning 3 instead. The only downside here is that the location of Lightning's submodules changes, which might break existing projects. So maybe we need to add a release note advising people to pin their Lightning version if they're still on 2.