### PR TITLE
Remove export from setup:composer:install

### DIFF
--- a/src/Robo/Commands/Composer/ComposerCommand.php
+++ b/src/Robo/Commands/Composer/ComposerCommand.php
@@ -4,6 +4,7 @@ namespace Acquia\Blt\Robo\Commands\Composer;
 
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Exceptions\BltException;
+use Robo\Contract\VerbosityThresholdInterface;
 
 /**
  * Defines commands in the "composer:*" namespace.
@@ -59,6 +60,39 @@ class ComposerCommand extends BltTasks {
     }
 
     return $result;
+  }
+
+  /**
+   * Performs a composer install.
+   *
+   * @param bool $dev
+   *   Whether or no dev packages should be installed.
+   *
+   * @return bool
+   *   If the command was successful.
+   *
+   * @command composer:install
+   */
+  public function install($dev = TRUE) {
+    $tasks = $this->taskExecStack()
+      ->stopOnFail()
+      ->dir($this->getConfigValue('repo.root'))
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE);
+
+    // Allow an optional cache clear configurable with project.yml.
+    if ($this->getConfig()->has('composer.cache-clear') && $this->getConfigValue('composer.cache-clear')) {
+      $tasks->exec('composer clear-cache --ansi --no-interaction');
+    }
+
+    $command = 'composer install --ansi --no-interaction';
+
+    if (!$dev) {
+      $command .= ' --no-dev --optimize-autoloader';
+    }
+
+    $tasks->exec($command);
+
+    return $tasks->run()->wasSuccessful();
   }
 
 }

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -380,18 +380,18 @@ class DeployCommand extends BltTasks {
    */
   protected function composerInstall() {
     $this->say("Rebuilding composer dependencies for production...");
+
     $this->taskDeleteDir([$this->deployDir . '/vendor'])
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
+
     $this->taskFilesystemStack()
       ->copy($this->getConfigValue('repo.root') . '/composer.json', $this->deployDir . '/composer.json', TRUE)
       ->copy($this->getConfigValue('repo.root') . '/composer.lock', $this->deployDir . '/composer.lock', TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
-    $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader")
-      ->stopOnFail()
-      ->dir($this->deployDir)
-      ->run();
+
+    $this->invokeCommand('composer:install', ['dev' => FALSE]);
   }
 
   /**

--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -112,13 +112,7 @@ class BuildCommand extends BltTasks {
    * @command setup:composer:install
    */
   public function composerInstall() {
-    $result = $this->taskExec("export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --ansi --no-interaction")
-      ->dir($this->getConfigValue('repo.root'))
-      ->detectInteractive()
-      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-      ->run();
-
-    return $result;
+    return $this->invokeCommand('composer:install');
   }
 
 }


### PR DESCRIPTION
Other composer installs from BLT do not enforce failure on patch which
can cause some issues eg. blt deploy will work but blt setup will fail
at composer install. Given that composer patches doesn't fully support ignoring patches dependent projects can introduce patches that may break throughout a build which could cause issues with developer on-boarding.

For consistency all composer installs should follow the same process.

- This can be enforced per project in composer.json with "composer-exit-on-patch-failure": true.

Changes proposed:

- Add `composer:install` command
- Update `setup:composer:install` to invoke `composer:install`.
- Update `deploy` to invoke `composer:install` without dev.
- Add `project.yml` key to control composer cache clearing (for deploy
and setup).
- Remove `export COMPOSER_EXIT_ON_PATCH_FAILURE=1` from the
`composer:install` command ([this can be added in composer.json](https://github.com/cweagans/composer-patches#error-handling) per
project).

