### PR TITLE
Feature/deploy gitignore improvements

### DIFF
--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -4,9 +4,9 @@ local.*
 local.blt.yml
 
 # Ignore paths that contain user-generated content.
-docroot/sites/*/files
-/files-private
-docroot/sites/*/private
+/docroot/sites/*/files/
+/docroot/sites/*/private/
+/files-private/
 
 # Ignore build artifacts
 tmp

--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -98,34 +98,63 @@ $RECYCLE.BIN/
 
 # Editor files
 # ------------
-# Eclipse
-*.pydevproject
-.project
+# - Eclipse
+# ------------
+
 .metadata
-tmp/**
-tmp/**/*
 *.tmp
 *.bak
 *.swp
 *~.nib
 local.properties
-.classpath
 .settings/
 .loadpath
 
-# External tool builders
+# External tool builders.
 .externalToolBuilders/
 
-# Locally stored "Eclipse launch configurations"
+# Locally stored "Eclipse launch configurations".
 *.launch
 
-# CDT-specific
+# PyDev specific (Python IDE for Eclipse).
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling).
 .cproject
 
-# PDT-specific
-.buildpathk
+# CDT- autotools.
+.autotools
 
-# Emacs
+# Java annotation processor (APT).
+.factorypath
+
+# PDT-specific (PHP Development Tools).
+.buildpath
+
+# sbteclipse plugin.
+.target
+
+# Tern plugin.
+.tern-project
+
+# TeXlipse plugin.
+.texlipse
+
+# STS (Spring Tool Suite).
+.springBeans
+
+# Code Recommenders.
+.recommenders/
+
+# Scala IDE specific (Scala & Java development for Eclipse).
+.cache-main
+.scala_dependencies
+.worksheet
+
+# ------------
+# - Emacs
+# ------------
+
 *~
 \#*\#
 /.emacs.desktop
@@ -135,9 +164,95 @@ auto-save-list
 tramp
 .\#*
 
-# User-specific stuff:
-.idea/
+# Org-mode.
+.org-id-locations
+*_archive
 
-#Netbeans IDE
-nbproject
-nbproject/*
+# flymake-mode.
+*_flymake.*
+
+# eshell files.
+/eshell/
+
+# elpa packages.
+/elpa/
+
+# reftex files.
+*.rel
+
+# AUCTeX auto folder.
+/auto/
+
+# cask packages.
+.cask/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory.
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration.
+.dir-locals.el
+
+
+# ------------
+# - JetBrains
+# ------------
+
+.idea/
+.idea_modules/
+*.iws
+
+# JIRA plugin.
+atlassian-ide-plugin.xml
+
+
+# ------------
+# - NetBeans
+# ------------
+
+nbproject/
+nbbuild/
+nbdist/
+.nb-gradle/
+
+
+# ------------
+# - Sublime
+# ------------
+
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+*.sublime-workspace
+*.sublime-project
+*.sublime-settings
+
+/sftp-config.json
+/docroot/sftp-config.json
+
+# Package Control files.
+Package Control.*
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+
+# ------------
+# - Vim
+# ------------
+
+Session.vim
+
+# Swap files.
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Temporary files.
+.netrwhist
+*~

--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -12,6 +12,23 @@ local.blt.yml
 /tmp/
 /reports/
 
+# Node.js package manager.
+npm-debug.log
+
+# Profiler tools.
+xhprof_*
+
+# SASS artifacts.
+.sass-cache
+*.css.map
+
+# Vagrant virtual machines.
+/.vagrant/
+/Vagrantfile
+
+# Acquia Cli tool
+acquiacli.yml
+
 # OS X
 .DS_Store
 .AppleDouble
@@ -74,16 +91,6 @@ tramp
 # User-specific stuff:
 .idea/
 
-#XHProf
-xhprof_*
-
-#Sass
-.sass-cache
-*.css.map
-
 #Netbeans IDE
 nbproject
 nbproject/*
-
-#DrupalVM
-.vagrant/

--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -29,7 +29,27 @@ xhprof_*
 # Acquia Cli tool
 acquiacli.yml
 
-# OS X
+# OS files
+# ------------
+# - Linux
+# ------------
+
+*~
+
+# Handle open for deleted file.
+.fuse_hidden*
+.nfs*
+
+# KDE directory preferences.
+.directory
+
+# Linux trash folder.
+.Trash-*
+
+# ------------
+# - MacOS
+# ------------
+
 .DS_Store
 .AppleDouble
 .LSOverride
@@ -37,20 +57,47 @@ acquiacli.yml
 # Thumbnails
 ._*
 
-# Files that might appear on external disk
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
 .Spotlight-V100
+.TemporaryItems
 .Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.*
 
-# Windows image file caches
+# Directories potentially created on remote AFP share
+.AppleDB/
+.AppleDesktop/
+Network Trash Folder/
+Temporary Items/
+.apdisk/
+
+# ------------
+# - Windows
+# ------------
+
+# Thumbnail cache files.
 Thumbs.db
-ehthumbs.db
+ehthumbs*.db
 
-# Folder config file
+# Directory config file.
 Desktop.ini
 
-# Recycle Bin used on file shares
+# Recycle or Trash.
 $RECYCLE.BIN/
 
+# Windows Installer files.
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Shortcuts.
+*.lnk
+
+# Editor files
+# ------------
 # Eclipse
 *.pydevproject
 .project

--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -8,9 +8,9 @@ local.blt.yml
 /docroot/sites/*/private/
 /files-private/
 
-# Ignore build artifacts
-tmp
-reports
+# Ignore build artifacts.
+/tmp/
+/reports/
 
 # OS X
 .DS_Store

--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -33,6 +33,7 @@ acquiacli.yml
 # ------------
 # - Linux
 # ------------
+# Reference: https://github.com/github/gitignore/blob/master/Global/Linux.gitignore
 
 *~
 
@@ -47,8 +48,9 @@ acquiacli.yml
 .Trash-*
 
 # ------------
-# - MacOS
+# - macOS
 # ------------
+# Reference: https://github.com/github/gitignore/blob/master/Global/macOS.gitignore
 
 .DS_Store
 .AppleDouble
@@ -76,6 +78,7 @@ Temporary Items/
 # ------------
 # - Windows
 # ------------
+# Reference: https://github.com/github/gitignore/blob/master/Global/Windows.gitignore
 
 # Thumbnail cache files.
 Thumbs.db
@@ -97,6 +100,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # Editor files
+# - Reference: https://github.com/github/gitignore/tree/master/Global
 # ------------
 # - Eclipse
 # ------------


### PR DESCRIPTION
## Motivation

As BLT removes the global gitignore during creation of the deploy build artefact, it was necessary to update the deploy gitignore to cover Linux OS files. While there, it seemed appropriate to update existing rules with the latest IDE and OS specific files that should not be included.

## Changes proposed

- Clearly organise and reference all deploy gitignore rules
- Update deploy gitignore rules with adapted global rules from Github
- Add Linux OS deploy gitignore rules

## Related issues

- #1839 
