### PR TITLE
BLT always reports configuration overridden

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -814,7 +814,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
   public function isActiveConfigIdentical() {
     $result = $this->executor->drush("config:status")->run();
     $message = trim($result->getMessage());
-    $identical = strstr($message, 'No differences between DB and sync directory') !== FALSE;
+    $identical = empty($message);
 
     return $identical;
   }


### PR DESCRIPTION
Whenever I run `blt setup`, it always complains that configuration has been overridden, even though it hasn't:

>[warning] The active configuration is not identical to the configuration in the export directory.
[warning] This means that you have not exported all of your active configuration.
[warning] Run drush cex to export the active config to the sync directory.
[warning] Continuing will overwrite the active configuration.

The problem is that getMessage() in the inspector class returns null when configuration is not overridden, but BLT expects it to return a string. I'm not sure if this ever worked, or if it used to work what changed to break it--maybe something in Drush or how Robo is returning strings. Might be worth looking into.

Anyway, this PR fixes it.

I'm running drush 9.2.1 and blt 9.0.5