### PR TITLE
Clarified Git hook documentation.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -86,8 +86,8 @@ drush:
 
 git:
   # The value of a hook should be the file path to a directory containing an
-  # executable file named after the hook.
-  # Changing a hook value to 'false' will disable it.
+  # executable file named after the hook. Changing a hook value to 'false' will disable it.
+  # You should execute `blt blt:init:git-hooks` after modifying these values.
   hooks:
     pre-commit: ${blt.root}/scripts/git-hooks
     commit-msg: ${blt.root}/scripts/git-hooks

--- a/docs/extending-blt.md
+++ b/docs/extending-blt.md
@@ -161,7 +161,7 @@ You may use a custom git hook in place of BLT's default git hooks by setting its
 
 In this example, an executable file named `pre-commit` should exist in `${repo.root}/my-custom-git-hooks`.
 
-You should execute `blt blt:init:git-hooks` after modifying these values in order for changes to take effect.
+You should execute `blt blt:init:git-hooks` after modifying these values in order for changes to take effect. Also note that most projects will already have a `git` key in their `blt.yml` file, make sure to append `hooks` to this existing key.
 
 #### commit-msg
 

--- a/src/Robo/Commands/Git/GitCommand.php
+++ b/src/Robo/Commands/Git/GitCommand.php
@@ -26,7 +26,7 @@ class GitCommand extends BltTasks {
     if (!preg_match($pattern, $message)) {
       $this->logger->error("Invalid commit message!");
       $this->say("Commit messages must conform to the regex $pattern");
-      $this->logger->notice("To disable this command, see http://blt.rtfd.io/en/9.x/readme/extending-blt/#disabling-a-command");
+      $this->logger->notice("To disable this command, see http://blt.rtfd.io/en/9.x/readme/extending-blt/#git-hooks");
       $this->logger->notice("To customize git hooks, see http://blt.rtfd.io/en/9.x/readme/extending-blt/#setupgit-hooks.");
 
       return 1;


### PR DESCRIPTION
I just spent more time than I feel comfortable admitting trying to figure out how to disable the commit-msg hook.

I was confused because in BLT 9, you no longer disable the Git hook _target_, you actually set a config variable that completely removes the hook the next time you run `blt blt:init:git-hooks`. But the note on this is buried in the docs and not linked to correctly from the git targets themselves.

Additionally, I didn't realize that there's already a `git` key in `blt.yml`, so I appended `git.hooks.commit-msg` to the end of my `blt.yml` file (so that the `git` root key existed twice). That blew things up in really new and interesting ways that were hard to track down, so I added a note for folks to not do that.