### PR TITLE
Issue 2517: Making config directory dynamic for multisite.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -48,7 +48,7 @@ cm:
     dirs:
       # Corresponding value is defined in config.settings.php.
       sync:
-        path: ${cm.core.path}/default
+        path: ${cm.core.path}/${site}
   features:
     no-overrides: true
 


### PR DESCRIPTION
Fixes #2517.

Changes proposed:
- Make name of config-dir dynamic using the site id
