### PR TITLE
Upgrade PHPunit optionally to 6.5. This is needed to support PHP 7.2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "grasmash/yaml-cli": "^1.0.0",
         "grasmash/yaml-expander": "^1.2.0",
         "oomphinc/composer-installers-extender": "^1.1",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.35 || ^6.5",
         "squizlabs/php_codesniffer": "^2.7",
         "symfony/console": "^3.4.0",
         "symfony/twig-bridge": "^3.3",


### PR DESCRIPTION
Fixes #2771

Changes proposed:
- Make PHPUnit 6.5+ an option for those that need it (e.g. PHP 7.2+). For those people on <= PHP 5.6, PHPUnit 4.8 is still an option. This brings the version in line with what [Drupal core 8.6 requires](https://github.com/drupal/drupal/blob/8.6.x/core/composer.json#L61).
