### PR TITLE
Fixes #2441 by updating Setup/BuildCommand.php

### DIFF
--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -15,9 +15,7 @@ class BuildCommand extends BltTasks {
   /**
    * Install dependencies, builds docroot, installs Drupal.
    *
-   * @command setup
-   *
-   * @aliases setup:all
+   * @command setup:build
    */
   public function setup() {
     $this->say("Setting up local environment for site '{$this->getConfigValue('site')}' using drush alias @{$this->getConfigValue('drush.alias')}");


### PR DESCRIPTION
Addresses issue opened in #2441 with 8.9.x branches of BLT being unable to set the setup strategy due to AllCommand.php and BuildCommand.php having identical command annotations, and BuildCommand.php always gets chosen over AllCommand.php.