### PR TITLE
Issue #2796: Fixes failing deploys due to config status check.

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -811,7 +811,8 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    *   TRUE if config is identical.
    */
   public function isActiveConfigIdentical() {
-    $result = $this->executor->drush("config:status 2>&1")->run();
+    $uri = $this->getConfigValue('drush.uri');
+    $result = $this->executor->drush("config:status --uri=$uri 2>&1")->run();
     $message = trim($result->getMessage());
     $identical = strstr($message, 'No differences between DB and sync directory') !== FALSE;
 


### PR DESCRIPTION
Fixes #2796 

This Drush command needs to use whatever Drush context is provided, especially the URI in the case of site factory. Really, all of the Drush calls in this file should probably be refactored to be more consistent (like we do with the Drush task for setup and similar commands), but this solves the immediate problem.

I'm not sure if it's the best approach, but I've confirmed it works on ACSF and doesn't break anything locally.