### PR TITLE
Fixes #2747 to define target_env for BLT 9.x.

### DIFF
--- a/settings/acsf/post-install/post-install.php
+++ b/settings/acsf/post-install/post-install.php
@@ -15,6 +15,7 @@
 
 $site = $_ENV['AH_SITE_GROUP'];
 $env = $_ENV['AH_SITE_ENVIRONMENT'];
+$target_env = $site . $env;
 
 // The public domain name of the website.
 // Run updates against requested domain rather than acsf primary domain.


### PR DESCRIPTION
Fixes #2747  .

Changes proposed:
- defines $target_env variable based on existing $site and $env
- version 9.x