### PR TITLE
Fixes #2967: Explicitly invoke drupal:hash-salt:init in blt:init:settings

### DIFF
--- a/src/Robo/Commands/Setup/AllCommand.php
+++ b/src/Robo/Commands/Setup/AllCommand.php
@@ -23,7 +23,6 @@ class AllCommand extends BltTasks {
 
     $commands = [
       'source:build',
-      'drupal:hash-salt:init',
       'drupal:deployment-identifier:init',
     ];
 

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -49,6 +49,9 @@ class SettingsCommand extends BltTasks {
       }
     }
 
+    // Generate hash file in salt.txt.
+    $this->invokeCommand('drupal:hash-salt:init');
+
     $default_multisite_dir = $this->getConfigValue('docroot') . "/sites/default";
     $default_project_default_settings_file = "$default_multisite_dir/default.settings.php";
 

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -50,7 +50,7 @@ class SettingsCommand extends BltTasks {
     }
 
     // Generate hash file in salt.txt.
-    $this->invokeCommand('drupal:hash-salt:init');
+    $this->hashSalt();
 
     $default_multisite_dir = $this->getConfigValue('docroot') . "/sites/default";
     $default_project_default_settings_file = "$default_multisite_dir/default.settings.php";


### PR DESCRIPTION
Fixes #2967 .

Changes proposed:
- Explicitly invoke drupal:hash-salt:init in blt:init:settings
