### PR TITLE
Add PHPUnit bridge adapter.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -21,6 +21,7 @@
     "jakoch/phantomjs-installer":   "2.1.1-p07",
     "dmore/behat-chrome-extension": "^1.0.0",
     "mikey179/vfsStream": "~1.2",
+    "symfony/phpunit-bridge": "^3.4.3",
     "sensiolabs-de/deprecation-detector": "dev-master"
   },
   "autoload-dev": {


### PR DESCRIPTION
In Drupal 8.4.0, core added a dev dependency on phpunit-bridge: https://www.drupal.org/project/drupal/issues/2488860

Currently, you cannot run core PHPUnit tests without that dependency installed.

Since composer will only install dev dependencies from the root of a composer project (not recursively), we need to mirror this dev dependency in BLT. Note that there is precedent for this: #1725