### PR TITLE
Allow PHPUnit to bootstrap from core.

### DIFF
--- a/src/Robo/Commands/Tests/PhpUnitCommand.php
+++ b/src/Robo/Commands/Tests/PhpUnitCommand.php
@@ -19,12 +19,6 @@ class PhpUnitCommand extends BltTasks {
   protected $reportsDir;
 
   /**
-   * The bootstrap filename.
-   *
-   * @var string*/
-  protected $bootstrapFile;
-
-  /**
    * The filename for PHPUnit report.
    *
    * @var string*/
@@ -47,7 +41,6 @@ class PhpUnitCommand extends BltTasks {
     $this->reportFile = $this->reportsDir . '/results.xml';
     $this->testsDir = $this->getConfigValue('repo.root') . '/tests/phpunit';
     $this->phpunitConfig = $this->getConfigValue('phpunit');
-    $this->bootstrapFile = $this->getConfigValue('blt.root') . '/scripts/phpunit/bootstrap.php';
   }
 
   /**
@@ -60,7 +53,6 @@ class PhpUnitCommand extends BltTasks {
     $this->createLogs();
     foreach ($this->phpunitConfig as $test) {
       $task = $this->taskPHPUnit()
-        ->bootstrap($this->bootstrapFile)
         ->xml($this->reportFile)
         ->printOutput(TRUE)
         ->printMetadata(FALSE);


### PR DESCRIPTION
This PR replaces #3007, which I mucked up when retargeting it to the 9.2.x branch.