### PR TITLE
ACSF Cloud Hooks / Factory Hooks Enhancements

### DIFF
--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -7,12 +7,12 @@ drush_alias=${site}'.'${target_env}
 
 deploy_updates() {
 
-  case $target_env in
-    01dev|01test)
+  case $target_env in 
+    [0-9][1-9](dev|test))
       acsf_deploy
       ;;
-    # Do not run deploy updates on 01live in case a branch is deployed in prod. 
-    01devup|01testup|01update|01live)
+    # Do not run updates on update or live environments. 
+    [0-9][1-9](devup|testup|update)|[0-9][1-9](live))
       ;;
     ode[[:digit:]]*)
       deploy_install

--- a/scripts/cloud-hooks/functions.sh
+++ b/scripts/cloud-hooks/functions.sh
@@ -8,10 +8,14 @@ drush_alias=${site}'.'${target_env}
 deploy_updates() {
 
   case $target_env in
-    01dev|01test|01live)
+    01dev|01test)
       acsf_deploy
       ;;
-    01devup|01testup|01update)
+    # Do not run deploy updates on 01live in case a branch is deployed in prod. 
+    01devup|01testup|01update|01live)
+      ;;
+    ode[[:digit:]]*)
+      deploy_install
       ;;
     *)
       ace_deploy
@@ -69,6 +73,24 @@ ace_deploy() {
   fi
 
   echo "Finished updates for environment: $target_env"
+}
+
+deploy_sync() {
+
+  echo "Running sync refresh for environment: $target_env"
+
+  # Prep for BLT commands.
+  repo_root="/var/www/html/$site.$target_env"
+  export PATH=$repo_root/vendor/bin:$PATH
+  cd $repo_root
+
+  blt deploy:sync:refresh --define environment=$target_env -v -y
+  if [ $? -ne 0 ]; then
+      echo "Sync errored."
+      exit 1
+  fi
+
+  echo "Finished sync for environment: $target_env"
 }
 
 deploy_install() {

--- a/scripts/cloud-hooks/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/scripts/cloud-hooks/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -20,9 +20,13 @@ repo_url="$5"
 repo_type="$6"
 
 
+acsf_file="/mnt/files/$site.$target_env/files-private/sites.json"
+if [ ! -f $acsf_file ]; then
   . /var/www/html/$site.$target_env/vendor/acquia/blt/scripts/cloud-hooks/functions.sh
   deploy_updates
+fi
   # Send notifications to Slack, if configured. See readme/deploy.md for setup instructions.
   . `dirname $0`/../slack.sh
+
 
 set +v

--- a/settings/acsf/db-update/db-update.sh
+++ b/settings/acsf/db-update/db-update.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Factory Hook: db-update
+#
+# The existence of one or more executable files in the
+# /factory-hooks/db-update directory will prompt them to be run *instead of* the
+# regular database update (drush updatedb) command. So that update command will
+# normally be part of the commands executed below.
+#
+# Usage: post-code-deploy site env db-role domain custom-arg
+# Map the script inputs to convenient names.
+# Acquia hosting site / environment names
+site="$1"
+env="$2"
+# database role. (Not expected to be needed in most hook scripts.)
+db_role="$3"
+# The public domain name of the website.
+domain="$4"
+
+# BLT executable:
+blt="/var/www/html/$site.$env/vendor/acquia/blt/bin/blt"
+
+deployupdate="$blt artifact:update:drupal:all-sites --define environment=$env --define drush.uri=$domain --verbose --yes"
+
+$deployupdate

--- a/settings/acsf/post-install/post-install.php
+++ b/settings/acsf/post-install/post-install.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Factory Hook: post-install.
+ *
+ * This hook enables you to execute PHP after a new website is created
+ * in your subscription. Unlike most API-based hooks, this hook does not
+ * take arguments, but instead executes the PHP code it is provided.
+ *
+ * This is used so that an ACSF site install will match a local BLT site
+ * install. After a local site install, the update functions are run.
+ *
+ */
+
+$site = $_ENV['AH_SITE_GROUP'];
+$env = $_ENV['AH_SITE_ENVIRONMENT'];
+
+// The public domain name of the website.
+// Run updates against requested domain rather than acsf primary domain.
+$domain = $_SERVER['HTTP_HOST'];
+
+exec("/mnt/www/html/$target_env/vendor/acquia/blt/bin/blt artifact:update:drupal --define environment=$env --define drush.uri=$domain --verbose --yes");

--- a/settings/acsf/post-settings-php/includes.php
+++ b/settings/acsf/post-settings-php/includes.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Example implementation of ACSF post-settings-php hook.
+ *
+ * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
+ */
+
+// Set config directories to default location.
+$config_directories['vcs'] = '../config/default';
+$config_directories['sync'] = '../config/default';

--- a/settings/acsf/post-theme-deploy/clear-twig-cache.sh
+++ b/settings/acsf/post-theme-deploy/clear-twig-cache.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Clears TWIG cache for a site after a theme deploy. Executes via drush alias.
+# See https://docs.acquia.com/site-factory/theme/external#refresh.
+# $1 = The hosting site group.
+# $2 = The hosting environment.
+# $5 = The site domain.
+site="$1"
+env="$2"
+
+# local drush  executable:
+repo="/var/www/html/$site.$env"
+
+cd $repo
+drush @$1.$2 --uri=$5 ev '\Drupal\Core\PhpStorage\PhpStorageFactory::get("twig")->deleteAll();'


### PR DESCRIPTION
Fixes #2673 and #2676

This is a mix of backports and enhancements. 

Changes proposed:
- Support additional environment stages and Stacks following the standard xxdev / xxtest / xxlive syntax
- Excludes non-standard update environments / Stacks and production environment from Cloud Hook scripts
- Disables `post-code-update` Cloud Hook execution on ACSF
- Adds `post-install`, `db-update`, and `post-theme-refresh` Factory Hooks
- Updates `post-settings-php` Factory Hook
