### PR TITLE
Suggest typhonius/acquia_cli v1.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     },
     "suggest": {
         "hirak/prestissimo": "^0.3",
-        "typhonius/acquia_cli": "^0.0.7",
+        "typhonius/acquia_cli": "^1.0",
         "davereid/drush-acquia-hook-invoke": "dev-master"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Acquia Cli v1.0.0+ fixes deprecated dependency warnings. 

Changes proposed:
- Update suggestion to stable supported Acquia Cli version
