### PR TITLE
Fixes #2707 by resyncing the ci.blt.yml with the template file.

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -540,7 +540,7 @@ class Updates {
    *
    * @Update(
    *    version = "9001000",
-   *    description = "Add deployment_identifier to project .gitignore."
+   *    description = "Add deployment_identifier to project .gitignore and re-syncs ci.blt.yml."
    * )
    */
   public function update_9001000() {
@@ -551,5 +551,14 @@ class Updates {
     $this->updater->getOutput()->writeln("");
     $this->updater->getOutput()->writeln($formattedBlock);
     $this->updater->getOutput()->writeln("");
+
+    $this->updater->syncWithTemplate('blt/ci.blt.yml', TRUE);
+    $messages = ['blt/ci.blt.yml has been updated. Review it for any custom changes that may have been overwritten.'];
+
+    $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
+    $this->updater->getOutput()->writeln("");
+    $this->updater->getOutput()->writeln($formattedBlock);
+    $this->updater->getOutput()->writeln("");
   }
+
 }


### PR DESCRIPTION
Fixes #2707.

Changes proposed:
- resync the blt/ci.blt.yml file to ensure that the 9.x version includes appropriate behat server info
