### PR TITLE
Revert to Lightning 2.

### DIFF
--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "acquia/lightning": "^3.0.1",
+    "acquia/lightning": "^2.2.7",
     "drupal/acquia_connector": "^1.5.0",
     "drupal/cog": "^1.0.0",
     "drupal/qa_accounts": "^1.0.0-alpha1",


### PR DESCRIPTION
The Lightning team graciously gave us another 2.x release while people are in the process of upgrading, so fortunately BLT doesn't need a new release any more.