### PR TITLE
Require PHP 7.1 in all the right places.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "type": "composer-plugin",
     "license": "GPL-2.0-only",
     "require": {
-        "php": ">=7",
+        "php": ">=7.1",
         "composer-plugin-api": "^1.0.0",
         "composer/installers": "^1.2.0",
         "composer/semver": "^1.4",

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -25,7 +25,6 @@ cache:
   - "$HOME/.drush/cache"
   - "$HOME/.npm"
   - "$HOME/.nvm"
-  - "vendor"
   - ".rules"
   # Cache front end dependencies to dramatically improve build time.
   # - "docroot/themes/custom/mytheme/node_modules"
@@ -63,16 +62,16 @@ deploy:
      skip_cleanup: true
      on:
        branch: develop
-       php: 5.6
+       php: 7.1
    - provider: script
      script: "${BLT_DIR}/scripts/travis/deploy_branch"
      skip_cleanup: true
      on:
        branch: master
-       php: 5.6
+       php: 7.1
    - provider: script
      script: "${BLT_DIR}/scripts/travis/deploy_tag"
      skip_cleanup: true
      on:
        tags: true
-       php: 5.6
+       php: 7.1

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: php
 dist: trusty
 


### PR DESCRIPTION
This is considered a bug fix. 9.0.0 should have required this since it's already the default PHP version in Drupal VM and acquia-pipelines.yml. Without this fix, it's possible to build dependencies in the VM that cannot be installed on Travis CI or run in the cloud.