### PR TITLE
Adding PHP 7.2 to the version testing list.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 php:
   - 5.6
   - 7.1
+  - 7.2
 
 env:
   global:


### PR DESCRIPTION
Changes proposed:
- Add PHP 7.2 to the list of versions that travis tests against.
