### PR TITLE
adding the apache vhost for the Drupal VM Dashboard

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -36,6 +36,11 @@ apache_vhosts:
     serveralias: "www.{{ drupal_domain }}"
     documentroot: "{{ drupal_core_path }}"
     extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
+  # Domain for the Drupal VM Dashboard
+  - servername: "dashboard.{{ drupal_domain }}"
+    serveralias: "www.dashboard.{{ drupal_domain }}"
+    documentroot: "/var/www/dashboard"
+    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
 #  - servername: "local.second-drupal-site.com"
 #    documentroot: "{{ drupal_core_path }}"
 #    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"


### PR DESCRIPTION
Problem/Motivation: Unable to easily get access to the Drupal VM Dashboard at `dashboard.local.example.test` without going through extra steps despite a message after running `vagrant up` that says `* Visit the dashboard for an overview of your site: http://dashboard.local.example.test (or http://192.168.28.101)`

Changes proposed:
- Add the Drupal VM Dashboard to the default vhosts file in the Drupal VM Vagrant Box.
