### PR TITLE
Updates for drush 9 files and removing irrelevant drush 8 references.

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -35,7 +35,7 @@ If your project uses a virtual development environment such as Drupal VM:
 If your project does not use a virtual development environment:
 
 1. Setup your local LAMP stack with the webroot pointing at you project's `docroot` directory.
-1. Run `blt blt:init:settings` This will generate `docroot/sites/default/settings/local.settings.php` and `docroot/sites/default/local.drushrc.php`. Update these with your local database credentials and your local site URL.
+1. Run `blt blt:init:settings` This will generate `docroot/sites/default/settings/local.settings.php` and `docroot/sites/default/local.drush.yml`. Update these with your local database credentials and your local site URL.
 1. Run `blt setup`. This will build all project dependencies and install drupal.
 
 Please see [Local Development](local-development.md) for more information on setting up a local \*AMP stack or virtual development environment.

--- a/scripts/blt/deploy/deploy-exclude.txt
+++ b/scripts/blt/deploy/deploy-exclude.txt
@@ -29,7 +29,8 @@
 .git
 example.*
 local.settings.php
-local.drushrc.php
+local.drush.yml
+local.site.yml
 node_modules
 /vendor
 local.blt.yml

--- a/src/Robo/Commands/Doctor/DrushCheck.php
+++ b/src/Robo/Commands/Doctor/DrushCheck.php
@@ -14,7 +14,7 @@ class DrushCheck extends DoctorCheck {
   }
 
   /**
-   * Checks for local.drushrc.php file and prints messaging to screen.
+   * Checks for local.drush.yml file and prints messaging to screen.
    */
   protected function checkLocalDrushFile() {
     $drush_site_yml = $this->getConfigValue('docroot') . "/sites/default/local.drush.yml";

--- a/src/Robo/Hooks/ValidateHook.php
+++ b/src/Robo/Hooks/ValidateHook.php
@@ -117,7 +117,7 @@ class ValidateHook implements ConfigAwareInterface, LoggerAwareInterface, Inspec
     if (!$this->getInspector()->isDrupalLocalSettingsFilePresent()) {
       throw new BltException("Could not find settings.php for this site.");
     }
-    // @todo Look for local.drushrc.php.
+    // @todo Look for local.drush.yml.
   }
 
   /**

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,8 +1,7 @@
 # Ignore configuration files that may contain sensitive information.
 local.settings.php
-local.drushrc.php
 local.drush.yml
-local.aliases.drushrc.php
+local.site.yml
 local.services.yml
 tests/behat/local.yml
 box/local.config.yml

--- a/template/drush/drush.yml
+++ b/template/drush/drush.yml
@@ -3,9 +3,11 @@
 # ../docroot/sites/[site]/drush.yml
 drush:
   paths:
-    # Load a drush.yml configuration file from the current working directory.
     config:
+      # Load a drush.yml configuration file from the current working directory.
       - ../docroot/sites/default/local.drush.yml
+      # Allow local global config overrides.
+      - local.drush.yml
     include:
       - '${env.home}/.drush'
       - /usr/share/drush/commands


### PR DESCRIPTION
Expanding upon the upgrade to Drush 9 to support more drush 9 files and remove drush 8 files where possible (e.g. not retroactively touching update hooks)

### Changes proposed:

- Add support for optional `drush/sites/local.drush.yml`, for global local drush config settings/overrides that aren't related to the default site drush config (`sites/default/local.drush.yml`)
    - No error occurs if the file is not present because Drush is smart enough to check if the file exists or not before trying to load it
- gitignore `local.site.yml` (local only site aliases that would live in `/drush/sites`) as well as `drush/sites/local.drush.yml` from above (local only global drush config)
- Remove references to drush 8 config/alias files, except where used in the drush 8 to 9 upgrade function
    - Does anyone have a use case for keeping these old files?

### Questions: 

**1) What is `docroot/sites/$site/local.drush.yml` used for?** 

The default site `local.drush.yml` is loaded by BLT default in `drush/drush.yml`. Loading `options.uri` into drush's global config for the project (not on a `site` level). It seems to be needed for `$ drush` and `$ drush @self` to work. But there can only be one `options.uri` set so there's not really multisite support here. And the only places I can find the non-default `docroot/sites/$site/local.drush.yml`s being read is in `Acquia\Blt\Robo\Commands\Doctor\WebUriCheck::performAllChecks()`. 

Unless I am overlooking something, I feel like `settings/default.local.drush.yml` should be copied to `/drush/local.drush.yml` instead of `docroot/sites/$site/local.drush.yml`, with the uri default being populated by the default site's `'${project.local.uri}'`. Multisite is supported by site aliases (`$site.site.yml`) providing their own URI, or by passing uri as a command line param

**2) Why does `drush/drush.yml` use drush 8?**

It looks like `drush/drush.yml` is only used by`DrushTest::testDrushConfig()`? which verifies `drush status` works when using that drush config file. `drush.paths.include` includes the acquia cloud drush commands, and I don't think `drush.paths.drush-script` is valid, so it's not changing the remote drush command to drush 8, I think it would have to be `drush.options.drush-script`

It doesn't seem that config file is copied anywhere so it may be internal to BLT, but curious what the files intentions are

### Observation:

During the drush upgrade (called in BLT in `update_9000000()`), `drush site:alias-convert` brought along our `drush8` value from `['path-aliases']['%drush-script']` for our remote aliases. This is probably more of a drush issue than BLT, but I feel somewhere there should be a notice or prompted confirmation of if drush9 is inheriting a command path, is that still desired"? Seems if no command path is specified, it defaults to the project's `/vendor/drush` folder (if I am understanding drush's preflight correctly)