### PR TITLE
Run drush cr instead off cc-drush in SyncCommand.

### DIFF
--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -144,7 +144,7 @@ class SyncCommand extends BltTasks {
       $task->drush('sql-sanitize');
     }
 
-    $task->drush('cache-clear drush');
+    $task->drush('cr');
     $task->drush('sqlq "TRUNCATE cache_entity"');
 
     $result = $task->run();


### PR DESCRIPTION
Copy of #2619 for `9.x` branch.

In a nutshell, a `$ drush cc drush` is not enough "cache clearing" in all situations.