### PR TITLE
PHPUnit tags for tests that fail without a database

### DIFF
--- a/tests/phpunit/BltProject/ConfigImportTest.php
+++ b/tests/phpunit/BltProject/ConfigImportTest.php
@@ -14,6 +14,9 @@ class ConfigImportTest extends BltProjectTestBase {
     $this->importDbFromFixture();
   }
 
+  /**
+   * @group requires-db
+   */
   public function testNoConfig() {
     $this->drush("config-export --yes");
     $this->blt("setup:config-import", [
@@ -23,6 +26,9 @@ class ConfigImportTest extends BltProjectTestBase {
     ]);
   }
 
+  /**
+   * @group requires-db
+   */
   public function testFeatures() {
     $this->drush("pm-enable features --yes");
     $this->drush("config-export --yes");
@@ -33,6 +39,9 @@ class ConfigImportTest extends BltProjectTestBase {
     ]);
   }
 
+  /**
+   * @group requires-db
+   */
   public function testCoreOnly() {
     $this->drush("config-export --yes");
     $this->blt("setup:config-import", [
@@ -42,6 +51,9 @@ class ConfigImportTest extends BltProjectTestBase {
     ]);
   }
 
+  /**
+   * @group requires-db
+   */
   public function testConfigSplit() {
     $this->drush("pm-enable config_split --yes");
     $this->drush("config-export --yes");

--- a/tests/phpunit/BltProject/DoctorTest.php
+++ b/tests/phpunit/BltProject/DoctorTest.php
@@ -6,6 +6,8 @@ use Acquia\Blt\Tests\BltProjectTestBase;
 
 /**
  * Class DoctorTest.
+ *
+ * @group requires-db
  */
 class DoctorTest extends BltProjectTestBase {
 

--- a/tests/phpunit/BltProject/LightningTest.php
+++ b/tests/phpunit/BltProject/LightningTest.php
@@ -6,6 +6,8 @@ use Acquia\Blt\Tests\BltProjectTestBase;
 
 /**
  * Class LightningTest.
+ *
+ * @group requires-db
  */
 class LightningTest extends BltProjectTestBase {
 

--- a/tests/phpunit/BltProject/MultiSiteTest.php
+++ b/tests/phpunit/BltProject/MultiSiteTest.php
@@ -6,6 +6,8 @@ use Acquia\Blt\Tests\BltProjectTestBase;
 
 /**
  * Class MultiSiteTest.
+ *
+ * @group requires-db
  */
 class MultiSiteTest extends BltProjectTestBase {
 

--- a/tests/phpunit/BltProject/SetupCommandTest.php
+++ b/tests/phpunit/BltProject/SetupCommandTest.php
@@ -6,6 +6,8 @@ use Acquia\Blt\Tests\BltProjectTestBase;
 
 /**
  * Class SetupCommandTest.
+ *
+ * @group requires-db
  */
 class SetupCommandTest extends BltProjectTestBase {
 

--- a/tests/phpunit/BltProject/SetupToggleModulesTest.php
+++ b/tests/phpunit/BltProject/SetupToggleModulesTest.php
@@ -6,6 +6,8 @@ use Acquia\Blt\Tests\BltProjectTestBase;
 
 /**
  * Class ToggleModulesTest.
+ *
+ * @group requires-db
  */
 class ToggleModulesTest extends BltProjectTestBase {
 

--- a/tests/phpunit/BltProject/TestBehatCommandTest.php
+++ b/tests/phpunit/BltProject/TestBehatCommandTest.php
@@ -23,7 +23,7 @@ class BehatTest extends BltProjectTestBase {
   }
 
   /**
-   *
+   * @group requires-db
    */
   public function testBehatCommand() {
     $this->installDrupalMinimal();

--- a/tests/phpunit/README.md
+++ b/tests/phpunit/README.md
@@ -8,11 +8,26 @@
 
 ## Customize PHPUnit execution
 
+PHPUnit can be configured either through a configuration file or through command line options. Depending on how often you rerun tests, one may be an easier approach than another.
+
+### XML configuration
 ```
 cp phpunit.xml.dist phpunit.xml
 ```
 
 Edit phpunit.xml.
+
+### CLI options
+
+```
+./vendor/bin/phpunit -my-options
+```
+
+For example, to exclude certain groups of tests,
+
+```
+./vendor/bin/phpunit --exclude-group requires-db
+```
 
 ## Sandbox
 


### PR DESCRIPTION
- Tag tests with `requires-db`
- Update readme with information on using CLI options.

With these tags and excluding this group, I have run all current tests on my local machine.

It's likely that there are additional tests that don't do much without a database, but do not report failures with PHPUnit and do not stop the later tests from running. Those have not been audited.