### PR TITLE
BLT 2477: Updating typhonius/acquia-php-sdk-v2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/twig-bridge": "^3.3",
         "symfony/yaml": "~3.2.8",
         "tivie/php-os-detector": "^1.0",
-        "typhonius/acquia-php-sdk-v2": "^1.0.0",
+        "typhonius/acquia-php-sdk-v2": "^1.0.2",
         "wikimedia/composer-merge-plugin": "^1.4.1"
     },
     "autoload": {


### PR DESCRIPTION
Fixes #2477  .

Changes proposed:
- updates typhonius/acquia-php-sdk-v2 to a version that supports PHP 5.6.x
