### PR TITLE
Add ability to determine which order modules are enabled/uninstalled during setup:toggle-modules.

### DIFF
--- a/src/Robo/Commands/Setup/ToggleModulesCommand.php
+++ b/src/Robo/Commands/Setup/ToggleModulesCommand.php
@@ -41,13 +41,16 @@ class ToggleModulesCommand extends BltTasks {
     }
 
     if (isset($environment)) {
-      // Enable modules.
-      $enable_key = "modules.$environment.enable";
-      $this->doToggleModules('pm-enable', $enable_key);
-
-      // Uninstall modules.
-      $disable_key = "modules.$environment.uninstall";
-      $this->doToggleModules('pm-uninstall', $disable_key);
+      // Determine if modules should be enabled or uninstalled first.
+      $enable_first = $this->getConfigValue("modules.$environment.enable_first", TRUE);
+      $toggle_operations = ['enable', 'uninstall'];
+      if (FALSE === $enable_first) {
+        $toggle_operations = array_reverse($toggle_operations);
+      }
+      // Execute toggle operations.
+      foreach ($toggle_operations as $toggle_operation) {
+        $this->doToggleModules("pm-$toggle_operation", "modules.$environment.$toggle_operation");
+      }
     }
     else {
       $this->say("Environment is unset. Skipping setup:toggle-modules...");


### PR DESCRIPTION
Changes proposed:
- Add ability to determine which order modules are toggled in (either enabled first or uninstalled first).
    - Adds new boolean configuration value -> modules.$environment.enable_first. Defaults to TRUE to maintain backwards compatibility.

Reasoning:

Gives developer flexibility in managing order which modules are enabled vs uninstalled. This can be important when managing conflicts caused by existing configuration when these modules are enabled or uninstalled.

Use case (somewhat longwinded):

I have a codebase that is leveraging the Features configuration management strategy. I have a feature for managing Search API configuration. In particular, I have an index that depends on the acquia_search Solr server.

I have a feature dedicated to local development which is placed in the enable toggle modules list, and in this feature I have a duplicate configuration of the search index which depends on a local solr server configuration.

When I issue a `sync:refresh` followed by `setup:toggle-modules`, I get an error.

```
Exception: The Search API Server serving this index is currently in read-only mode. in                                                                        [error]
/var/www/docroot/modules/contrib/acquia_connector/acquia_search/src/Plugin/SolrConnector/SearchApiSolrAcquiaConnector.php:202
Stack trace:
#0 /var/www/docroot/modules/contrib/search_api_solr/src/Plugin/search_api/backend/SearchApiSolrBackend.php(865):
Drupal\acquia_search\Plugin\SolrConnector\SearchApiSolrAcquiaConnector->getUpdateQuery()
#1 /var/www/docroot/modules/contrib/search_api_solr/src/Plugin/search_api/backend/SearchApiSolrBackend.php(691):
Drupal\search_api_solr\Plugin\search_api\backend\SearchApiSolrBackend->deleteAllIndexItems(Object(Drupal\search_api\Entity\Index))
#2 /var/www/docroot/modules/contrib/search_api/src/Entity/Server.php(310):
Drupal\search_api_solr\Plugin\search_api\backend\SearchApiSolrBackend->removeIndex(Object(Drupal\search_api\Entity\Index))
#3 /var/www/docroot/modules/contrib/search_api/src/Entity/Index.php(1395):
Drupal\search_api\Entity\Server->removeIndex(Object(Drupal\search_api\Entity\Index))
#4 /var/www/docroot/modules/contrib/search_api/src/Entity/Index.php(1330):
Drupal\search_api\Entity\Index->reactToServerSwitch(Object(Drupal\search_api\Entity\Index))
#5 /var/www/docroot/modules/contrib/search_api/src/Entity/SearchApiConfigEntityStorage.php(51):
Drupal\search_api\Entity\Index->postSave(Object(Drupal\search_api\Entity\SearchApiConfigEntityStorage), true)
#6 /var/www/docroot/core/lib/Drupal/Core/Entity/EntityStorageBase.php(395):
Drupal\search_api\Entity\SearchApiConfigEntityStorage->doPostSave(Object(Drupal\search_api\Entity\Index), true)
#7 /var/www/docroot/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php(259):
Drupal\Core\Entity\EntityStorageBase->save(Object(Drupal\search_api\Entity\Index))
#8 /var/www/docroot/core/lib/Drupal/Core/Entity/Entity.php(364): Drupal\Core\Config\Entity\ConfigEntityStorage->save(Object(Drupal\search_api\Entity\Index))
#9 /var/www/docroot/core/lib/Drupal/Core/Config/Entity/ConfigEntityBase.php(637): Drupal\Core\Entity\Entity->save()
#10 /var/www/docroot/core/lib/Drupal/Core/Config/ConfigInstaller.php(341): Drupal\Core\Config\Entity\ConfigEntityBase->save()
#11 /var/www/docroot/modules/contrib/features/src/FeaturesConfigInstaller.php(106): Drupal\Core\Config\ConfigInstaller->createConfiguration('', Array)
#12 /var/www/docroot/core/lib/Drupal/Core/Config/ConfigInstaller.php(145): Drupal\features\FeaturesConfigInstaller->createConfiguration('', Array)
#13 /var/www/docroot/core/lib/Drupal/Core/Extension/ModuleInstaller.php(248): Drupal\Core\Config\ConfigInstaller->installDefaultConfig('module',
'bax_com_docksal...')
#14 /var/www/docroot/core/lib/Drupal/Core/ProxyClass/Extension/ModuleInstaller.php(83): Drupal\Core\Extension\ModuleInstaller->install(Array, true)
#15 /var/www/vendor/drush/drush/commands/core/drupal/environment.inc(143): Drupal\Core\ProxyClass\Extension\ModuleInstaller->install(Array, true)
#16 /var/www/vendor/drush/drush/commands/core/drupal/environment.inc(210): drush_module_install(Array)
#17 /var/www/vendor/drush/drush/commands/pm/pm.drush.inc(1167): drush_module_enable(Array)
#18 /var/www/vendor/drush/drush/includes/command.inc(422): drush_pm_enable('dblog', 'devel', 'field_ui', 'seckit', 'views_ui', 'features_ui',
'bax_base_featur...', 'bax_com_feature...', 'bax_com_docksal...', 'stage_file_prox...')
#19 /var/www/vendor/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array)
#20 /var/www/vendor/drush/drush/includes/command.inc(199): drush_command('dblog', 'devel', 'field_ui', 'seckit', 'views_ui', 'features_ui',
'bax_base_featur...', 'bax_com_feature...', 'bax_com_docksal...', 'stage_file_prox...')
#21 /var/www/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array)
#22 /var/www/vendor/drush/drush/includes/preflight.inc(66): Drush\Boot\BaseBoot->bootstrap_and_dispatch()
#23 /var/www/vendor/drush/drush/drush.php(12): drush_main()
#24 {main}
[Acquia\Blt\Robo\Tasks\DrushTask]  Exit code 1  Time 8.22s
[error]  Could not toggle modules listed in modules.local.enable. 
```

Here is my toggle configuration:
```
modules:
  local:
    enable: [dblog, devel, field_ui, seckit, views_ui, features_ui, bax_base_feature_configuration, bax_com_feature_configuration, bax_com_docksal_configuration, stage_file_proxy]
    uninstall: [acsf, acquia_connector, shield]
```
This is happening because at the time of enabling my local configuration feature (containing the overridden index object), there is some series of events that causes the index to reset but still try to call up the Acquia server which I can't connect to locally.

Now, I could sleuth my way through the code and Features and try to understand why after my local config module is installed the active config object for the index isn't properly updated with my local server (it should be, but it's not for whatever reason)...

However, the alternative thought to me was "Well, what if before enabling that local configuration module I uninstalled the acquia_search module first?" After adding this new BLT configuration value and trying it out, acquia_search was uninstalled first and no error was thrown when my bax_com_docksal_configuration (my local config module) was enabled. Looking at the Search API dashboard afterwards, that confirmed that the index was now properly assigned to my local Solr server.

TL;DR: Really simple tweak to BLT allowed me to continue operating smoothly.