### PR TITLE
Run tests:behat:definitions from VM if possible.

### DIFF
--- a/src/Robo/Commands/Tests/BehatCommand.php
+++ b/src/Robo/Commands/Tests/BehatCommand.php
@@ -122,6 +122,9 @@ class BehatCommand extends TestsCommandBase {
    * @option mode l (default), i, or needle. Use l to just list definition expressions, i to show definitions with extended info, or needle to find specific definitions.
    *
    * @validateMySqlAvailable
+   * @validateBehatIsConfigured
+   * @validateVmConfig
+   * @executeInDrupalVm
    */
   public function behatDefinitions($options = ['mode' => 'l']) {
     $task = $this->taskBehat($this->getConfigValue('composer.bin') . '/behat')

--- a/src/Robo/Hooks/CommandEventHook.php
+++ b/src/Robo/Hooks/CommandEventHook.php
@@ -95,11 +95,11 @@ class CommandEventHook extends BltTasks {
           if (gettype($value) === 'string') {
             $command_string .= " --$name=$value";
           }
-         else {
-           foreach ($value as $sub_value) {
-             $command_string .= " --$name=$sub_value";
-           }
-         }
+          else {
+            foreach ($value as $sub_value) {
+              $command_string .= " --$name=$sub_value";
+            }
+          }
         }
         else {
           $command_string .= " --$name";

--- a/src/Robo/Hooks/CommandEventHook.php
+++ b/src/Robo/Hooks/CommandEventHook.php
@@ -92,9 +92,14 @@ class CommandEventHook extends BltTasks {
     foreach ($new_input->getOptions() as $name => $value) {
       if ($new_input->getOption($name)) {
         if ($command_definition->getOption($name)->acceptValue()) {
-          foreach ($value as $sub_value) {
-            $command_string .= " --$name=$sub_value";
+          if (gettype($value) === 'string') {
+            $command_string .= " --$name=$value";
           }
+         else {
+           foreach ($value as $sub_value) {
+             $command_string .= " --$name=$sub_value";
+           }
+         }
         }
         else {
           $command_string .= " --$name";


### PR DESCRIPTION
Fixes #2431 .

Changes proposed:
- Handle the type of command option used in the Behat definitions list.
- Run the Behat definitions list command from the VM if possible.
