### PR TITLE
Update Drupal core required version

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "drupal/core": "^8.5.0",
+    "drupal/core": "^8.5.6",
     "drupal/config_split": "^1.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
This bumps the required version of Drupal core to 8.5.6 (today's security release).

Note that this PR is _not_ simply intended to upgrade Drupal core for folks using BLT (they can already do that themselves by simply running `composer update`). It just happens to coincide with the date of a security release.

Rather, this is mainly intended to avoid issue like this one: https://github.com/acquia/blt-project/issues/29

By forcing a more modern version of Drupal core, people will get immediate errors if they are missing required PHP extensions rather than inexplicably getting months-old versions of Drupal core installed.