### PR TITLE
Remove cache-rebuild prior to release, to avoid database issues.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -55,9 +55,6 @@ class ConfigCommand extends BltTasks {
         ->stopOnFail()
         // Sometimes drush forgets where to find its aliases.
         ->drush("cc")->arg('drush')
-        // Rebuild caches in case service definitions have changed.
-        // @see https://www.drupal.org/node/2826466
-        ->drush("cache-rebuild")
         // Execute db updates.
         // This must happen before features are imported or configuration is
         // imported. For instance, if you add a dependency on a new extension to


### PR DESCRIPTION
Fixes #3001.

Changes proposed:
- Do not clear the cache prior to an updb command. Instead do it after.
