### PR TITLE
Fixes #2758: Add notice about composer.suggested.json.

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -145,7 +145,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
         $target = $dir . DIRECTORY_SEPARATOR . $file;
         if (file_exists($source)) {
           if (!file_exists($target) || md5_file($source) != md5_file($target)) {
-            $this->io->write("Copying $source to $target");
+            $this->io->write("Copying $source to $target. Do not modify this file. To override BLT dependencies, see readme/dependency-management.md.");
             copy($source, $target);
           }
         }


### PR DESCRIPTION
Fixes #2758 

This log output only gets written if composer.suggested.json/composer.required.json has been tampered with or doesn't exist. Seems like a good time to remind people not to touch those files.