### PR TITLE
Remove export from setup:composer:install.

### DIFF
--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -112,7 +112,7 @@ class BuildCommand extends BltTasks {
    * @command setup:composer:install
    */
   public function composerInstall() {
-    $result = $this->taskExec("export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --ansi --no-interaction")
+    $result = $this->taskExec("composer install --ansi --no-interaction")
       ->dir($this->getConfigValue('repo.root'))
       ->detectInteractive()
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)


### PR DESCRIPTION
Other composer installs from BLT do not enforce failure on patch which
can cause some issues eg. blt deploy will work but blt setup will fail
at composer install. Given that composer patches doesn't fully support ignoring patches dependent projects can introduce patches that may break throughout a build which could cause issues with developer on-boarding.

For consistency all composer installs should follow the same process.

- This can be enforced per project in composer.json with
`"composer-exit-on-patch-failure": true`.

Changes proposed:
- Remove `export COMPOSER_EXIT_ON_PATCH_FAILURE=1` from `setup:composer:install`
