### PR TITLE
Use getenv('SHELL') in favor of $_ENV['SHELL']

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -455,7 +455,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
     $user = posix_getpwuid(posix_getuid());
     $home_dir = $user['dir'];
 
-    if (!empty($_ENV['SHELL']) && strstr($_ENV['SHELL'], 'zsh')) {
+    if (strstr(getenv('SHELL'), 'zsh')) {
       $file = $home_dir . '/.zshrc';
     }
     elseif (file_exists($home_dir . '/.bash_profile')) {


### PR DESCRIPTION
There is a possibility of $_ENV being empty if the variables_order setting
in php.ini is not configured properly.

See: http://us.php.net/manual/en/ini.core.php#ini.variables-order

Fixes #2413.

Changes proposed:
- Use `getenv('SHELL')` in favor of `$_ENV['SHELL']`.
