### PR TITLE
Do not overwrite existing VM configuration files.

### DIFF
--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -328,15 +328,23 @@ class VmCommand extends BltTasks {
   protected function createConfigFiles() {
     $this->logger->info("Creating configuration files for Drupal VM...");
 
-    $this->taskFilesystemStack()
-      ->mkdir($this->vmDir)
-      ->copy($this->defaultDrupalVmConfigFile, $this->projectDrupalVmConfigFile,
-        TRUE)
-      ->copy($this->defaultDrupalVmVagrantfile,
-        $this->projectDrupalVmVagrantfile, TRUE)
-      ->stopOnFail()
-      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-      ->run();
+    $configFiles = [
+      $this->projectDrupalVmConfigFile => $this->defaultDrupalVmConfigFile,
+      $this->projectDrupalVmVagrantfile => $this->defaultDrupalVmVagrantfile,
+    ];
+    foreach ($configFiles as $projectConfigFile => $defaultConfigFile) {
+      // Skip projects' existing configuration files.
+      if (file_exists($projectConfigFile)) {
+          continue;
+      }
+
+      $this->taskFilesystemStack()
+          ->mkdir($this->vmDir)
+          ->copy($defaultConfigFile, $projectConfigFile, true)
+          ->stopOnFail()
+          ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+          ->run();
+    }
   }
 
   /**


### PR DESCRIPTION
Our project has existing VM configuration files (comitted to VCS) that are overwritten with the defaults whenever BLT recreates the VM. This change makes BLT only write default configuration files if their targets do not yet exist.

See https://github.com/acquia/blt/pull/2942 for the PR targeted at BLT 8.9 (`8.9.x`).