### PR TITLE
Run drush cr instead off cc-drush in SyncCommand.

### DIFF
--- a/src/Robo/Commands/Sync/DbCommand.php
+++ b/src/Robo/Commands/Sync/DbCommand.php
@@ -80,7 +80,7 @@ class DbCommand extends BltTasks {
       }
     }
 
-    $task->drush('cache-clear drush');
+    $task->drush('cr');
 
     $result = $task->run();
 


### PR DESCRIPTION
I realize this is an edge case, but I wanted to post it and get some feedback.

#### Background
I have a site with the `domain` module. My current version is 6+ months old. I am trying to update.
I have Travis testing all my PRs. I do some additional tests outside of BLT default such as running `sync:refresh` command at the end of `run_tests` to ensure code doesn't error with existing database.

#### Problem
I updated the `domain` module and run `sync:refresh`.  💣 
This is because in `alpha10` release of this module, the maintainer changed his ConfigStorage to a custom class. `sync:refresh` runs `drush sql-snyc && drush cc drush` commands. My error is happening at the `drush cc drush` call.
I need a full `drush cr` or else this update just completely doesn't work. I'm not sure why, but the `drush cc drush` leaves some cache tables intact and the old config storage class is still associated with those objects.

---

So I'm sure someone else could have some kind of similar problem here... If this approach is acceptable, I can put up a PR for the `9.0.x` branch as well...?
Without this approach, I have no idea how I could a) make my build pass Travis to get the code merged, or b) allow fellow devs, after this goes in, to update their local copy of the site.

I know that my code works and I wouldnt have a problem DEPLOYING this code, but it's still an update that won't run correctly without this fix.

Thanks!





_Going to use this PR as a patch._