### PR TITLE
Make allow_failure step in .travis.yml reachable

### DIFF
--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -55,7 +55,7 @@ install:
   - source ${BLT_DIR}/scripts/travis/setup_project
 
 script:
-  - source ${BLT_DIR}/scripts/travis/run_tests
+  - ${BLT_DIR}/scripts/travis/run_tests
 
 deploy:
    - provider: script

--- a/scripts/travis/deploy_branch
+++ b/scripts/travis/deploy_branch
@@ -4,4 +4,4 @@ set -ev
 
 blt deploy --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" --branch "${TRAVIS_BRANCH}-build" --ignore-dirty --no-interaction -v
 
-set +v
+set +ev

--- a/scripts/travis/deploy_tag
+++ b/scripts/travis/deploy_tag
@@ -4,4 +4,4 @@ set -ev
 
 blt deploy --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_TAG}" --tag "${TRAVIS_TAG}-build" --ignore-dirty -v
 
-set +v
+set +ev

--- a/scripts/travis/run_tests
+++ b/scripts/travis/run_tests
@@ -9,4 +9,4 @@ blt validate:all
 ${BLT_DIR}/scripts/travis/tick-tock.sh blt setup --define drush.alias='${drush.aliases.ci}' --define environment=ci --no-interaction --yes -v
 blt tests:all --define drush.alias='${drush.aliases.ci}' --define tests.run-server=true --define environment=ci --yes -v
 
-set +v
+set +ev

--- a/scripts/travis/setup_environment
+++ b/scripts/travis/setup_environment
@@ -38,4 +38,4 @@ sh -e /etc/init.d/xvfb start
 # Installs chromedriver to vendor/bin.
 ${BLT_DIR}/scripts/linux/install-chrome.sh ${COMPOSER_BIN}
 
-set +v
+set +ev

--- a/scripts/travis/setup_project
+++ b/scripts/travis/setup_project
@@ -2,4 +2,4 @@
 
 set -ev
 
-set +v
+set +ev


### PR DESCRIPTION
Posting this as PR b/c I need it as a patch.

Not sure if this should be the extent of the change, or if other bash scripts should change as well, and what other branches this should be opened against...? Any direction here is welcome...

Here is my issue and what I'm trying to solve.
I use a Travis `after_failure` script to upload any behat errors to a 3rd party site. At some point, this stopped working, and I began trying to figure out why. I started by pairing my Travis file down to the bare minimum, and `after_failure` was executing for me. I found that by adding back my `install` scripts (which include the `setup_project` and `setup_environment` scripts), my `after_failure` script stopped running. Based on some Travis reading, a call to `set -e` in any file is changing the behavior of the entire shell, and any error bubbles up and stops the script. I found that by ending these scripts with a `set +e` that it is allowing me to correctly finish the build and hit the `after_failure` script, and still let the build end in error.

I hope that was a clear explanation, but I can try to give more details if possible.