### PR TITLE
Fixed error preventing DB sync from working with BLT.

### DIFF
--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -136,6 +136,8 @@ class SyncCommand extends BltTasks {
       ->option('structure-tables-key', 'lightweight')
       ->option('create-db');
 
+    $task->drush('cr');
+
     if ($this->getConfigValue('drush.sanitize')) {
       $task->drush('sql-sanitize');
     }


### PR DESCRIPTION
When running `blt drupal:sync:default:db` I get the following error.

## Fixes the following error

```
 [notice] Starting to dump database on source.
 [success] Database dump saved to /home/aamc/drush-backups/aamcstg/20180829115012/aamcstg_20180829_115012.sql.gz
You will delete files in /tmp/tmp.target.sql.gz and replace with data from aamc.test@staging-30349.prod.hosting.acquia.com:/home/aamc/drush-backups/aamcstg/20180829115012/aamcstg_20180829_115012.sql.gz

 // Do you want to continue?: yes.

 [notice] Copying dump file from source to target.
 [notice] Starting to import dump file onto target database.

The following operations will be performed:

 * Truncate sessions table.
 * Sanitize text fields associated with users.
 * Sanitize user passwords.
 * Sanitize user emails.

 [success] Sessions table truncated.
 [error]  Plugin (language) instance class "\Drupal\language\DefaultLanguageItem" does not exist.
[Acquia\Blt\Robo\Tasks\DrushTask]  Exit code 1  Time 37.362s
[error]
```

## Changes proposed:
- Add a drush CR after the DB sync
