### PR TITLE
Remove over-aggressive "Icon" .gitignore rule (8.9.x)

### DIFF
--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -16,7 +16,6 @@ reports
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
The `Icon` rule in `blt/scripts/blt/deploy/.gitignore` is too aggressive. It causes the `docroot/core/lib/Drupal/Core/Layout/Icon` directory that's now a part of Drupal core to be omitted from the build artifact.

c.f. https://github.com/acquia/blt/pull/2683 for PR to 9.x branch.