### PR TITLE
Cherry-pick in lost/abandoned commits from 9.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,25 @@
-Fixes # .
+Fixes # 
+--------
 
 Changes proposed:
+---------
+(What are you proposing we change?)
+
 -
 -
+
+Steps to replicate the issue:
+----------
+(If this PR is not fixing a defect/bug, you can remove this section.)
+
+1. 
+2. 
+
+Steps to verify the solution:
+-----------
+(How does someone verify that this does what you think does?)
+
+1.
+2. 
+
+ 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,3 +35,10 @@ To execute the same "release" testing that is performed during CI execution, run
 ## PHPUnit
 
 See [the PHPUnit section in the automated testing docs](testing.md#PHPUnit)
+
+# Submitting Pull Requests
+
+Changes should be submitted as Github Pull Requests to the project repository. To help with review, pull requests are expected to adhere to two main guidelines:
+
+1. PRs should be atomic and targeted at a single issue rather than broad-scope.
+2. PRs are expected to follow the template defined by the project in `.github/ISSUE_TEMPLATE.md` 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -54,6 +54,10 @@ To create a new git tag for the artifact (rather than committing to a branch) ru
 
 This will generate the artifact, tag it with `1.0.0`, and push it to the remotes defined in blt.yml.
 
+When deploying a tag to the artifact repo, if the config option `deploy.tag_source` is set to TRUE, BLT will also create the supplied tag on the source repository. This makes it easier to verify the source commit upon which an artifact tag is based.
+
+*Note* however that BLT _does not_ automatically push the tag created on the source repository to its remote.
+
 ## Modifying the artifact
 
 The artifact is built by running the `artifact:build` target, which does the following:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -27,6 +27,11 @@ To use [Drupal VM](http://www.drupalvm.com/) with a Drupal project that is gener
 1. Create & boot the VM
 
         blt vm
+        
+1. Commit all resulting files, including `box/config.yml` and `Vagrantfile`.
+        
+        git add -A
+        git commit -m <your commit meessage>
 
 1. Install Drupal
 
@@ -38,6 +43,8 @@ To use [Drupal VM](http://www.drupalvm.com/) with a Drupal project that is gener
         drush uli
 
 There are also other changes you can make if you choose to match the Acquia Cloud server configuration more closely. See Drupal VM's example configuration changes in Drupal VM's `examples/acquia/acquia.overrides.yml` file.
+
+Subsequently, you should use `vagrant` commands to interact with the VM. Do not re-run `blt vm`. For instance, use `vagrant up` to start the VM, and `vagrant halt` to stop it.
 
 Note: With a Drupal VM setup, BLT expects all commands (with the exception of commands in the `blt vm` namespace), to be executed within the VM. To SSH into the VM, simply run `vagrant ssh` as you did in the "Install Drupal" step above.
 

--- a/template/blt/blt.yml
+++ b/template/blt/blt.yml
@@ -21,6 +21,10 @@ git:
   default_branch: master
   remotes: []
 
+deploy:
+  # When manually deploying a tag, also tag the source repository.
+  tag_source: TRUE
+
 drush:
   # You can set custom project aliases in drush/sites/*.site.yml.
   aliases:


### PR DESCRIPTION
Looks like in the process of cutting the branch which became 9.2.x and advancing the 9.x mainline, some commits that we want in both branches didn't make it into the 9.2.x. 

Specifically the four commits right before we cut the 9.1.4 tag.
```
9b6e6f0f Fixes #2964: When manually deploying using a tag also push that tag to source repo. (#2992)
c5eaf137 New guidelines for contribution. (#3045)
de2bcda7 Update the VERSION constant and CHANGELOG to reflect the 9.1.3 release. (#3042)
85226779 VM setup tips (#3036)
```
Obviously we dont want to change the version back to 9.1.3, so this PR cherry-picks in the other commits.

Changes proposed:
---------
(What are you proposing we change?)

- Cherry-pick these commits into 9.2.x
    - 9b6e6f0f Fixes #2964: When manually deploying using a tag also push that tag to source repo. (#2992)
    - c5eaf137 New guidelines for contribution. (#3045)
    - 85226779 VM setup tips (#3036)

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. Checkout the 9.x branch, run `git log --oneline --decorate=full`, and notice the commits right before the 9.1.4 tag.
2. Checkout the 9.2.x branch, run the same command, and notice those commits are not present

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. Repeat step 2 above and notice now the commits are in 9.2.x.
2. Enjoy new, happier BLT 9.2'ing

 
