### PR TITLE
Fixes #2760: Workaround drush sql-sync bug.

### DIFF
--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -134,7 +134,7 @@ class SyncCommand extends BltTasks {
       ->arg($local_alias)
       // @see https://github.com/drush-ops/drush/releases/tag/9.2.1
       // @see https://github.com/acquia/blt/issues/2641
-      ->option('--source-dump', sys_get_temp_dir() . '/tmp.sql')
+      ->option('--source-dump', sys_get_temp_dir() . '/blt/tmp.sql')
       ->option('structure-tables-key', 'lightweight')
       ->option('create-db');
 


### PR DESCRIPTION
Errors when running blt sync:refresh for sites on the same host.