### PR TITLE
Correct invocation of wizard command.

### DIFF
--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -91,7 +91,7 @@ class UpdateCommand extends BltTasks {
     $this->invokeCommand('recipes:blt:init:command');
     $this->invokeCommand('blt:init:shell-alias');
     if ($this->input()->isInteractive()) {
-      $this->invokeCommand('setup:wizard');
+      $this->invokeCommand('wizard');
     }
   }
 


### PR DESCRIPTION
Changes proposed:
- In [initializeBlt()](https://github.com/acquia/blt/blob/9058f4a9ea639d0d53595e04f6835931b2d909ca/src/Robo/Commands/Blt/UpdateCommand.php#L81), correct the wizard command invocation.

This addresses an issue identified in #2971 but I don't believe will resolve that issue. 
