### PR TITLE
Requiring drupal/core:^8.5.0, acquia/lightning:^3.1.0.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "drupal/core": "^8.5.0-beta1",
+    "drupal/core": "^8.5.0",
     "drupal/config_split": "^1.0.0"
   },
   "require-dev": {

--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "acquia/lightning": "8.x-3.x-dev",
+    "acquia/lightning": "^3.1.0",
     "drupal/acquia_connector": "^1.5.0",
     "drupal/acquia_purge": "^1.0-beta3",
     "drupal/cog": "^1.0.0",


### PR DESCRIPTION
This is premature and should fail. These requirements are not available yet. Re-run Travis CI build after releases are available.