### PR TITLE
EditorConfig: Use tab indents for *.mk makefiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 # Tab indentation (no size specified)
-[Makefile]
+[Makefile,*.mk]
 indent_style = tab
 
 [composer.json]


### PR DESCRIPTION
Changes proposed:
- We have a `docker.mk` makefile which also requires tab indents, or it will error
- Add `*.mk` alongside `Makefile`
- If we edit `.editorconfig` ourselves, it will be overwritten by the next `acquia/blt` update