### PR TITLE
Revert back to requiring php 5.6 as the minimum php version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 dist: trusty
 
 php:
-  - 7.1
+  - 5.6
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,5 +83,5 @@ deploy:
     skip_cleanup: true
     on:
       branch: $DEPLOY_SOURCE_BRANCH
-      php: 7.1
+      php: 5.6
       condition: $DRUPAL_CORE_VERSION = default

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 
 php:
   - 5.6
+  - 7.1
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "type": "composer-plugin",
     "license": "GPL-2.0-only",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7",
         "composer-plugin-api": "^1.0.0",
         "composer/installers": "^1.2.0",
         "composer/semver": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "type": "composer-plugin",
     "license": "GPL-2.0-only",
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "composer-plugin-api": "^1.0.0",
         "composer/installers": "^1.2.0",
         "composer/semver": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "type": "composer-plugin",
     "license": "GPL-2.0-only",
     "require": {
-        "php": ">=7",
+        "php": ">=5.6",
         "composer-plugin-api": "^1.0.0",
         "composer/installers": "^1.2.0",
         "composer/semver": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "type": "composer-plugin",
     "license": "GPL-2.0-only",
     "require": {
-        "php": ">=7.1",
+        "php": ">=5.6",
         "composer-plugin-api": "^1.0.0",
         "composer/installers": "^1.2.0",
         "composer/semver": "^1.4",

--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -74,7 +74,7 @@ npm_config_prefix: "/home/{{ drupalvm_user }}/.npm-global"
 installed_extras: ${installed_extras}
 
 # PHP 7
-php_version: "7.1"
+php_version: "5.6"
 php_packages_extra:
   - "php{{ php_version }}-bz2"
   - "php{{ php_version }}-imagick"

--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -2,7 +2,7 @@ version: 1.1.0
 services:
   - mysql
   - php:
-      version: 7.1
+      version: 5.6
 
 variables:
   global:

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -1,4 +1,4 @@
-sudo: true
+sudo: false
 language: php
 dist: trusty
 
@@ -25,6 +25,7 @@ cache:
   - "$HOME/.drush/cache"
   - "$HOME/.npm"
   - "$HOME/.nvm"
+  - "vendor"
   - ".rules"
   # Cache front end dependencies to dramatically improve build time.
   # - "docroot/themes/custom/mytheme/node_modules"
@@ -62,16 +63,16 @@ deploy:
      skip_cleanup: true
      on:
        branch: develop
-       php: 7.1
+       php: 5.6
    - provider: script
      script: "${BLT_DIR}/scripts/travis/deploy_branch"
      skip_cleanup: true
      on:
        branch: master
-       php: 7.1
+       php: 5.6
    - provider: script
      script: "${BLT_DIR}/scripts/travis/deploy_tag"
      skip_cleanup: true
      on:
        tags: true
-       php: 7.1
+       php: 5.6

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: php
 dist: trusty
 
@@ -28,7 +28,6 @@ cache:
   - "$HOME/.drush/cache"
   - "$HOME/.npm"
   - "$HOME/.nvm"
-  - "vendor"
   - ".rules"
   # Cache front end dependencies to dramatically improve build time.
   # - "docroot/themes/custom/mytheme/node_modules"

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -2,8 +2,11 @@ sudo: false
 language: php
 dist: trusty
 
+# Adjust the version of PHP to match your production environment.
+# Making this version number greater than the production environment can unintended consequences including a
+# non-functional prod environment.
 php:
-  - 7.1
+  - 5.6
 
 matrix:
   fast_finish: true
@@ -57,6 +60,7 @@ install:
 script:
   - source ${BLT_DIR}/scripts/travis/run_tests
 
+# The version below MUST match the php version indicated at the top of this file, otherwise the artifact won't build.
 deploy:
    - provider: script
      script: "${BLT_DIR}/scripts/travis/deploy_branch"

--- a/src/Robo/Config/ConfigAwareTrait.php
+++ b/src/Robo/Config/ConfigAwareTrait.php
@@ -9,9 +9,7 @@ use Robo\Common\ConfigAwareTrait as RoboConfigAwareTrait;
  */
 trait ConfigAwareTrait {
 
-  use RoboConfigAwareTrait {
-    config as roboConfig;
-  }
+  use RoboConfigAwareTrait;
 
   /**
    * Gets a config value for a given key.

--- a/src/Robo/Config/ConfigAwareTrait.php
+++ b/src/Robo/Config/ConfigAwareTrait.php
@@ -9,7 +9,9 @@ use Robo\Common\ConfigAwareTrait as RoboConfigAwareTrait;
  */
 trait ConfigAwareTrait {
 
-  use RoboConfigAwareTrait;
+  use RoboConfigAwareTrait {
+    config as roboConfig;
+  }
 
   /**
    * Gets a config value for a given key.

--- a/src/Robo/Hooks/WebServerHook.php
+++ b/src/Robo/Hooks/WebServerHook.php
@@ -4,7 +4,6 @@ namespace Acquia\Blt\Robo\Hooks;
 
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\IO;
-use Acquia\Blt\Robo\Config\ConfigAwareTrait;
 use Acquia\Blt\Robo\Inspector\InspectorAwareTrait;
 use Consolidation\AnnotatedCommand\CommandData;
 use League\Container\ContainerAwareTrait;

--- a/src/Robo/Hooks/WebServerHook.php
+++ b/src/Robo/Hooks/WebServerHook.php
@@ -15,7 +15,6 @@ use Psr\Log\LoggerAwareTrait;
  */
 class WebServerHook extends BltTasks {
 
-  use ConfigAwareTrait;
   use ContainerAwareTrait;
   use LoggerAwareTrait;
   use InspectorAwareTrait;

--- a/src/Robo/Hooks/WebServerHook.php
+++ b/src/Robo/Hooks/WebServerHook.php
@@ -3,21 +3,12 @@
 namespace Acquia\Blt\Robo\Hooks;
 
 use Acquia\Blt\Robo\BltTasks;
-use Acquia\Blt\Robo\Common\IO;
-use Acquia\Blt\Robo\Inspector\InspectorAwareTrait;
 use Consolidation\AnnotatedCommand\CommandData;
-use League\Container\ContainerAwareTrait;
-use Psr\Log\LoggerAwareTrait;
 
 /**
  * Starts and kills Drush webserver for @launchWebServer annotation.
  */
 class WebServerHook extends BltTasks {
-
-  use ContainerAwareTrait;
-  use LoggerAwareTrait;
-  use InspectorAwareTrait;
-  use IO;
 
   protected $serverUrl;
   protected $serverPort;

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -788,7 +788,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function warnIfPhpOutdated() {
-    $minimum_php_version = 7;
+    $minimum_php_version = 5.6;
     $current_php_version = phpversion();
     if ($current_php_version < $minimum_php_version) {
       throw new BltException("BLT requires PHP $minimum_php_version or greater. You are using $current_php_version.");


### PR DESCRIPTION
This reverts back all the php7 changes that was performed after beta3 was released.

Note: We should be documenting that if you're using php7 locally, you'll need to manually update configuration files to support php7. While its unfortunate that we support both versions of PHP, we must continue to do so until our product roadmap makes it EOL, which is slated for the end of 2018.
