### PR TITLE
2836

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/yaml":                     "^2.7|^3.2.8",
         "symfony/console":                  "^2.7|^3.2.8",
         "wikimedia/composer-merge-plugin":  "^1.4.1",
-        "consolidation/robo":               "^1.1.0",
+        "consolidation/robo":               "~1.2.4",
         "consolidation/config":             "^1.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.0",
         "tivie/php-os-detector": "^1.0",

--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -17,6 +17,9 @@
   },
   "extra": {
     "patches": {
+      "drupal/lightning_core": {
+        "fixing broken db updates": "https://www.drupal.org/files/issues/2018-05-11/2972217-2.patch"
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #2836.
Fixes #2835 for BLT 8.9.x.

Changes proposed:
- patches lightning_core to fix db updates
- pins consolidation/robo to address $config issue with BLT 8.9.x.
