### PR TITLE
Fixes #2705: moving features override functionality and re-enabling.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -86,6 +86,11 @@ class ConfigCommand extends BltTasks {
 
         case 'features':
           $this->importFeatures($task, $cm_core_key);
+
+          if ($this->getConfigValue('cm.features.no-overrides')) {
+            // @codingStandardsIgnoreLine
+            $this->checkFeaturesOverrides();
+          }
           break;
       }
 
@@ -93,12 +98,6 @@ class ConfigCommand extends BltTasks {
       $result = $task->run();
       if (!$result->wasSuccessful()) {
         throw new BltException("Failed to import configuration!");
-      }
-
-      if ($this->getConfigValue('cm.features.no-overrides')) {
-        $this->logger->warning("Features override checks are currently disabled due to a Drush 9 incompatibility.");
-        // @codingStandardsIgnoreLine
-        // $this->checkFeaturesOverrides();
       }
 
       $this->checkConfigOverrides($cm_core_key);


### PR DESCRIPTION
Fixes #2705  .

Changes proposed:
- re-enable features override check
- stop running features override check outside of features configuration processing
