### PR TITLE
Add shim for symfony console 3.4 upgrade.

### DIFF
--- a/bin/blt-robo-run.php
+++ b/bin/blt-robo-run.php
@@ -31,7 +31,9 @@ $processor->extend($loader->load($config->get('repo.root') . '/blt/project.yml')
 $processor->extend($loader->load($config->get('repo.root') . '/blt/project.local.yml'));
 
 if ($input->hasParameterOption('environment')) {
-  $processor->extend($loader->load($config->get('repo.root') . '/blt/' . $input->getParameterOption('environment') . '.yml'));
+  // Symfony console 3.4 shim.
+  $env = ltrim($input->getParameterOption('environment'), '=');
+  $processor->extend($loader->load($config->get('repo.root') . '/blt/' . $env . '.yml'));
 }
 
 $config->import($processor->export());


### PR DESCRIPTION
Upgraded to `8.9.14` in order to upgrade Drupal core. When I upgrade to core 8.5, my symfony/console package was upgraded to 3.4 due to some other dependencies. It seems like this upgrade is causing BLT to no longer import the correct environment file (ci.yml, in particular).

The value of `$input->getParameterOption('environment')` before the upgrade was `ci`, and now it's `=ci`. This proposed shim will just strip the equals from the left of the string, if it exists.

I believe this is ONLY relevant to 8.9.x branch.