### PR TITLE
Update patch to clear Twig caches on deploys

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -50,7 +50,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/core": {
-        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-90.patch"
+        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-114.patch"
       }
     }
   },


### PR DESCRIPTION
The patch BLT is using to clear Twig caches on deploys is very outdated and even failed tests. It would seem using the latest patch (which passes tests) would be better.

Before committing this change **it'd be ideal to confirm everything works as anticipated**.