### PR TITLE
Update composer.required.json.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -34,11 +34,6 @@
       "Acquia\\Blt\\Custom\\": "src/"
     }
   },
-  "config": {
-    "platform": {
-      "php": "7"
-    }
-  },
   "extra": {
     "composer-exit-on-patch-failure": true,
     "drupal-scaffold": {


### PR DESCRIPTION
We shouldn't define the platform config as 7, especially when 7.1 is required.