### PR TITLE
Fixes #2563 so that setup no longer requires interaction.

### DIFF
--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -47,6 +47,7 @@ class DrupalCommand extends BltTasks {
       ->option('account-name', $username, '=')
       ->option('account-mail', $this->getConfigValue('drupal.account.mail'))
       ->option('locale', $this->getConfigValue('drupal.locale'))
+      ->option('-y')
       ->verbose(TRUE)
       ->printOutput(TRUE);
 


### PR DESCRIPTION
Fixes #2563  .

Changes proposed:
- adds a -y option to drupal install command

note that the assume(TRUE) doesn't seem to work with drush 9 but option(-y) does.
