### PR TITLE
Fixes 3029: Set and check acsf_project flag before overwriting sites.php

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -60,7 +60,12 @@ mysql_users:
   - name: drupal
     host: "%"
     password: drupal
-    priv: "drupal%.*:ALL"
+    priv: "*.*:ALL"
+  - name: drupal
+    host: "localhost"
+    password: drupal
+    priv: "*.*:ALL"
+
 
 # Set this to 'false' if you don't need to install drupal (using the drupal_*
 # settings below), but instead copy down a database (e.g., using drush sql-sync).

--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -7,9 +7,10 @@
 
 use Drupal\Component\Assertion\Handle;
 
+// The local db name must match the site_name key for split mapping.
 $db_name = '${drupal.db.database}';
 if (isset($acsf_site_name)) {
-  $db_name .= '_' . $acsf_site_name;
+  $db_name = $acsf_site_name;
 }
 
 /**
@@ -108,10 +109,10 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 /**
  * Configure static caches.
  *
- * Note: you should test with the config, bootstrap, and discovery caches enabled to 
+ * Note: you should test with the config, bootstrap, and discovery caches enabled to
  * test that metadata is cached as expected. However, in the early stages of development,
- * you may want to disable them. Overrides to these bins must be explicitly set for each 
- * bin to change the default configuration provided by Drupal core in core.services.yml. 
+ * you may want to disable them. Overrides to these bins must be explicitly set for each
+ * bin to change the default configuration provided by Drupal core in core.services.yml.
  * See https://www.drupal.org/node/2754947
  */
 

--- a/src/Robo/Blt.php
+++ b/src/Robo/Blt.php
@@ -36,7 +36,7 @@ class Blt implements ContainerAwareInterface, LoggerAwareInterface {
   /**
    * The BLT version.
    */
-  const VERSION = '9.1.2';
+  const VERSION = '9.1.3';
 
   /**
    * The Robo task runner.

--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -6,7 +6,6 @@ use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Defines commands in the "acsf" namespace.

--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -6,6 +6,7 @@ use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Defines commands in the "acsf" namespace.
@@ -59,6 +60,11 @@ class AcsfCommand extends BltTasks {
     if (!empty($project_config['modules'])) {
       $project_config['modules']['local']['uninstall'][] = 'acsf';
     }
+
+    // Set the flag indicating this is an ACSF project. Impacts handling of
+    // sites.php file for multisites.
+    $project_config['acsf_project'] = 'true';
+
     YamlMunge::writeFile($project_yml, $project_config);
   }
 

--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -22,7 +22,6 @@ class BuildCommand extends BltTasks {
    * @interactGenerateSettingsFiles
    *
    * @validateDrushConfig
-   * @validateMySqlAvailable
    * @validateDocrootIsPresent
    * @executeInVm
    *

--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -16,7 +16,6 @@ class DrupalCommand extends BltTasks {
    *
    * @command internal:drupal:install
    *
-   * @validateMySqlAvailable
    * @validateDrushConfig
    * @hidden
    *
@@ -25,6 +24,19 @@ class DrupalCommand extends BltTasks {
    * @throws BltException
    */
   public function install() {
+
+    $status = $this->getInspector()->getStatus();
+    $connection = @mysqli_connect(
+        $status['db-hostname'],
+        $status['db-username'],
+        $status['db-password'],
+        '',
+        $status['db-port']
+      );
+    if (!$connection) {
+      throw new BltException("Unable to connect to database.");
+    }
+    $connection->query('CREATE DATABASE IF NOT EXISTS ' . $status['db-name']);
 
     // Generate a random, valid username.
     // @see \Drupal\user\Plugin\Validation\Constraint\UserNameConstraintValidator

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -59,6 +59,10 @@ class SettingsCommand extends BltTasks {
     $initial_site = $this->getConfigValue('site');
     $current_site = $initial_site;
 
+    // Accretion variable for holding the list of all the defined multisites.
+    // Used so that we can gather all the info to write the sites.php file.
+    $sites = [];
+
     foreach ($multisites as $multisite) {
       if ($current_site != $multisite) {
         $this->switchSiteContext($multisite);
@@ -79,6 +83,10 @@ class SettingsCommand extends BltTasks {
       $blt_local_drush_file = $this->getConfigValue('blt.root') . '/settings/default.local.drush.yml';
       $default_local_drush_file = "$multisite_dir/default.local.drush.yml";
       $project_local_drush_file = "$multisite_dir/local.drush.yml";
+
+      // Populate the accretion variable.
+      $site_local_hostname = $this->getConfigValue('project.local.hostname');
+      $sites[$site_local_hostname] = $multisite;
 
       $copy_map = [
         $blt_local_settings_file => $default_local_settings_file,
@@ -148,6 +156,10 @@ class SettingsCommand extends BltTasks {
         throw new BltException("Unable to set permissions on $project_settings_file.");
       }
     }
+
+    // Generate sites.php for local multisite.
+    $contents = "<?php\n \$sites = " . var_export($sites, TRUE) . ";";
+    file_put_contents($this->getConfigValue('docroot') . "/sites/sites.php", $contents);
 
     if ($current_site != $initial_site) {
       $this->switchSiteContext($initial_site);

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -158,11 +158,13 @@ class SettingsCommand extends BltTasks {
     }
 
     // Generate sites.php for local multisite.
-    $contents = "<?php\n \$sites = " . var_export($sites, TRUE) . ";";
-    file_put_contents($this->getConfigValue('docroot') . "/sites/sites.php", $contents);
+    if (!$this->getConfigValue('acsf_project')) {
+      $contents = "<?php\n \$sites = " . var_export($sites, TRUE) . ";";
+      file_put_contents($this->getConfigValue('docroot') . "/sites/sites.php", $contents);
 
-    if ($current_site != $initial_site) {
-      $this->switchSiteContext($initial_site);
+      if ($current_site != $initial_site) {
+        $this->switchSiteContext($initial_site);
+      }
     }
   }
 

--- a/template/blt/blt.yml
+++ b/template/blt/blt.yml
@@ -76,3 +76,5 @@ modules:
     uninstall:
       - devel
       - views_ui
+
+acsf_project: false

--- a/tests/phpunit/BltProject/MultiSiteTest.php
+++ b/tests/phpunit/BltProject/MultiSiteTest.php
@@ -42,7 +42,7 @@ class MultiSiteTest extends BltProjectTestBase {
     $this->assertEquals("$this->site1Dir.clone", $site1_blt_yml['drush']['aliases']['remote']);
 
     $site2_blt_yml = YamlMunge::parseFile("$this->sandboxInstance/docroot/sites/$this->site2Dir/blt.yml");
-    $this->assertEquals("$this->site2Dir.local", $site2_blt_yml['drush']['aliases']['local']);
+    $this->assertEquals("self", $site2_blt_yml['drush']['aliases']['local']);
     $this->assertEquals("$this->site2Dir.clone", $site2_blt_yml['drush']['aliases']['remote']);
 
     // Clone.


### PR DESCRIPTION
Fixes #3029  .

Changes proposed:
- Add acsf_project:false setting to default blt.yml.
- When running `acsf:init`, set flag to true.
- In setup, before overwriting sites.php with multisite array, check flag value. Abort if true.
- (tangential) set version to 9.1.3. Appears this wasn't updated when 9.1.3 was tagged and released.
