### PR TITLE
Fixes #2727 to direct users to docs.acquia site.

### DIFF
--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -81,6 +81,8 @@ class AliasesCommand extends BltTasks {
       $this->appId = $app_id;
     }
     else {
+      $this->say("<info>To generate an alias for the Acquia Cloud, BLT require's your Acquia Cloud application ID.</info>");
+      $this->say("<info>See https://docs.acquia.com/acquia-cloud/manage/applications.</info>");
       $this->appId = $this->askRequired('Please enter your Acquia Cloud application ID');
       // @TODO write the app ID to blt.yml.
     }


### PR DESCRIPTION
Fixes #2727.

Changes proposed:
- provides guidance on where to find the acquia application id.
