### PR TITLE
Fixed #2867: Cache clear errors on ACSF deploys.

### DIFF
--- a/scripts/factory-hooks/db-update/db-update.sh
+++ b/scripts/factory-hooks/db-update/db-update.sh
@@ -33,6 +33,6 @@ IFS='.' read -a name <<< "${uri}"
 # Set Drush cache to local ephemeral storage to avoid race conditions. This is
 # done on a per site basis to completely avoid race conditions.
 # @see https://github.com/acquia/blt/pull/2922
-export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush/${DB_ROLE}
+export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush/${db_role}
 
 $blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes

--- a/scripts/factory-hooks/db-update/db-update.sh
+++ b/scripts/factory-hooks/db-update/db-update.sh
@@ -30,4 +30,7 @@ echo "$site.$target_env: Running BLT deploy tasks on $uri domain in $env environ
 
 IFS='.' read -a name <<< "${uri}"
 
+# Set Drush cache to local ephemeral storage to avoid race conditions.
+export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush
+
 $blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes

--- a/scripts/factory-hooks/db-update/db-update.sh
+++ b/scripts/factory-hooks/db-update/db-update.sh
@@ -30,7 +30,9 @@ echo "$site.$target_env: Running BLT deploy tasks on $uri domain in $env environ
 
 IFS='.' read -a name <<< "${uri}"
 
-# Set Drush cache to local ephemeral storage to avoid race conditions.
-export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush
+# Set Drush cache to local ephemeral storage to avoid race conditions. This is
+# done on a per site basis to completely avoid race conditions.
+# @see https://github.com/acquia/blt/pull/2922
+export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush/${DB_ROLE}
 
 $blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes


### PR DESCRIPTION
Fixes #2867 

Drush is about to introduce an environment variable that allows you to specify the cache directory: https://github.com/drush-ops/drush/pull/3597

We can use this to set the cache directory to local ephemeral (block) storage rather than Gluster in order to avoid race conditions. I've verified that this fixes #2867 when using the patched version of Drush.

Ideally we would shoehorn that Drush PR into BLT somehow, but I'm not sure how to do it since we don't patch anything else in our composer.json. I suppose people who really want the patch before the next stable Drush release can apply it themselves.