### PR TITLE
Use HEAD of main Lightning branch

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -22,7 +22,7 @@
     "dmore/chrome-mink-driver": "2.4.0",
     "dmore/behat-chrome-extension": "^1.0.0",
     "mikey179/vfsStream": "~1.2",
-    "sensiolabs-de/deprecation-detector": "^0.1.0-alpha4"
+    "sensiolabs-de/deprecation-detector": "dev-master"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "acquia/lightning": "3.1.x-dev",
+    "acquia/lightning": "8.x-3.x-dev",
     "drupal/acquia_connector": "^1.5.0",
     "drupal/acquia_purge": "^1.0-beta3",
     "drupal/cog": "^1.0.0",


### PR DESCRIPTION
HEAD of the main Lightning branch (8.x-3.x - from which we will cut the 3.1.0 tag) now requires core ~8.5.0 - so we can use that instead of the 3.1.x testing branch.