### PR TITLE
Workaround for composer patches bug.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -59,6 +59,9 @@
     "install-phantomjs": [
       "rm -rf vendor/bin/phantomjs",
       "PhantomInstaller\\Installer::installPhantomJS"
+    ],
+    "post-autoload-dump": [
+      "rm -rf docroot/core/core docroot/core/b"
     ]
   }
 }


### PR DESCRIPTION
Composer patches has a bug that causes extraneous directories to get created in `docroot/core` such as `docroot/core/core` and `docroot/core/b`: https://github.com/cweagans/composer-patches/issues/178

This creates a never-ending stream of issues and support noise. BLT could work around this issue and cut down on the noise by simply removing those extraneous directories after composer updates.

I'm not generally a fan of workarounds like this, but:
1. It's low risk (I can't see it being a problem unless Drupal legitimately adds a core/core or core/b directory, which seems unlikely)
2. It doesn't introduce significant additional complexity.
3. It solves a pretty immediate problem and actually decreases the overall maintenance burden for BLT.