### PR TITLE
BLT-2374: re-enabling features import with drush 9 compatible version…

### DIFF
--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -15,7 +15,8 @@
     "drupal/memcache": "^2.0-alpha5",
     "drupal/seckit": "^1.0.0-alpha2",
     "drupal/security_review": "*",
-    "drupal/shield": "^1.0.0"
+    "drupal/shield": "^1.0.0",
+    "drupal/features": "3.x-dev#2e82a6ad751fc88f771be5b4e53b98a8c6eb66b5"
   },
   "extra": {
     "patches": {

--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -149,9 +149,6 @@ class ConfigCommand extends BltTasks {
    */
   protected function checkFeaturesOverrides() {
     if ($this->getConfigValue('cm.features.no-overrides')) {
-      $this->logger->warning("Features configuration overrides will not be checked due to breaking changes in Drush 9.");
-      $this->logger->warning("This check will be re-enabled after fixes are made in the features module upstream.");
-      return 1;
       // @codingStandardsIgnoreStart
       $this->say("Checking for features overrides...");
       if ($this->getConfig()->has('cm.features.bundle')) {


### PR DESCRIPTION
… of features.

Fixes #2374  .

Changes proposed:
- add features to composer (suggested?) at hash: 2e82a6ad751fc88f771be5b4e53b98a8c6eb66b5 which includes https://www.drupal.org/project/features/issues/2913651
-remove early return in checkFeaturesOverrides() function in src/Robo/Commands/Setup/ConfigCommand.php to allow features import to continue running
