### PR TITLE
Update RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ To perform a release:
 
 ## Check build statuses
 
-* [BLT 8.x](https://github.com/acquia/blt): [![Build Status](https://travis-ci.org/acquia/blt.svg?branch=8.x)](https://travis-ci.org/acquia/blt)
+* [BLT 9.x](https://github.com/acquia/blt): [![Build Status](https://travis-ci.org/acquia/blt.svg?branch=9.x)](https://travis-ci.org/acquia/blt)
 * [BLTed 8.x Travis](https://github.com/acquia-pso/blted8): [![Build Status](https://travis-ci.org/acquia-pso/blted8.svg?branch=8.x)](https://travis-ci.org/acquia-pso/blted8)
 * [BLTed 8.x Pipelines](https://cloud.acquia.com/app/develop/applications/d74d1e87-f611-4e46-ba11-3e9b29cdcbdb/pipelines)
 * [![Documentation Status](https://readthedocs.org/projects/blt/badge/?version=8.x)](http://blt.readthedocs.io/en/9.x/?badge=8.x)


### PR DESCRIPTION
Seems like this document needs some cleanup. The only thing I know for sure can be updated is the 8.x/9.x test branch.

I'm not sure if we still use the blted repo, it hasn't had any commits since last year so I assume not?