### PR TITLE
Add Acquia Cloud support to BLT alias and command

### DIFF
--- a/scripts/blt/alias
+++ b/scripts/blt/alias
@@ -1,8 +1,10 @@
 function blt() {
-  if [ "`git rev-parse --show-cdup 2> /dev/null`" != "" ]; then
-    GIT_ROOT=$(git rev-parse --show-cdup)
+  if [[ ! -z ${AH_SITE_ENVIRONMENT} ]]; then
+    PROJECT_ROOT="/var/www/html/${AH_SITE_GROUP}.${AH_SITE_ENVIRONMENT}"
+  elif [ "`git rev-parse --show-cdup 2> /dev/null`" != "" ]; then
+    PROJECT_ROOT=$(git rev-parse --show-cdup)
   else
-    GIT_ROOT="."
+    PROJECT_ROOT="."
   fi
 
   if [ -f "$GIT_ROOT/vendor/bin/blt" ]; then
@@ -13,7 +15,7 @@ function blt() {
     ./vendor/bin/blt "$@"
 
   else
-    echo "You must run this command from within a BLT-generated project repository."
+    echo "You must run this command from within a BLT-generated project."
     return 1
   fi
 }

--- a/src/Robo/Commands/Blt/AliasCommand.php
+++ b/src/Robo/Commands/Blt/AliasCommand.php
@@ -24,7 +24,7 @@ class AliasCommand extends BltTasks {
       if (is_null($config_file)) {
         $this->logger->warning("Could not find your CLI configuration file.");
         $this->logger->warning("Looked in ~/.zsh, ~/.bash_profile, ~/.bashrc, ~/.profile, and ~/.functions.");
-        $created = $this->createOsxBashProfile();
+        $created = $this->createBashProfile();
         if (!$created) {
           $this->logger->warning("Please create one of the aforementioned files, or create the BLT alias manually.");
         }
@@ -166,10 +166,13 @@ class AliasCommand extends BltTasks {
   }
 
   /**
-   * Creates a ~/.bash_profile on OSX if one does not exist.
+   * Creates a ~/.bash_profile on supporting systems if one does not exist.
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  protected function createOsxBashProfile() {
-    if ($this->getInspector()->isOsx()) {
+  protected function createBashProfile() {
+    $inspector = $this->getInspector();
+    if ($inspector->isOsx() || $inspector->isAhEnv()) {
       $continue = $this->confirm("Would you like to create ~/.bash_profile?");
       if ($continue) {
         $user = posix_getpwuid(posix_getuid());

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -713,6 +713,16 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
   }
 
   /**
+   * Determines whether operating in an Acquia Hosting environment or not.
+   *
+   * @return bool
+   *   Returns TRUE if on Acquia Hosting or FALSE if not.
+   */
+  public function isAhEnv() {
+    return isset($_ENV['AH_SITE_ENVIRONMENT']);
+  }
+
+  /**
    * Gets the Operating system type.
    *
    * @return int


### PR DESCRIPTION
This adds support for Acquia Cloud Hosting to the `create-alias` command and to the bash alias it creates. I have tested it and confirmed that it works on the Cloud and doesn't break the local functionality.