### PR TITLE
Fixes #2851: Adds @executeInDrupalVm annotation to sync:refresh command.

### DIFF
--- a/src/Robo/Commands/Sync/RefreshCommand.php
+++ b/src/Robo/Commands/Sync/RefreshCommand.php
@@ -54,6 +54,7 @@ class RefreshCommand extends BltTasks {
    * local db, re-imports config, and executes db updates.
    *
    * @command sync:refresh
+   * @executeInDrupalVm
    */
   public function refreshDefault() {
     $this->invokeCommands([


### PR DESCRIPTION
Fixes #2851.

Changes proposed:
- For the 8.9 branch, add the @executeInDrupalVm annotation to the sync:refresh command.
