### PR TITLE
Refactoring how git hooks are installed so they are found from yml configuration.

### DIFF
--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -199,7 +199,7 @@ class SettingsCommand extends BltTasks {
    * @aliases big setup:git-hooks
    */
   public function gitHooks() {
-    foreach (['pre-commit', 'commit-msg'] as $hook) {
+    foreach ($this->getConfigValue('git.hooks') as $hook => $path) {
       $this->installGitHook($hook);
     }
   }


### PR DESCRIPTION
I'm using BLT on a project and I'd like a post-merge hook along the lines of https://gist.github.com/sindresorhus/7996717. I was unable to add the new hook via project.yml because the way that the git hooks were being installed via `blt setup:git-hooks`. The documentation makes it sound like it should work automatically in this way, but the hooks are installed from a hard coded array.

Changes proposed:
- Search for available git hooks to install via yml configuration instead of a hard coded array.
