### PR TITLE
Fixes #2864 to run a redundant config import for config splits.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -127,6 +127,9 @@ class ConfigCommand extends BltTasks {
   protected function importConfigSplit($task, $cm_core_key) {
     $task->drush("pm-enable")->arg('config_split');
     $task->drush("config-import")->arg($cm_core_key);
+    // Runs a second import to ensure splits are
+    // both defined and imported.
+    $task->drush("config-import")->arg($cm_core_key);
   }
 
   /**


### PR DESCRIPTION
Fixes #2864.

Changes proposed:
- adds a redundant config import for config splits, as the "first" pass defines the splits and the "second" one imports them during blt setup.
