### PR TITLE
Fixing the exit_early command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,5 @@ Copyright (C) 2016 Acquia, Inc.
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+Here is a documentation update only, to show a failing build.


### PR DESCRIPTION
Closes #2403.

First commit shows a `README.md` change only to show Travis builds stalling with existing code.

Second commit (_coming after failure_) introduces a new method of exiting early.

  