### PR TITLE
Allow config_splits to be enabled when config files are not exported.

### DIFF
--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -86,26 +86,22 @@ if (!isset($split)) {
 }
 
 // Enable the environment split only if it exists.
-if ($split != 'none' && file_exists("$split_filepath_prefix.$split.yml")) {
+if ($split != 'none') {
   $config["$split_filename_prefix.$split"]['status'] = TRUE;
 }
 
 /**
  * Set multisite split.
  */
-if (file_exists("$split_filepath_prefix.$site_dir.yml")) {
-  $config["$split_filename_prefix.$site_dir"]['status'] = TRUE;
-}
+$config["$split_filename_prefix.$site_dir"]['status'] = TRUE;
 
 // Set acsf site split.
-if (isset($acsf_site_name) && file_exists("$split_filepath_prefix.$acsf_site_name.yml")) {
+if (isset($acsf_site_name)) {
   $config["$split_filename_prefix.$acsf_site_name"]['status'] = TRUE;
 }
 
 // Set profile split.
 if (array_key_exists('install_profile', $settings)) {
   $active_profile = $settings['install_profile'];
-  if (file_exists("$split_filepath_prefix.$active_profile.yml")) {
-    $config["$split_filename_prefix.$active_profile"]['status'] = TRUE;
-  }
+  $config["$split_filename_prefix.$active_profile"]['status'] = TRUE;
 }


### PR DESCRIPTION
Fixes #2715 

Changes proposed:
- Do no check if file exists, that means, do not check if config is exported, in order to enable config splits. The config_split can exists and not be exported yet, for example in installation profiles. If the config_split does not exist, nothing will happen so there is no problem to add this extra config overrides to the $config array
