### PR TITLE
Add support for generating ACSF site aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/twig-bridge": "^3.3",
         "symfony/yaml": "^3.2.8",
         "tivie/php-os-detector": "^1.0",
-        "typhonius/acquia-php-sdk-v2": "^1.0.2",
+        "typhonius/acquia-php-sdk-v2": "dev-master",
         "wikimedia/composer-merge-plugin": "^1.4.1"
     },
     "autoload": {

--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -6,6 +6,7 @@ use Acquia\Blt\Robo\BltTasks;
 use AcquiaCloudApi\CloudApi\Client;
 use AcquiaCloudApi\CloudApi\Connector;
 use Symfony\Component\Yaml\Yaml;
+use Acquia\Blt\Robo\Common\YamlMunge;
 
 /**
  * Defines commands in the "generate:aliases" namespace.

--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -205,6 +205,46 @@ class AliasesCommand extends BltTasks {
     $this->writeSiteAliases($siteID, $aliases);
   }
 
+    /**
+   * Generates a site alias for valid domains.
+   *
+   * @param string $uri
+   *   The unique site url.
+   * @param string $envName
+   *   The current environment.
+   * @param string $remoteHost
+   *   The remote host.
+   * @param string $remoteUser
+   *   The remote user.
+   * @param string $siteID
+   *   The siteID / group.
+   *
+   * @return array
+   *   The full alias for this site.
+   */
+  protected function getAliases($uri, $envName, $remoteHost, $remoteUser, $siteID) {
+    $alias = array();
+    // Skip wildcard domains.
+    $skip_site = FALSE;
+    if (strpos($uri, ':*') !== FALSE) {
+      $skip_site = TRUE;
+    }
+
+    if (!$skip_site) {
+      $docroot = '/var/www/html/' . $remoteUser . '/docroot';
+      $alias[$envName]['uri'] = $uri;
+      $alias[$envName]['host'] = $remoteHost;
+      $alias[$envName]['options'] = '';
+      $alias[$envName]['paths'] = ['dump-dir' => '/mnt/tmp'];
+      $alias[$envName]['root'] = $docroot;
+      $alias[$envName]['user'] = $remoteUser;
+      $alias[$envName]['ssh'] = ['options' => '-p 22'];
+
+      return $alias;
+
+    }
+  }
+
   /**
    * Writes site aliases to disk.
    *

--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -246,6 +246,42 @@ class AliasesCommand extends BltTasks {
   }
 
   /**
+   * Gets ACSF sites info without secondary API calls or Drupal bootstrap.
+   *
+   * @param string $sshFull
+   *   The full ssh connection string for this environment.
+   * @param string $remoteUser
+   *   The site.env remoteUser string used in the remote private files path.
+   *
+   * @return array
+   *   An array of ACSF site data for the current environment.
+   */
+  protected function getSitesJson($sshFull, $remoteUser) {
+
+    $this->say('Getting ACSF sites.json information...');
+    $result = $this->taskRsync()
+
+      ->fromPath('/mnt/files/' . $remoteUser . '/files-private/sites.json')
+      ->fromHost($sshFull)
+      ->toPath($this->cloudConfDir)
+      ->remoteShell('ssh -A -p 22')
+      ->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new \Exception("Unable to rsync ACSF sites.json");
+    }
+
+    $fullPath = $this->cloudConfDir . '/sites.json';
+
+    $response_body = file_get_contents($fullPath);
+
+    $sites_json = json_decode($response_body, TRUE);
+
+    return $sites_json;
+
+  }
+
+  /**
    * Writes site aliases to disk.
    *
    * @param $site_id

--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -87,7 +87,28 @@ class AliasesCommand extends BltTasks {
       $this->say("<info>To generate an alias for the Acquia Cloud, BLT require's your Acquia Cloud application ID.</info>");
       $this->say("<info>See https://docs.acquia.com/acquia-cloud/manage/applications.</info>");
       $this->appId = $this->askRequired('Please enter your Acquia Cloud application ID');
-      // @TODO write the app ID to blt.yml.
+      $this->writeAppConfig($this->appId);
+    }
+  }
+
+  /**
+   * Sets appId value in blt.yml to disable interative prompt.
+   *
+   * @param string $app_id
+   *  The Acquia Cloud application UUID.
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  protected function writeAppConfig($app_id) {
+
+    $project_yml = $this->getConfigValue('blt.config-files.project');
+    $this->say("Updating ${project_yml}...");
+    $project_config = YamlMunge::parseFile($project_yml);
+    $project_config['cloud']['appId'] = $app_id;
+    try {
+      YamlMunge::writeFile($project_yml, $project_config);
+    }
+    catch (\Exception $e) {
+      throw new BltException("Unable to update $project_yml.");
     }
   }
 


### PR DESCRIPTION
Fixes #2914 #2925  

Changes proposed:
- Adds support for generating ACSF site aliases without ACSF tools via `blt recipes:aliases:init:acquia`
- Supports non-acquia primary domains
- Sets appId config in blt.yml to disable interactive prompt.
- Fixes phpcs issues in previous task
