### PR TITLE
BLT-2466: updating 9.x update hook to correct alias issues.

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -456,9 +456,11 @@ class Updates {
    * )
    */
   public function update_9000000() {
+    $this->updater->syncWithTemplate('.gitignore', TRUE);
     $this->updater->moveFile('drush/site-aliases/aliases.drushrc.php', 'drush/site-aliases/legacy.aliases.drushrc.php');
+    $this->updater->replaceInFile('drush/site-aliases/legacy.aliases.drushrc.php', "' . drush_server_home() . '", '$HOME');
     $process = new Process(
-      './vendor/bin/drush site:alias-convert $(pwd)/drush/site --sources=$(pwd)/drush/site-aliases',
+      './vendor/bin/drush site:alias-convert $(pwd)/drush/sites --sources=$(pwd)/drush/site-aliases',
       $this->updater->getRepoRoot()
     );
     $process->run();

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -128,3 +128,6 @@ atlassian-ide-plugin.xml
 
 #NPM
 npm-debug.log
+
+# Drush 9 Checksums
+drush/sites/.checksums


### PR DESCRIPTION
Fixes #2466  .

Changes proposed:
- Updating .gitignore to ignore the checksums generated as the aliases get updated
- Re-copying template .gitignore to project root
- Moved new aliases from drush/site to drush/sites 
- Added replacement for ```drush_server_home()```
