### PR TITLE
Add merged composer deploy scripts

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -50,6 +50,8 @@
   },
   "scripts": {
     "blt-alias": "blt blt:init:shell-alias -y --ansi",
+    "deploy:branch": "blt deploy --commit-msg=\"Automated build by $(git config user.name) for commit $(git rev-parse HEAD)\" --branch=\"$(git rev-parse --abbrev-ref HEAD)-build\" --ignore-dirty --no-interaction --verbose",
+    "deploy:tag": "git name-rev --tags --name-only --no-undefined $(git rev-parse HEAD) && blt deploy --commit-msg=\"Automated build by $(git config user.name) for commit $(git rev-parse HEAD)\" --tag=\"$(git describe --tags --abbrev=0)\" --ignore-dirty --no-interaction --verbose || echo \"error: create an annotated tag and try again\"",
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "nuke": [
       "rm -rf vendor composer.lock docroot/core docroot/modules/contrib docroot/profiles/contrib docroot/themes/contrib",


### PR DESCRIPTION
## Motivation

We've been maintaining `composer deploy` scripts in our BLTed projects and I thought it may be worth sharing with everyone. They're a quick way to call `blt deploy` with sensible defaults for the commit message and a branch or tag name. 

Not sure if this is the right place, but sharing is caring! right? or not. You tell me. I thought at least here they'll get merged into the root project composer.json.

## Changes proposed

- Add `composer deploy:branch` script 
- Add `composer deploy:tag` script 

## Usage examples

For a branch, you do something like this

```
git checkout master
composer install --no-interaction
composer deploy:branch
```

For a tag, you do something like this

```
git checkout master
git tag -a v1.0.0 -m "Release version 1.0.0"
composer install --no-interaction
composer deploy:tag
```
