### PR TITLE
Adding a postDbCopy cloud hook command, with additional params.

### DIFF
--- a/scripts/cloud-hooks/hooks/common/post-db-copy/post-db-copy.sh
+++ b/scripts/cloud-hooks/hooks/common/post-db-copy/post-db-copy.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# db-copy Cloud hook: post-db-copy
+#
+# Run updates on copied databases.
+#
+# Usage: post-db-copy.sh site target-env db-name source-env
+
+set -ev
+
+site="$1"
+target_env="$2"
+db_name="$3"
+source_env="$4"
+
+# Prep for BLT commands.
+repo_root="/var/www/html/$site.$target_env"
+export PATH=$repo_root/vendor/bin:$PATH
+cd $repo_root
+
+blt artifact:ac-hooks:post-db-copy $site $target_env $db_name $source_env --environment=$target_env -v --yes --no-interaction
+
+set +v


### PR DESCRIPTION
Fixes #2781

Expanding on #2782 from @dpagini to add additional params that `post-code-deploy` and `post-code-update` utilize: `--environment=$target_env -v --yes --no-interaction`

To summarize why these are also required for this cloud hook (same reason it's needed for the others): without the environment override the `post-db-copy` cloud hook will try to toggle modules from `modules.local`. Verbose output is helpful, and we don't want cloud hooks to hang on any prompts.