### PR TITLE
Issue #2794: Fix db update failures on ACSF.

### DIFF
--- a/src/Robo/Commands/Artifact/FactoryHooksCommand.php
+++ b/src/Robo/Commands/Artifact/FactoryHooksCommand.php
@@ -38,7 +38,6 @@ class FactoryHooksCommand extends BltTasks {
       ->drush("cc drush")
       ->run();
     $this->say("Running updates for site <comment>$site</comment> in environment <comment>$target_env</comment>.");
-    $this->switchSiteContext($site);
     $this->invokeCommand('artifact:update:drupal');
   }
 

--- a/src/Robo/Commands/Artifact/FactoryHooksCommand.php
+++ b/src/Robo/Commands/Artifact/FactoryHooksCommand.php
@@ -10,34 +10,42 @@ use Acquia\Blt\Robo\BltTasks;
 class FactoryHooksCommand extends BltTasks {
 
   /**
-   * Execute updates against an artifact hosted in AC Cloud.
+   * Execute updates against an artifact hosted in ACSF.
    *
-   * This is intended to be called from post-code-deploy.sh cloud hook.
+   * This is intended to be called via the db-update factory hook whenever
+   * code is deployed from the management console and the user has opted to
+   * apply DB updates.
+   *
+   * Note that ACSF calls this hook once per site being updated.
    *
    * @param string $site
-   *   The site name. E.g., site1.
+   *   The "ACSF site" name (actually subscription name). E.g., foo.
    * @param string $target_env
-   *   The cloud env. E.g., dev
+   *   The cloud env. E.g., 01dev
+   * @param string $db_role
+   *   Internal to ACSF.
+   * @param string $domain
+   *   Domain for the site being updated. E.g., foo1.foo.acsitefactory.com.
    *
    * @command artifact:acsf-hooks:db-update
    */
   public function dbUpdate($site, $target_env, $db_role, $domain) {
-    $this->updateAcsfSites($site, $target_env);
+    $this->updateAcsfSites($domain, $target_env);
   }
 
   /**
-   * Executes updates against all ACSF sites in the target environment.
+   * Executes updates against a single ACSF site in the target environment.
    *
-   * @param $site
+   * @param $domain
    * @param $target_env
    *
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  public function updateAcsfSites($site, $target_env) {
+  public function updateAcsfSites($domain, $target_env) {
     $this->taskDrush()
       ->drush("cc drush")
       ->run();
-    $this->say("Running updates for site <comment>$site</comment> in environment <comment>$target_env</comment>.");
+    $this->say("Running updates for site <comment>$domain</comment> in environment <comment>$target_env</comment>.");
     $this->invokeCommand('artifact:update:drupal');
   }
 


### PR DESCRIPTION
Fixes #2794 

This feels like a ham-fisted approach, but it does seem to fix the problem. Note that `artifact:acsf-hooks:db-update` almost immediately invokes `artfifact:update:drupal`, which also invokes `switchSiteContext()`. It seems wrong to call that twice, I don't if that could have been part of the problem here.