### PR TITLE
Multisite setup and breakfix

### DIFF
--- a/scripts/blt/deploy/deploy-exclude.txt
+++ b/scripts/blt/deploy/deploy-exclude.txt
@@ -34,3 +34,4 @@ local.site.yml
 node_modules
 /vendor
 local.blt.yml
+local.sites.php

--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -60,7 +60,12 @@ mysql_users:
   - name: drupal
     host: "%"
     password: drupal
-    priv: "drupal%.*:ALL"
+    priv: "*.*:ALL"
+  - name: drupal
+    host: "localhost"
+    password: drupal
+    priv: "*.*:ALL"
+
 
 # Set this to 'false' if you don't need to install drupal (using the drupal_*
 # settings below), but instead copy down a database (e.g., using drush sql-sync).

--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -7,9 +7,10 @@
 
 use Drupal\Component\Assertion\Handle;
 
+// The local db name must match the site_name key for split mapping.
 $db_name = '${drupal.db.database}';
 if (isset($acsf_site_name)) {
-  $db_name .= '_' . $acsf_site_name;
+  $db_name = $acsf_site_name;
 }
 
 /**
@@ -108,10 +109,10 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
+ * Note: you should test with the config, bootstrap, and discovery caches enabled to
  * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * you may want to disable them. Overrides to these bins must be explicitly set for each
+ * bin to change the default configuration provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 

--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -22,7 +22,6 @@ class BuildCommand extends BltTasks {
    * @interactGenerateSettingsFiles
    *
    * @validateDrushConfig
-   * @validateMySqlAvailable
    * @validateDocrootIsPresent
    * @executeInVm
    *

--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -16,7 +16,6 @@ class DrupalCommand extends BltTasks {
    *
    * @command internal:drupal:install
    *
-   * @validateMySqlAvailable
    * @validateDrushConfig
    * @hidden
    *
@@ -25,6 +24,19 @@ class DrupalCommand extends BltTasks {
    * @throws BltException
    */
   public function install() {
+
+    $status = $this->getInspector()->getStatus();
+    $connection = @mysqli_connect(
+        $status['db-hostname'],
+        $status['db-username'],
+        $status['db-password'],
+        '',
+        $status['db-port']
+      );
+    if (!$connection) {
+      throw new BltException("Unable to connect to database.");
+    }
+    $connection->query('CREATE DATABASE IF NOT EXISTS ' . $status['db-name']);
 
     // Generate a random, valid username.
     // @see \Drupal\user\Plugin\Validation\Constraint\UserNameConstraintValidator

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -52,6 +52,18 @@ class SettingsCommand extends BltTasks {
     // Generate hash file in salt.txt.
     $this->hashSalt();
 
+    // Append local multisite settings to sites.php
+    $result = $this->taskWriteToFile($this->getConfigValue('docroot') . "/sites/sites.php")
+    ->appendUnlessMatches('#sites/local.sites.php#', "\n" . 'if (file_exists(DRUPAL_ROOT . "/sites/local.sites.php")) {' 
+      . "\n" . "\t" . 'include DRUPAL_ROOT . "/sites/local.sites.php";' . "\n" . '}')
+      ->append(TRUE)
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+      ->run();
+
+  if (!$result->wasSuccessful()) {
+      throw new BltException("Unable to include local.sites.php in sites.php");
+  }
+
     $default_multisite_dir = $this->getConfigValue('docroot') . "/sites/default";
     $default_project_default_settings_file = "$default_multisite_dir/default.settings.php";
 
@@ -157,9 +169,9 @@ class SettingsCommand extends BltTasks {
       }
     }
 
-    // Generate sites.php for local multisite.
+    // Generate local.sites.php for local multisite.
     $contents = "<?php\n \$sites = " . var_export($sites, TRUE) . ";";
-    file_put_contents($this->getConfigValue('docroot') . "/sites/sites.php", $contents);
+    file_put_contents($this->getConfigValue('docroot') . "/sites/local.sites.php", $contents);
 
     if ($current_site != $initial_site) {
       $this->switchSiteContext($initial_site);

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -55,7 +55,7 @@ class SettingsCommand extends BltTasks {
     // Append local multisite settings to sites.php.
     $result = $this->taskWriteToFile($this->getConfigValue('docroot') . "/sites/sites.php")
       ->appendUnlessMatches('#sites/local.sites.php#', "\n" . 'if (file_exists(DRUPAL_ROOT . "/sites/local.sites.php")) {'
-      . "\n" . "\t" . 'include DRUPAL_ROOT . "/sites/local.sites.php";' . "\n" . '}')
+      . "\n" . "\t" . 'require DRUPAL_ROOT . "/sites/local.sites.php";' . "\n" . '}')
       ->append(TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -59,6 +59,10 @@ class SettingsCommand extends BltTasks {
     $initial_site = $this->getConfigValue('site');
     $current_site = $initial_site;
 
+    // Accretion variable for holding the list of all the defined multisites.
+    // Used so that we can gather all the info to write the sites.php file.
+    $sites = [];
+
     foreach ($multisites as $multisite) {
       if ($current_site != $multisite) {
         $this->switchSiteContext($multisite);
@@ -79,6 +83,10 @@ class SettingsCommand extends BltTasks {
       $blt_local_drush_file = $this->getConfigValue('blt.root') . '/settings/default.local.drush.yml';
       $default_local_drush_file = "$multisite_dir/default.local.drush.yml";
       $project_local_drush_file = "$multisite_dir/local.drush.yml";
+
+      // Populate the accretion variable.
+      $site_local_hostname = $this->getConfigValue('project.local.hostname');
+      $sites[$site_local_hostname] = $multisite;
 
       $copy_map = [
         $blt_local_settings_file => $default_local_settings_file,
@@ -148,6 +156,10 @@ class SettingsCommand extends BltTasks {
         throw new BltException("Unable to set permissions on $project_settings_file.");
       }
     }
+
+    // Generate sites.php for local multisite.
+    $contents = "<?php\n \$sites = " . var_export($sites, TRUE) . ";";
+    file_put_contents($this->getConfigValue('docroot') . "/sites/sites.php", $contents);
 
     if ($current_site != $initial_site) {
       $this->switchSiteContext($initial_site);

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -52,17 +52,17 @@ class SettingsCommand extends BltTasks {
     // Generate hash file in salt.txt.
     $this->hashSalt();
 
-    // Append local multisite settings to sites.php
+    // Append local multisite settings to sites.php.
     $result = $this->taskWriteToFile($this->getConfigValue('docroot') . "/sites/sites.php")
-    ->appendUnlessMatches('#sites/local.sites.php#', "\n" . 'if (file_exists(DRUPAL_ROOT . "/sites/local.sites.php")) {' 
+      ->appendUnlessMatches('#sites/local.sites.php#', "\n" . 'if (file_exists(DRUPAL_ROOT . "/sites/local.sites.php")) {'
       . "\n" . "\t" . 'include DRUPAL_ROOT . "/sites/local.sites.php";' . "\n" . '}')
       ->append(TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
 
-  if (!$result->wasSuccessful()) {
+    if (!$result->wasSuccessful()) {
       throw new BltException("Unable to include local.sites.php in sites.php");
-  }
+    }
 
     $default_multisite_dir = $this->getConfigValue('docroot') . "/sites/default";
     $default_project_default_settings_file = "$default_multisite_dir/default.settings.php";

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,5 +1,6 @@
 # Ignore configuration files that may contain sensitive information.
 local.settings.php
+local.sites.php
 local.drush.yml
 local.site.yml
 local.services.yml

--- a/tests/phpunit/BltProject/MultiSiteTest.php
+++ b/tests/phpunit/BltProject/MultiSiteTest.php
@@ -42,7 +42,7 @@ class MultiSiteTest extends BltProjectTestBase {
     $this->assertEquals("$this->site1Dir.clone", $site1_blt_yml['drush']['aliases']['remote']);
 
     $site2_blt_yml = YamlMunge::parseFile("$this->sandboxInstance/docroot/sites/$this->site2Dir/blt.yml");
-    $this->assertEquals("$this->site2Dir.local", $site2_blt_yml['drush']['aliases']['local']);
+    $this->assertEquals("self", $site2_blt_yml['drush']['aliases']['local']);
     $this->assertEquals("$this->site2Dir.clone", $site2_blt_yml['drush']['aliases']['remote']);
 
     // Clone.


### PR DESCRIPTION
Fixes #2907, #2996, #2814, #2930, #3030, #3024, #2930, #3029

New Changes proposed: 
- [x]  Manage local multisite $sites[] via local.sites.php includes
- [x]  Exclude local multisite settings from deploy artifacts and vcs

Original Changes proposed:
- [x]  Validate mysql connection with output of drush status rather than drush sqlq for `blt internal:drupal:install` and `blt drupal:install`
- [x]  Create database with drush credentials if it does not exist
- [x]  Grants needed mysql user / db permissions for all multisite database names for all hosts including localhost
- [x]  Remove drupal_* namespace restriction for mysql database name grants
- [x]  Create sites.php file if it does not exist
- [x]  Generate sites.php sites array mapping project multisite local uris to site directories
- [x]  Remove default local.* config/settings files from new multisite directory to regenerate db and drush config from input
- [x]  Fix multisite local drush alias config
- [x]  Populate multsite database credentials from blt and user input
- [x]  Simplify use of $acsf_site_name in multisite setup
- [x]  Exclude default site files from multisite directory
- [x]  Update README

Testing steps

Generate multisite site files, vm config, and settings.php config

 1. run `blt multisite`. Validate that the task: 
 - creates new multisite in docroot/sites/[sitename]
 - generates vm host in box/config.yml
 - generates vm db config in box.config.yml
 - generates local.settings.php and local.drush.yml with new multisite config
 - generates sites.php with new multisite mapping local site hostname to site directory:
 - Excludes files directory from default site
 - Creates drush alias in drush/sites/[sitename].site.yml
 - drush alias returns correct uri, site directory, and db credentials

2. Re-provision vm to add new multisite host and database
- Exit from vm and reprovision with `vagrant reload --provision`
- ssh to vm: `vagrant ssh`

3. Multisite install/setup
- Install drupal / set up blt: `blt setup --site=[sitename]`
- Validate that database is dropped and created automatically
- Validate that site is installed according to config in sites/[sitename].blt.yml / local.settings.php
- Once installed, both `drush @sitename.local st` and `drush --root=path/to/docroot --uri=hostname` should return the correct site uri and site path and the database in `sites/[sitename]/settings/local.settings.php` should bootstrap
