### PR TITLE
Handle parameters used by Behat definitions list command.

### DIFF
--- a/src/Robo/Hooks/ExecuteInDrupalVmHook.php
+++ b/src/Robo/Hooks/ExecuteInDrupalVmHook.php
@@ -68,8 +68,13 @@ class ExecuteInDrupalVmHook extends BltTasks {
     foreach ($new_input->getOptions() as $name => $value) {
       if ($new_input->getOption($name)) {
         if ($command_definition->getOption($name)->acceptValue()) {
-          foreach ($value as $sub_value) {
-            $command_string .= " --$name=$sub_value";
+          if (gettype($value) === 'string') {
+            $command_string .= " --$name=$value";
+          }
+          else {
+            foreach ($value as $sub_value) {
+              $command_string .= " --$name=$sub_value";
+            }
           }
         }
         else {


### PR DESCRIPTION
Fixes #2431 .

This is a copy of #2432 for 9.1.x-dev.

Tested against the `blt tests:behat:definitions` and `blt tests:behat:definitions --mode=i` commands.

The 9.1.x `blt tests:behat:definitions` already includes the tag to run within the VM, so that wasn't added with this PR.
