### PR TITLE
Alter setup command to execute multisite.

### DIFF
--- a/src/Robo/Commands/Setup/AllCommand.php
+++ b/src/Robo/Commands/Setup/AllCommand.php
@@ -13,9 +13,20 @@ class AllCommand extends BltTasks {
    * Executes source:build:* and installs Drupal via setup.strategy.
    *
    * @command setup
+   *
    * @executeInVm
    */
-  public function setup() {
+  public function allSites() {
+    foreach ($this->getConfigValue('multisites') as $multisite) {
+      $this->switchSiteContext($multisite);
+      $this->setup();
+    }
+  }
+
+  /**
+   * Executes source:build:* and installs Drupal via setup.strategy.
+   */
+  protected function setup() {
     $this->say("Setting up local environment for site <comment>{$this->getConfigValue('site')}</comment>.");
     if ($this->getConfigValue('drush.alias')) {
       $this->say("Using drush alias <comment>@{$this->getConfigValue('drush.alias')}</comment>");


### PR DESCRIPTION
Alternative to #2891.
This will run site setup against all multisites in a BLT project as the default behavior. #2891 creates a new command called `$ blt setup:all`, but this feels like more natural functionality to me. I believe this command would be most often run by new developers in which case they'd want to create all sites in their project at once.
