### PR TITLE
Run validation without interaction on CI.

### DIFF
--- a/scripts/travis/run_tests
+++ b/scripts/travis/run_tests
@@ -2,7 +2,7 @@
 
 set -ev
 
-blt validate:all
+blt validate:all --no-interaction
 ${BLT_DIR}/scripts/blt/ci/tick-tock.sh blt setup --define drush.alias='${drush.aliases.ci}' --environment=ci --no-interaction --yes --verbose
 blt tests:all --define drush.alias='${drush.aliases.ci}' --define tests.run-server=true --environment=ci --yes --verbose
 


### PR DESCRIPTION
Fixes #3069  
--------

Changes proposed:
---------
- Run linting non-interactively on CI

Steps to replicate the issue:
----------
1. Run a CI build with a PHPCS violation and confirm the linting task waits for interaction

Steps to verify the solution:
-----------
1. Apply this patch
2. Run a build with a PHPCS violation and confirm it fails immediately when the violation is found

 
