### PR TITLE
Change default project.local.hostname to ${project.machine_name}.localhost

### DIFF
--- a/template/blt/blt.yml
+++ b/template/blt/blt.yml
@@ -14,7 +14,7 @@ project:
   # This will be used as the local uri for all developers.
   local:
     protocol: http
-    hostname: local.${project.machine_name}.com
+    hostname: ${project.machine_name}.localhost
 
 # Configuration settings for new git repository.
 git:


### PR DESCRIPTION
[RFC 2606](https://tools.ietf.org/html/rfc2606) reserves the TLD `.localhost` for precisely the local development use case. It seems better to use it than to "abuse" `.com`.

> The ".localhost" TLD has traditionally been statically defined in host DNS implementations as having an A record pointing to the loop back IP address and is reserved for such use.  Any other use would conflict with widely deployed code which assumes this use.