### PR TITLE
Fixes #2880: Re-add ACSF tools.

### DIFF
--- a/scripts/blt/deploy/deploy-exclude.txt
+++ b/scripts/blt/deploy/deploy-exclude.txt
@@ -17,7 +17,7 @@
 /files-private
 /docroot/sites/*/private
 /docroot/themes/contrib
-/drush/contrib
+/drush/Commands
 /README.md
 /readme
 /sites/development.services.yml

--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -45,6 +45,14 @@ class AcsfCommand extends BltTasks {
     $this->invokeCommand('internal:composer:require', $package_options);
     $this->say("In the future, you may pass in a custom value for acsf-version to override the default version, e.g., blt recipes:acsf:init:all --acsf-version='8.1.x-dev'");
     $this->acsfDrushInitialize();
+    $this->say('Adding acsf-tools drush module as a dependency...');
+    $package_options = [
+      'package_name' => 'acquia/acsf-tools',
+      'package_version' => 'dev-9.x-dev',
+    ];
+    $this->invokeCommand('internal:composer:require', $package_options);
+    $this->say('<comment>ACSF Tools has been added. Some post-install configuration is necessary.</comment>');
+    $this->say('<comment>See /drush/Commands/acsf_tools/README.md. </comment>');
     $this->say('<info>ACSF was successfully initialized.</info>');
     $project_yml = $this->getConfigValue('blt.config-files.project');
     $project_config = YamlMunge::parseFile($project_yml);

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -537,7 +537,7 @@ class Updates {
   }
 
   /**
-   * 9.1.0.
+   * 9.1.0-alpha1.
    *
    * @Update(
    *    version = "9001000",
@@ -574,6 +574,31 @@ class Updates {
       $messages = ["Updated $project_composer_json. Review changes, then re-run composer update."];
     }
 
+    $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
+    $this->updater->getOutput()->writeln("");
+    $this->updater->getOutput()->writeln($formattedBlock);
+    $this->updater->getOutput()->writeln("");
+  }
+
+  /**
+   * 9.1.0.
+   *
+   * @Update(
+   *    version = "9001001",
+   *    description = "Adjust Drush 9 Composer contrib directory."
+   * )
+   */
+  public function update_9001001() {
+    $composer_json = $this->updater->getComposerJson();
+    if (isset($composer_json['extra']['installer-paths']['drush/contrib/{$name}'])) {
+      unset($composer_json['extra']['installer-paths']['drush/contrib/{$name}']);
+    }
+    $composer_json['extra']['installer-paths']['drush/Commands/{$name}'][] = 'type:drupal-drush';
+    $this->updater->writeComposerJson($composer_json);
+    $messages = [
+      "Your composer.json file has been modified to be compatible with Drush 9.",
+      "You must execute `composer update --lock` to update your lock file.",
+    ];
     $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
     $this->updater->getOutput()->writeln("");
     $this->updater->getOutput()->writeln($formattedBlock);

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -589,6 +589,7 @@ class Updates {
    * )
    */
   public function update_9001001() {
+    $this->updater->syncWithTemplate('.gitignore', TRUE);
     $composer_json = $this->updater->getComposerJson();
     if (isset($composer_json['extra']['installer-paths']['drush/contrib/{$name}'])) {
       unset($composer_json['extra']['installer-paths']['drush/contrib/{$name}']);

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -22,7 +22,7 @@ docroot/modules/contrib
 docroot/themes/contrib
 docroot/profiles/contrib
 docroot/libraries
-drush/contrib
+drush/Commands
 
 # Ignore custom theme build artifacts
 docroot/themes/custom/*/node_modules

--- a/template/composer.json
+++ b/template/composer.json
@@ -18,7 +18,7 @@
             "docroot/themes/contrib/{$name}": ["type:drupal-theme"],
             "docroot/themes/custom/{$name}": ["type:drupal-custom-theme"],
             "docroot/libraries/{$name}": ["type:drupal-library", "type:bower-asset", "type:npm-asset"],
-            "drush/contrib/{$name}": ["type:drupal-drush"]
+            "drush/Commands/{$name}": ["type:drupal-drush"]
         },
         "merge-plugin": {
             "require": [


### PR DESCRIPTION
Fixes #2880 

I've tested this and it works great.

I'm still in the process of testing ACSF tools itself, there do appear to be a few gaps in the 9.x branch (for instance it doesn't yet generate Drush aliases for you). But regardless, I think it's worth merging this and continuing work on ACSF Tools upstream.