### PR TITLE
Reverted changes to solr config script for DrupalVM.

### DIFF
--- a/scripts/drupal-vm/configure-solr.sh
+++ b/scripts/drupal-vm/configure-solr.sh
@@ -34,13 +34,7 @@ if [ ! -e "$SOLR_SETUP_COMPLETE_FILE" ]; then
   sudo chown -R solr:solr $SOLR_CORE_PATH/conf
 
   # Restart Apache Solr.
-  #
-  # There is some problem with the service command suggested by DrupalVM, hence
-  # we use init instead. See:
-  # - https://github.com/geerlingguy/ansible-role-solr/pull/81
-  # - https://github.com/geerlingguy/drupal-vm/issues/1546
-  sudo /etc/init.d/solr stop
-  sudo /etc/init.d/solr start
+  sudo service solr restart
 
   # Create a file to indicate this script has already run.
   sudo touch $SOLR_SETUP_COMPLETE_FILE


### PR DESCRIPTION
As Jeff noted in #2841 (comment), #2841 has been fixed upstream in DrupalVM so we no longer need to work around it. Woot!

I've tested and verified that Solr runs as expected with DrupalVM 4.9.0 and BLT patched with this PR.