### PR TITLE
Install Wizard recipe bugfixes and automated test.

### DIFF
--- a/src/Robo/Commands/Setup/WizardCommand.php
+++ b/src/Robo/Commands/Setup/WizardCommand.php
@@ -5,7 +5,8 @@ namespace Acquia\Blt\Robo\Commands\Setup;
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\StringManipulator;
 use Acquia\Blt\Robo\Common\YamlMunge;
-use Acquia\Club\Configuration\ProjectConfiguration;
+use Acquia\Blt\Robo\Config\ProjectConfiguration;
+use function file_put_contents;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
@@ -44,7 +45,7 @@ class WizardCommand extends BltTasks {
     $this->updateProjectYml($answers);
 
     if (!empty($answers['ci']['provider'])) {
-      $this->invokeCommand("ci:{$answers['ci']['provider']}:init");
+      $this->invokeCommand("recipes:ci:{$answers['ci']['provider']}:init");
     }
 
     if ($answers['vm']) {

--- a/src/Robo/Commands/Setup/WizardCommand.php
+++ b/src/Robo/Commands/Setup/WizardCommand.php
@@ -33,13 +33,13 @@ class WizardCommand extends BltTasks {
     }
     else {
       $answers = $this->askForAnswers();
-    }
 
-    $this->say("<comment>You have entered the following values:</comment>");
-    $this->printArrayAsTable($answers);
-    $continue = $this->confirm("Continue?");
-    if (!$continue) {
-      return 1;
+      $this->say("<comment>You have entered the following values:</comment>");
+      $this->printArrayAsTable($answers);
+      $continue = $this->confirm("Continue?");
+      if (!$continue) {
+        return 1;
+      }
     }
 
     $this->updateProjectYml($answers);

--- a/src/Robo/Config/ProjectConfiguration.php
+++ b/src/Robo/Config/ProjectConfiguration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acquia\Club\Configuration;
+namespace Acquia\Blt\Robo\Config;
 
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/tests/phpunit/BltProject/BltConfigurationWizard.php
+++ b/tests/phpunit/BltProject/BltConfigurationWizard.php
@@ -26,7 +26,7 @@ class BltConfigurationWizard extends BltProjectTestBase {
    * Tests setup:wizard with recipe file option
    */
   public function testWizardUsingRecipe() {
-    $this->blt("setup:wizard", ['--recipe' => 'recipe.yml', '--yes' => '']);
+    $this->blt("setup:wizard", ['--recipe' => 'recipe.yml']);
 
     $recipe = Yaml::parse(
       file_get_contents('recipe.yml')

--- a/tests/phpunit/BltProject/BltConfigurationWizard.php
+++ b/tests/phpunit/BltProject/BltConfigurationWizard.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Acquia\Blt\Tests\Blt;
+
+use Acquia\Blt\Tests\BltProjectTestBase;
+use Symfony\Component\Yaml\Yaml;
+use Acquia\Blt\Robo\Config\ConfigAwareTrait;
+
+/**
+ * Class BltConfigurationWizard.
+ */
+class BltConfigurationWizard extends BltProjectTestBase {
+
+  use ConfigAwareTrait;
+
+  /**
+   * Tests setup:wizard command.
+   */
+  public function testWizard() {
+    $this->markTestIncomplete(
+      'This test has not been implemented yet.'
+    );
+  }
+
+  /**
+   * Tests setup:wizard with recipe file option
+   */
+  public function testWizardUsingRecipe() {
+    $this->blt("setup:wizard", ['--recipe' => 'recipe.yml', '--yes' => '']);
+
+    $recipe = Yaml::parse(
+      file_get_contents('recipe.yml')
+    );
+
+    /*
+     * TODO: Determine if there is a better way to test this.
+     *
+     * The project.yml file seems to be missing most of the values you'd expect.
+     * Is the setup for the PHPUnit tests not copying over the default file as
+     * you would expect?
+     */
+    $project_configuration = Yaml::parse(
+      file_get_contents('blt/project.yml')
+    );
+
+    $config_keys = [
+      'human_name',
+      'machine_name',
+      'prefix',
+      'vm',
+    ];
+
+    foreach($config_keys as $key) {
+      $this->assertEquals($recipe[$key], $project_configuration['project'][$key]);
+    }
+
+  }
+
+}

--- a/tests/phpunit/BltProject/BltConfigurationWizardTest.php
+++ b/tests/phpunit/BltProject/BltConfigurationWizardTest.php
@@ -9,7 +9,7 @@ use Acquia\Blt\Robo\Config\ConfigAwareTrait;
 /**
  * Class BltConfigurationWizard.
  */
-class BltConfigurationWizard extends BltProjectTestBase {
+class BltConfigurationWizardTest extends BltProjectTestBase {
 
   use ConfigAwareTrait;
 

--- a/tests/phpunit/BltProject/BltConfigurationWizardTest.php
+++ b/tests/phpunit/BltProject/BltConfigurationWizardTest.php
@@ -14,7 +14,7 @@ class BltConfigurationWizardTest extends BltProjectTestBase {
   use ConfigAwareTrait;
 
   /**
-   * Tests setup:wizard command.
+   * Tests wizard command.
    */
   public function testWizard() {
     $this->markTestIncomplete(
@@ -23,10 +23,10 @@ class BltConfigurationWizardTest extends BltProjectTestBase {
   }
 
   /**
-   * Tests setup:wizard with recipe file option
+   * Tests wizard with recipe file option
    */
   public function testWizardUsingRecipe() {
-    $this->blt("setup:wizard", ['--recipe' => 'recipe.yml']);
+    $this->blt("wizard", ['--recipe' => 'recipe.yml']);
 
     $recipe = Yaml::parse(
       file_get_contents('recipe.yml')

--- a/tests/phpunit/fixtures/sandbox/blt/project.yml
+++ b/tests/phpunit/fixtures/sandbox/blt/project.yml
@@ -1,0 +1,3 @@
+# This file is included as a placeholder and copied over during the testing.
+# TODO: Determine if this should be managed differently during PHPUnit
+# test setup.

--- a/tests/phpunit/fixtures/sandbox/recipe.yml
+++ b/tests/phpunit/fixtures/sandbox/recipe.yml
@@ -1,0 +1,6 @@
+human_name: "TEST PROJECT"
+machine_name: TEST
+prefix: TST
+vm: false
+ci:
+  provider: pipelines


### PR DESCRIPTION
Change namespace for `Acquia\Blt\Robo\Config\ProjectConfiguration` to use the BLT namespace which matches the folder it's in.

If the recipe is used, the wizard will not ask for confirmation of provided values. It seems odd to ask for confirmation when the recipe is used since there is no user interaction.

I think there is a better way to deal with the sandbox `recipe.yml` file, but I'm not sure what it is. I also think there is a bug or better way to handle the `project.yml` file, but I'm not sure what that is either.