### PR TITLE
checkUriResponse should better indicate whether /etc/hosts is correctly configured

### DIFF
--- a/src/Robo/Commands/Doctor/WebUriCheck.php
+++ b/src/Robo/Commands/Doctor/WebUriCheck.php
@@ -43,6 +43,7 @@ class WebUriCheck extends DoctorCheck {
       $this->logProblem(__FUNCTION__, [
         "Did not get a response from {$this->drushStatus['uri']}",
         "Is your *AMP stack running?",
+        "Is your /etc/hosts file correctly configured?",
         "Is your web server configured to serve this URI from {$this->drushStatus['root']}?",
         "Is options.uri set correctly in {$this->localSiteDrushYml}?",
       ], 'error');


### PR DESCRIPTION
Context: I had `/etc/hosts` configured as such:

```
203.0.113.10	drucker.local drucker
```

Since I didn't have `blt.local`, Robo kept on complaining with the below error:

```
Did not get a response from http://blt.local
Is your *AMP stack running?
Is your web server configured to serve this URI from
/var/www/html/blt/docroot?
Is options.uri set correctly in /var/www/html/blt/docroot/sites/default/local.drush.yml?
```

We're currently checking for Apache running, Apache vHosts and Drush URI. We're missing `/etc/hosts`. This led me into [fixing a bug in my stack](https://github.com/anavarre/drucker/commit/8da0bead321c5e2e3d5fef293ce18230a9bceb81), but I'd have loved if BLT could have informed me instead of looking around.