### PR TITLE
Correcting the vm command invocation.

### DIFF
--- a/src/Robo/Commands/Setup/WizardCommand.php
+++ b/src/Robo/Commands/Setup/WizardCommand.php
@@ -48,7 +48,11 @@ class WizardCommand extends BltTasks {
     }
 
     if ($answers['vm']) {
-      $this->invokeCommand('vm', ['--yes']);
+      $this->invokeCommand('vm', [
+        [
+          'no-boot' => '--yes',
+        ],
+      ]);
     }
   }
 


### PR DESCRIPTION
Changes proposed:
- Change the invocation of `vm` command to pass array of associative array items.

When building the VM through the `wizard` command, I was seeing the following warning returned:
> PHP Warning:  Illegal string offset 'no-boot' in /Users/barrett.smith/Desktop/blt/src/Robo/Commands/Vm/VmCommand.php on line 81

The invocation of the `vm` command by the wizard is using `invokeCommand` and passing a single array of `['--yes']` rather than a an array containing an array of options like the `vm` command expects.