### PR TITLE
Fixes #2830 to default back to PHP 7.1 in the VM.

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -80,8 +80,8 @@ nodejs_install_npm_user: "{{ drupalvm_user }}"
 npm_config_prefix: "/home/{{ drupalvm_user }}/.npm-global"
 installed_extras: ${installed_extras}
 
-# PHP 5.6.
-php_version: "5.6"
+# PHP 7.1.
+php_version: "7.1"
 php_packages_extra:
   - "php{{ php_version }}-bz2"
   - "php{{ php_version }}-imagick"

--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -171,6 +171,7 @@ class VmCommand extends BltTasks {
    */
   protected function boot() {
     $this->checkRequirements();
+    $this->yell(" * We have configured your new Drupal VM to use PHP 7.1 If you would like to change this, edit box/config.yml.");
     $confirm = $this->confirm("Do you want to boot Drupal VM?", TRUE);
     if ($confirm) {
       $this->say("In future, run <comment>vagrant up</comment> to boot the VM.");


### PR DESCRIPTION
Fixes #2830.

Changes proposed:
- default Drupal VM to PHP 7.1 for new Drupal VM configuration.
- warn the user that we have done so and tell them where they can change it if they do desire.
