### PR TITLE
Fixes #3066: Forward-port PR 3058 to fix memcache.

### DIFF
--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -13,7 +13,7 @@
     "drupal/cog": "^1.0.0",
     "drupal/devel": "^1.0.0",
     "drupal/qa_accounts": "^1.0.0-alpha1",
-    "drupal/memcache": "^2.0-alpha5",
+    "drupal/memcache": "^2.0-alpha7",
     "drupal/seckit": "^1.0.0-alpha2",
     "drupal/security_review": "*",
     "drupal/shield": "^1.0.0",

--- a/settings/memcache.settings.php
+++ b/settings/memcache.settings.php
@@ -37,12 +37,12 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
           'class' => 'Drupal\Core\Site\Settings',
           'factory' => 'Drupal\Core\Site\Settings::getInstance',
         ],
-        'memcache.config' => [
-          'class' => 'Drupal\memcache\DrupalMemcacheConfig',
+        'memcache.settings' => [
+          'class' => 'Drupal\memcache\MemcacheSettings',
           'arguments' => ['@settings'],
         ],
         'memcache.backend.cache.factory' => [
-          'class' => 'Drupal\memcache\DrupalMemcacheFactory',
+          'class' => 'Drupal\memcache\MemcacheDriverFactory',
           'arguments' => ['@memcache.config'],
         ],
         'memcache.backend.cache.container' => [


### PR DESCRIPTION
Fixes #3066  
------------

Changes proposed:
---------
(What are you proposing we change?)

- Take PR #3058 and cherry-pick it on to the 9.2.x branch
> * Require drupal/memcache equal or greater than 2.0-alpha7.
> * Updating memcache settings based on change in drupal/memcache module.
