### PR TITLE
Update (again) the patch to clear Twig caches on deploys

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -50,7 +50,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/core": {
-        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-114.patch"
+        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-130.patch"
       }
     }
   },


### PR DESCRIPTION
This is a follow-up to #2570 since there was a new patch that was just posted. See https://www.drupal.org/project/drupal/issues/2752961#comment-12496589 (which passes tests)