### PR TITLE
Database Validation / Creation on site install bugfixes

### DIFF
--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -22,7 +22,6 @@ class BuildCommand extends BltTasks {
    * @interactGenerateSettingsFiles
    *
    * @validateDrushConfig
-   * @validateMySqlAvailable
    * @validateDocrootIsPresent
    * @executeInVm
    *

--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -16,7 +16,6 @@ class DrupalCommand extends BltTasks {
    *
    * @command internal:drupal:install
    *
-   * @validateMySqlAvailable
    * @validateDrushConfig
    * @hidden
    *
@@ -25,6 +24,19 @@ class DrupalCommand extends BltTasks {
    * @throws BltException
    */
   public function install() {
+
+     $status = $this->getInspector()->getStatus();
+      $connection = @mysqli_connect(
+        $status['db-hostname'],
+        $status['db-username'],
+        $status['db-password'],
+        '',
+        $status['db-port']
+      );
+      if (!$connection) {
+        throw new BltException("Unable to connect to database.");
+      }
+      $connection->query('CREATE DATABASE IF NOT EXISTS ' . $status['db-name']);
 
     // Generate a random, valid username.
     // @see \Drupal\user\Plugin\Validation\Constraint\UserNameConstraintValidator

--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -25,18 +25,18 @@ class DrupalCommand extends BltTasks {
    */
   public function install() {
 
-     $status = $this->getInspector()->getStatus();
-      $connection = @mysqli_connect(
+    $status = $this->getInspector()->getStatus();
+    $connection = @mysqli_connect(
         $status['db-hostname'],
         $status['db-username'],
         $status['db-password'],
         '',
         $status['db-port']
       );
-      if (!$connection) {
-        throw new BltException("Unable to connect to database.");
-      }
-      $connection->query('CREATE DATABASE IF NOT EXISTS ' . $status['db-name']);
+    if (!$connection) {
+      throw new BltException("Unable to connect to database.");
+    }
+    $connection->query('CREATE DATABASE IF NOT EXISTS ' . $status['db-name']);
 
     // Generate a random, valid username.
     // @see \Drupal\user\Plugin\Validation\Constraint\UserNameConstraintValidator


### PR DESCRIPTION
Fixes #2814

Changes proposed:
- Validate mysql connection with output of drush status rather than drush sqlq for `blt internal:drupal:install` and `blt drupal:install`
- Create database with drush credentials if it does not exist
