### PR TITLE
Fixes #3074. Further changes to update memcache settings

### DIFF
--- a/settings/memcache.settings.php
+++ b/settings/memcache.settings.php
@@ -42,8 +42,8 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
           'arguments' => ['@settings'],
         ],
         'memcache.backend.cache.factory' => [
-          'class' => 'Drupal\memcache\MemcacheDriverFactory',
-          'arguments' => ['@memcache.config'],
+          'class' => 'Drupal\memcache\Driver\MemcacheDriverFactory',
+          'arguments' => ['@memcache.settings'],
         ],
         'memcache.backend.cache.container' => [
           'class' => 'Drupal\memcache\DrupalMemcacheFactory',
@@ -63,9 +63,8 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
           'arguments' => [
             'container',
             '@memcache.backend.cache.container',
-            '@lock.container',
-            '@memcache.config',
             '@cache_tags_provider.container',
+            '@lock.container',
           ],
         ],
       ],


### PR DESCRIPTION
Fixes #3074
--------

Changes proposed:
---------

- Update default memcache settings to match the following more closely https://cgit.drupalcode.org/memcache/tree/README.txt?h=8.x-2.x#n138

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. Install fresh copy of BLT 9.1.5
2. Deploy code to Acquia Cloud, and run `drush si` to try installing and run into error.

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. Patch memcache.settings.php with recommendation in PR
2. Deploy to code to Acquia Cloud and run `drush si`, installation should complete.

 
