### PR TITLE
Fixes #2981: Correct alias to use consistent variable naming.

### DIFF
--- a/scripts/blt/alias
+++ b/scripts/blt/alias
@@ -7,8 +7,8 @@ function blt() {
     PROJECT_ROOT="."
   fi
 
-  if [ -f "$GIT_ROOT/vendor/bin/blt" ]; then
-    $GIT_ROOT/vendor/bin/blt "$@"
+  if [ -f "$PROJECT_ROOT/vendor/bin/blt" ]; then
+    $PROJECT_ROOT/vendor/bin/blt "$@"
 
   # Check for local BLT.
   elif [ -f "./vendor/bin/blt" ]; then


### PR DESCRIPTION
Changes proposed:
- Correct the variable naming used in the alias script.
