### PR TITLE
Fixes two small 8.9 bugs (simplesaml:build:config & sync:refresh).

### DIFF
--- a/src/Robo/Commands/Saml/SimpleSamlPhpCommand.php
+++ b/src/Robo/Commands/Saml/SimpleSamlPhpCommand.php
@@ -193,6 +193,15 @@ class SimpleSamlPhpCommand extends BltTasks {
   }
 
   /**
+   * @hook post-command setup:composer:install
+   */
+  public function simpleSamlPhpBuildConfigAfterComposer() {
+    if ($this->getConfig()->has('simplesamlphp') && $this->getConfigValue('simplesamlphp')) {
+      $this->invokeCommand('simplesamlphp:build:config');
+    }
+  }
+
+  /**
    * Outputs a message to edit the new config files.
    */
   protected function outputCompleteSetupInstructions() {

--- a/src/Robo/Commands/Sync/RefreshCommand.php
+++ b/src/Robo/Commands/Sync/RefreshCommand.php
@@ -54,6 +54,7 @@ class RefreshCommand extends BltTasks {
    * local db, re-imports config, and executes db updates.
    *
    * @command sync:refresh
+   * @executeInDrupalVm
    */
   public function refreshDefault() {
     $this->invokeCommands([


### PR DESCRIPTION
I keep making these two small changes locally, so wanted to put them up for feedback and consideration. I can break up if desired.

When I run the `$ blt sync:refresh` command from a computer running the VM, it fails b/c it doesn't run it in the VM. I know this is going away in 9.0, but it's a pain in the butt to remember that's the only command I have to run iNSIDE the VM in 8.9.

We recently made some changes to simplesamlphp library, and the vendor library folder is constantly being updated when switching branches. We're most often running `$ blt sync:refresh` and when composer updates the library, the config file is gone. This adds a post-command to the composer update command to make sure the file is always there.

This one to me _maybe_ makes sense for 9.x? If it's desired, I can break this out and push a PR for 9.x as well. I hope this approach is OK?