### PR TITLE
Fixes #2059: override site uri during deploy:update (backport to 8.9.x).

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -563,9 +563,7 @@ class DeployCommand extends BltTasks {
 
     foreach ($this->getConfigValue('multisites') as $multisite) {
       $this->say("Deploying updates to $multisite...");
-      if (!$this->config->get('drush.uri')) {
-        $this->config->set('drush.uri', $multisite);
-      }
+      $this->config->set('drush.uri', $multisite);
 
       $this->invokeCommand('setup:config-import');
       $this->invokeCommand('setup:toggle-modules');


### PR DESCRIPTION
Fixes #2059 . This is the same PR as https://github.com/acquia/blt/pull/2060/files but this time raised against 8.9.x branch.

This fixes a bug that prevents configuration to be properly imported on Drupal multisite. Therefore I think it should be backported to 8.9.x branch.