### PR TITLE
Fixes #3065: Use webflo/drupal-core-require-dev instead of tracking core dev dependencies

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -11,8 +11,6 @@
   },
   "require-dev": {
     "behat/behat": ">=3.1 <3.4",
-    "behat/mink": "~1.7",
-    "behat/mink-selenium2-driver": "^1.3.1",
     "bex/behat-screenshot": "^1.2",
     "drupal/drupal-extension": "~3.2",
     "drupal-composer/drupal-scaffold": "^2.1.0",
@@ -20,9 +18,8 @@
     "se/selenium-server-standalone": "^2.53",
     "jakoch/phantomjs-installer":   "2.1.1-p07",
     "dmore/behat-chrome-extension": "^1.0.0",
-    "mikey179/vfsStream": "~1.2",
-    "symfony/phpunit-bridge": "^3.4.3",
-    "sensiolabs-de/deprecation-detector": "dev-master"
+    "sensiolabs-de/deprecation-detector": "dev-master",
+    "webflo/drupal-core-require-dev": "^8.6.0"
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
Fixes #3065
--------

Changes proposed:
---------
- Currently we duplicate every single dev dependency defined by Drupal core on an individual basis. This is tedious and error prone. webflo/drupal-core-require-dev already tracks these, so if we just track that one package we can get all new dev dependencies for free.

Steps to verify the solution:
-----------
1. Start with a fresh BLT 9.2.x project.
2. Patch BLT with this PR.
3. Run composer update.
4. Verify that the only package updates are fairly trivial and mostly related to dev dependencies that core defines but BLT previously failed to include.

 
