### PR TITLE
ACSF Factory Hooks, Deploy tasks, and Config bugfixes

### DIFF
--- a/scripts/factory-hooks/db-update/db-update.sh
+++ b/scripts/factory-hooks/db-update/db-update.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Factory Hook: db-update
 #
@@ -20,6 +20,14 @@ domain="$4"
 # BLT executable:
 blt="/var/www/html/$site.$env/vendor/acquia/blt/bin/blt"
 
-IFS=. read -a ARRAY <<< "$domain" # get site name
+# You need the URI of the site factory website in order for drush to target that
+# site. Without it, the drush command will fail. Use the uri.php file provided by the acsf module to
+# locate the URI based on the site, environment and db role arguments.
+uri=`/usr/bin/env php /mnt/www/html/$site.$env/hooks/acquia/uri.php $site $env $db_role`
 
-$blt drupal:update --environment=$env --site=${ARRAY[0]} --define drush.uri=$domain --verbose --yes
+# Print a statement to the cloud log.
+echo "$site.$target_env: Running BLT deploy tasks on $uri domain in $env environemnt on the $site subscription."
+
+IFS='.' read -a name <<< "${uri}"
+
+$blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes

--- a/scripts/factory-hooks/db-update/db-update.sh
+++ b/scripts/factory-hooks/db-update/db-update.sh
@@ -20,4 +20,6 @@ domain="$4"
 # BLT executable:
 blt="/var/www/html/$site.$env/vendor/acquia/blt/bin/blt"
 
-$blt artifact:acsf-hooks:db-update $site $env $db_role $domain --environment=$env --define drush.uri=$domain --verbose --yes
+IFS=. read -a ARRAY <<< "$domain" # get site name
+
+$blt drupal:update --environment=$env --site=${ARRAY[0]} --define drush.uri=$domain --verbose --yes

--- a/scripts/factory-hooks/post-install/post-install.php
+++ b/scripts/factory-hooks/post-install/post-install.php
@@ -21,4 +21,7 @@ $target_env = $site . $env;
 // Run updates against requested domain rather than acsf primary domain.
 $domain = $_SERVER['HTTP_HOST'];
 
-exec("/mnt/www/html/$site.$env/vendor/acquia/blt/bin/blt artifact:update:drupal $site $env $domain --environment=$env --define drush.uri=$domain --verbose --yes");
+$domain_fragments = explode('.', $_SERVER['HTTP_HOST']);
+$site_name = array_shift($domain_fragments);
+
+exec("/mnt/www/html/$site.$env/vendor/acquia/blt/bin/blt drupal:update --environment=$env --site=$site_name --define drush.uri=$domain --verbose --yes");

--- a/scripts/factory-hooks/post-sites-php/includes.php
+++ b/scripts/factory-hooks/post-sites-php/includes.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @file
+ * Example implementation of ACSF post-sites-php hook.
+ *
+ * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
+ */
+// The function_exists check is required as the file is included several times.
+if (!function_exists('gardens_data_get_sites_from_file')) {
+  /**
+   * Get the domains defined for the given site.
+   *
+   * @param string $name
+   *   The technical ACSF site name to filter on.
+   * @param $reset
+   *   Whetever to reset APC cache or not.
+   *
+   * @return array|mixed|null
+   *   An array of sites indexed by domain that matches the given site name.
+   */
+  function gardens_data_get_sites_from_file($name, $reset = FALSE) {
+    static $domains = NULL;
+    if (!isset($domains)) {
+      $cid = 'domains-' . $name;
+      if (
+        !$reset
+        && GARDENS_SITE_DATA_USE_APC
+        && ($data = gardens_site_data_cache_get($cid)) !== FALSE
+      ) {
+        $domains = $data;
+      }
+      elseif ($map = gardens_site_data_load_file()) {
+        $domains = array_filter(
+          $map['sites'],
+          function($item) use ($name) {
+            return $item['name'] == $name;
+          }
+        );
+        if (GARDENS_SITE_DATA_USE_APC) {
+          gardens_site_data_cache_set($cid, $domains);
+        }
+      }
+      else {
+        $domains = [];
+      }
+    }
+    return $domains;
+  }
+}
+// Get all the domains that are defined for the current site.
+$domains = gardens_data_get_sites_from_file($data['gardens_site_settings']['conf']['acsf_db_name']);
+// Get the site's name from the first domain.
+global $acsf_site_name;
+$acsf_site_name = explode('.', array_keys($domains)[0])[0];

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -1,11 +1,11 @@
 <?php
 
-/**
- * @file
- * Setup BLT utility variables, include required files.
- */
+  /**
+   * @file
+   * Setup BLT utility variables, include required files.
+   */
 
-use Acquia\Blt\Robo\Config\ConfigInitializer;
+  use Acquia\Blt\Robo\Config\ConfigInitializer;
 use Drupal\Component\Utility\Bytes;
 use Drupal\Core\DrupalKernel;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -114,11 +114,10 @@ if ($is_acsf_inited) {
     $config_initializer = new ConfigInitializer($repo_root, $input);
     $blt_config = $config_initializer->initialize();
 
-    // The hostname must match the pattern local.[sitename].com, where [sitename]
-    // is a value in the multisites array.
-
+    // The hostname must match the pattern local.[sitename].com, where
+    // [sitename] is a value in the multisites array.
     $domain_fragments = explode('.', $_SERVER['HTTP_HOST']);
-    $name =  array_slice($domain_fragments, 1);
+    $name = array_slice($domain_fragments, 1);
     $acsf_sites = $blt_config->get('multisites');
     if (in_array($name, $acsf_sites)) {
       $acsf_site_name = $name;

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -116,25 +116,14 @@ if ($is_acsf_inited) {
 
     // The hostname must match the pattern [sitename].local, where [sitename]
     // is a value in the multisites array.
-    $name = substr($_SERVER['HTTP_HOST'], 0, strpos($_SERVER['HTTP_HOST'], '.local'));
+
+    $domain_fragments = explode('.', $_SERVER['HTTP_HOST']);
+    $name =  array_slice($domain_fragments, 1)
     $acsf_sites = $blt_config->get('multisites');
     if (in_array($name, $acsf_sites)) {
       $acsf_site_name = $name;
     }
   }
-  // In a site factory environment, we can use environmental variables to
-  // determine the active site.
-  elseif ($is_acsf_env && function_exists('gardens_site_data_load_file')) {
-    // Function gardens_site_data_load_file() lives in
-    // /mnt/www/html/$ah_site/docroot/sites/g/sites.inc.
-    if (($map = gardens_site_data_load_file()) && isset($map['sites'])) {
-      foreach ($map['sites'] as $domain => $site_details) {
-        if ($acsf_db_name == $site_details['name']) {
-          $acsf_site_name = $domain;
-          break;
-        }
-      }
-    }
 
     // ACSF uses a pseudo-multisite architecture that places all site files
     // under sites/g/files.

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -118,16 +118,11 @@ if ($is_acsf_inited) {
     // is a value in the multisites array.
 
     $domain_fragments = explode('.', $_SERVER['HTTP_HOST']);
-    $name =  array_slice($domain_fragments, 1)
+    $name =  array_slice($domain_fragments, 1);
     $acsf_sites = $blt_config->get('multisites');
     if (in_array($name, $acsf_sites)) {
       $acsf_site_name = $name;
     }
-  }
-
-    // ACSF uses a pseudo-multisite architecture that places all site files
-    // under sites/g/files.
-    $site_dir = 'default';
   }
 }
 

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -114,7 +114,7 @@ if ($is_acsf_inited) {
     $config_initializer = new ConfigInitializer($repo_root, $input);
     $blt_config = $config_initializer->initialize();
 
-    // The hostname must match the pattern [sitename].local, where [sitename]
+    // The hostname must match the pattern local.[sitename].com, where [sitename]
     // is a value in the multisites array.
 
     $domain_fragments = explode('.', $_SERVER['HTTP_HOST']);

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -96,7 +96,6 @@ if ($split != 'none') {
 $config["$split_filename_prefix.$site_dir"]['status'] = TRUE;
 
 // Set acsf site split if explicit global exists.
-global $acsf_site_name;
 if (isset($acsf_site_name)) {
   $config["$split_filename_prefix.$acsf_site_name"]['status'] = TRUE;
 }

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -95,7 +95,8 @@ if ($split != 'none') {
  */
 $config["$split_filename_prefix.$site_dir"]['status'] = TRUE;
 
-// Set acsf site split.
+// Set acsf site split if explicit global exists.
+global $acsf_site_name;
 if (isset($acsf_site_name)) {
   $config["$split_filename_prefix.$acsf_site_name"]['status'] = TRUE;
 }

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -811,7 +811,8 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    *   TRUE if config is identical.
    */
   public function isActiveConfigIdentical() {
-    $result = $this->executor->drush("config:status 2>&1")->run();
+    $uri = $this->getConfigValue('drush.uri');
+    $result = $this->executor->drush("config:status --uri=$uri 2>&1")->run();
     $message = trim($result->getMessage());
     $identical = strstr($message, 'No differences between DB and sync directory') !== FALSE;
 


### PR DESCRIPTION
Fixes # 

Changes proposed:
This fixes a few issues impacting deploys and code updates to ACSF projects related to using BLT to run updates, import configuration, and install/update sites from config. The `artifact:deploy:update` and `artifact:acsf-hooks:db-update` tasks used in previous iterations of the Factory Hooks scripts should not be used as they are currently architected, as the commands are not ACSF multisite and task aware and assume the architecture of a traditional multisite rather than ACSF. In the case of invoking `switchSiteContext()`, BLT currently assumes that $site_name is equivalent to the `--uri` or domain value used in Drush 9 commands, however this is problematic on ACSF because logic in sites.php and other settings included via drush acsf-init dynamically map the site names and FQDN passed in `--uri` to the respective ACSF sites identified by their ACSF database name. 

When invalid and empty --uri or --site values are used on ACSF, or when it assumed that traditional multisite names map 1:1 to drush --uris, this will result in the default site / database being used rather than the context provided by ACSF on site install and code updates.

The db-update and post-install hooks have been modified to resolve these issues and add both $site_name and $domain values are passed to the respective `--site` and `--drush.uri` options based on the active host and primary domain. A new `post-sites-php` Factory provides a global `$acsf_site_name` value that is now mapped to site splits based on the acsf site name which can be tested on the default or available multisites locally by passing that value into `--site.`

Automatically activating config splits based on the active site was also not working with the previous configuration in `blt.settings.php`, as it set the `db_role` value to `$acsf_site_name` rather than the ACSF $site_name value or its respective site in the BLT multisite array.

# Testing steps

## db-update (code update)
- After patching BLT, update ACSF Factory Hooks with `blt acsf` and validate that db-update.sh and post-install.php have been updated
- Commit resulting updated files
- deploy code to ACSF environment via BLT deploy or CI
- Execute Site Update via UI and select existing or new branch containing BLT updates
- Validate that db-update Factory Hooks executed correct BLT deploy / update / config import tasks in ACSF logs (example below). There is also an exaple below of how to run and test this task manually on the ACSF environment. 



Successful output: 
```
[ded-1572|1849] - The db-update.sh script has completed: Completed in 24 seconds. Exit code: 0. Standard out: sandbox.: Running BLT deploy tasks on demo1.sandbox.acsitefactory.com domain in 01live environemnt on the sandbox subscription.
> drupal:config:import
 [37;46;1m[success][39;49;22m 'drush' cache was cleared.
 [37;46;1m[success][39;49;22m Cache rebuild complete.
 [37;46;1m[success][39;49;22m No database updates required.
 [37;46;1m[notice][39;49;22m Already enabled: config_split
+------------+---------------+-----------+
|[32m Collection [39m|[32m Config        [39m|[32m Operation [39m|
+------------+---------------+-----------+
|            | acsf.settings | [30;43mUpdate[39;49m    |
+------------+---------------+-----------+
 [37;46;1m[notice][39;49;22m Synchronized configuration: update acsf.settings.
 [37;46;1m[notice][39;49;22m Finalizing configuration synchronization.
 [37;46;1m[success][39;49;22m The configuration was imported successfully.
 [37;46;1m[success][39;49;22m Cache rebuild complete.
> drupal:toggle:modules
23.864s total time elapsed.; Standard error: [info] Skipped pre-config-import target hook. No hook is defined.
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vend...one in 12.048s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self config:set system.site uuid eb86db6f-5e3f-4f5d-ba97-be8a405c2a49 --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 13.487s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self pm-enable config_split --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 14.619s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self config-import sync --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 17.43s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self cache-rebuild --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 21.542s
[info] Skipped post-config-import target hook. No hook is defined.
[info] modules.01live.enable is not set.
[info] modules.01live.uninstall is not set.
```


Manual execution of Factory Hook: 

```
sandbox@web-1577:/mnt/gfs/home/sandbox$  /mnt/www/html/sandbox01live/vendor/acquia/blt/bin/blt drupal:update --environment=01live --site=demo1 --define drush.uri=demo1.sandbox.acsitefactory.com --verbose --yes
> drupal:config:import
[info] Skipped pre-config-import target hook. No hook is defined.
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self cc drush --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
 [success] 'drush' cache was cleared.
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 2.964s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self cache-rebuild --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
 [success] Cache rebuild complete.
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 7.571s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self updb --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
 [success] No database updates required.
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 13.085s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self config:set system.site uuid eb86db6f-5e3f-4f5d-ba97-be8a405c2a49 --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 14.504s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self pm-enable config_split --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
 [notice] Already enabled: config_split
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 15.609s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self config-import sync --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
 [notice] There are no changes to import.
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 16.735s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self cache-rebuild --uri=demo1.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
 [success] Cache rebuild complete.
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 20.313s
[info] Skipped post-config-import target hook. No hook is defined.
> drupal:toggle:modules
[info] modules.01live.enable is not set.
[info] modules.01live.uninstall is not set.
22.385s total time elapsed.
```


## post-install (site creation)

- After patching BLT, update ACSF Factory Hooks with `blt acsf` and validate that db-update.sh and post-install.php have been updated
- Commit resulting updated files
- deploy code to ACSF environment via BLT deploy or CI
- Create new site via ACSF UI
- Validate that post-install Factory Hooks executed correct BLT deploy / update / config import tasks in ACFS logs (example below) 


Successful output:

```
ded-1571|6310] - Execute post install hook post-install.php. - The following command is executed synchronously on web-1577.enterprise-g1.hosting.acquia.com: CACHE_PREFIX='/mnt/tmp/sandbox.01live' \drush8 --root='/mnt/www/html/sandbox.01live/docroot' -l 'test4.sandbox.acsitefactory.com' scr --script-path='/mnt/www/html/sandbox.01live/factory-hooks/post-install' 'post-install.php'

[ded-1571|6310] - The post-install hook post-install.php completed: Completed in 51 seconds. Exit code: 0. Standard out: ; Standard error: [info] Skipped pre-config-import target hook. No hook is defined.
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self cc drush --uri=test4.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 1.275s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self cache-rebuild --uri=test4.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 6.192s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self updb --uri=test4.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 11.788s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self config:set system.site uuid eb86db6f-5e3f-4f5d-ba97-be8a405c2a49 --uri=test4.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 13.309s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self pm-enable config_split --uri=test4.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 14.506s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self config-import sync --uri=test4.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 42.498s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandbox01live/vendor/bin/drush @self cache-rebuild --uri=test4.sandbox.acsitefactory.com --no-interaction --ansi in /mnt/www/html/sandbox01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 46.385s
[info] Skipped post-config-import target hook. No hook is defined.
[info] modules.01live.enable is not set.
[info] modules.01live.uninstall is not set.
```