### PR TITLE
Do not overwrite existing VM configuration files.

### DIFF
--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -137,13 +137,23 @@ class VmCommand extends BltTasks {
 
     $this->logger->info("Creating configuration files for Drupal VM...");
 
-    $this->taskFilesystemStack()
-      ->mkdir($this->vmDir)
-      ->copy($this->defaultDrupalVmConfigFile, $this->projectDrupalVmConfigFile, TRUE)
-      ->copy($this->defaultDrupalVmVagrantfile, $this->projectDrupalVmVagrantfile, TRUE)
-      ->stopOnFail()
-      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-      ->run();
+    $configFiles = [
+      $this->projectDrupalVmConfigFile => $this->defaultDrupalVmConfigFile,
+      $this->projectDrupalVmVagrantfile => $this->defaultDrupalVmVagrantfile,
+    ];
+    foreach ($configFiles as $projectConfigFile => $defaultConfigFile) {
+      // Skip projects' existing configuration files.
+      if (file_exists($projectConfigFile)) {
+        continue;
+      }
+
+      $this->taskFilesystemStack()
+        ->mkdir($this->vmDir)
+        ->copy($defaultConfigFile, $projectConfigFile, TRUE)
+        ->stopOnFail()
+        ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+        ->run();
+    }
 
     $config = clone $this->getConfig();
 


### PR DESCRIPTION
Our project has existing VM configuration files (comitted to VCS) that are overwritten with the defaults whenever BLT recreates the VM. This change makes BLT only write default configuration files if their targets do not yet exist.

See https://github.com/acquia/blt/pull/2941 for the PR targeted at BLT 9 (`master`).