### PR TITLE
Fixes #2565 to allow config to be imported for existing sites.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -66,6 +66,14 @@ class ConfigCommand extends BltTasks {
         // necessary configuration file(s) as part of the db update.
         ->drush("updb");
 
+      // Retrieve the config UUID and set site UUID to allow config import
+      // for existing sites.
+      $cm_uuid = $this->getConfigValue('cm.uuid');
+      if ($cm_uuid != NULL) {
+        $task = $this->taskDrush()
+          ->drush("config:set system.site uuid $cm_uuid");
+      }
+
       switch ($strategy) {
         case 'core-only':
           $this->importCoreOnly($task, $cm_core_key);

--- a/template/blt/blt.yml
+++ b/template/blt/blt.yml
@@ -12,6 +12,11 @@ project:
     protocol: http
     hostname: local.${project.machine_name}.com
 
+cm:
+  # This will be used during config-imports to import existing configuration.
+  # Replace with the UUID from your system.site.yml after initial installation.
+  uuid: ''
+
 # Configuration settings for new git repository.
 git:
   default_branch: master

--- a/tests/phpunit/BltProject/ConfigImportTest.php
+++ b/tests/phpunit/BltProject/ConfigImportTest.php
@@ -68,4 +68,15 @@ class ConfigImportTest extends BltProjectTestBase {
     ]);
   }
 
+  /**
+   * @group requires-db
+   */
+  public function testExistingConfig() {
+    $this->blt("setup", [
+      '--define' => [
+        'project.profile.name=lightning',
+      ],
+    ]);
+  }
+  
 }


### PR DESCRIPTION
Fixes #2565  .

Changes proposed:
- sets the UUID in current drupal install to match "config" version as defined in project / blt yml file
- adds cm.uuid to the templates/blt.yml file