### PR TITLE
Update the VERSION constant and CHANGELOG to reflect the 9.1.3 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+#### 9.1.3 (2018-08-24)
+
+This out-of-cycle release addresses a critical failure observed with ACSF sites.
+
+[Full Changelog](https://github.com/acquia/blt/compare/9.1.2...9.1.3)
+
+**Fixed bugs**
+
+- Revert "Multisite setup enhancements and bugfixes" (#3028)
+
 #### 9.1.2 (2018-08-16)
 
 [Full Changelog](https://github.com/acquia/blt/compare/9.1.1...9.1.2)

--- a/src/Robo/Blt.php
+++ b/src/Robo/Blt.php
@@ -36,7 +36,7 @@ class Blt implements ContainerAwareInterface, LoggerAwareInterface {
   /**
    * The BLT version.
    */
-  const VERSION = '9.1.2';
+  const VERSION = '9.1.3';
 
   /**
    * The Robo task runner.


### PR DESCRIPTION
It looks like the VERSION and CHANGELOG were not updated as part of the 9.1.3 release. This updates both so that when we do the next release it will be at the correct place in the version and changelog.

Changes proposed:
- Update VERSION to 9.1.3.
- Add 9.1.3 release to changelog
