### PR TITLE
Adding the BLT logo to the README.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # BLT
 
-![BLT logo of styalized sandwich](https://github.com/acquia/blt/raw/9.x/blt-logo.png)
+![BLT logo of stylized sandwich](https://github.com/acquia/blt/raw/9.x/blt-logo.png)
 
 [![Build Status](https://travis-ci.org/acquia/blt.svg?branch=9.x)](https://travis-ci.org/acquia/blt) [![Documentation Status](https://readthedocs.org/projects/blt/badge/?version=9.x)](http://blt.readthedocs.io/en/9.x/?badge=9.x) [![Packagist](https://img.shields.io/packagist/v/acquia/blt.svg)](https://packagist.org/packages/acquia/blt) [![Stories in Ready](https://badge.waffle.io/acquia/blt.png?label=ready&title=Ready)](http://waffle.io/acquia/blt)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # BLT
 
+![BLT logo of styalized sandwich](https://github.com/acquia/blt/raw/9.x/blt-logo.png)
+
 [![Build Status](https://travis-ci.org/acquia/blt.svg?branch=9.x)](https://travis-ci.org/acquia/blt) [![Documentation Status](https://readthedocs.org/projects/blt/badge/?version=9.x)](http://blt.readthedocs.io/en/9.x/?badge=9.x) [![Packagist](https://img.shields.io/packagist/v/acquia/blt.svg)](https://packagist.org/packages/acquia/blt) [![Stories in Ready](https://badge.waffle.io/acquia/blt.png?label=ready&title=Ready)](http://waffle.io/acquia/blt)
 
 BLT (Build and Launch Tool) provides an automation layer for testing, building, and launching Drupal 8 applications.


### PR DESCRIPTION
Some users have requested that we add the project logo to the README page so that branding is consistent with the [blog](https://acquia-pso.github.io/blt-blog/).