### PR TITLE
Remove bootstrap line from behat config.

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -572,7 +572,6 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
     return [
       $behat_local_config->get('local.extensions.Drupal\DrupalExtension.drupal.drupal_root'),
       $behat_local_config->get('local.suites.default.paths.features'),
-      $behat_local_config->get('local.suites.default.paths.bootstrap'),
     ];
   }
 

--- a/template/tests/behat/example.local.yml
+++ b/template/tests/behat/example.local.yml
@@ -10,7 +10,6 @@ local:
         # Set features to repo root so that .feature files belonging to contrib
         # modules, themes, and profiles can be discovered.
         features: ${repo.root}
-        bootstrap: ${repo.root}/tests/behat/features/bootstrap
       contexts:
         - Drupal\FeatureContext:
           parameters:


### PR DESCRIPTION
Fixes #2711

Changes proposed:
- This `bootstrap` setting is restating the default value (when digging into the behat source). In addition, I was expecting that this path would auto load any contexts put into that folder, but that does not appear to me to be the case. I still need to specify each context I wish to have loaded, so I'm just not sure what this setting is doing at all... 