### PR TITLE
Finished updating memcache config for alpha7.

### DIFF
--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -13,7 +13,7 @@
     "drupal/cog": "^1.0.0",
     "drupal/devel": "^1.0.0",
     "drupal/qa_accounts": "^1.0.0-alpha1",
-    "drupal/memcache": "^2.0-alpha7",
+    "drupal/memcache": "2.0-alpha7",
     "drupal/seckit": "^1.0.0-alpha2",
     "drupal/security_review": "*",
     "drupal/shield": "^1.0.0",

--- a/settings/memcache.settings.php
+++ b/settings/memcache.settings.php
@@ -24,7 +24,7 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
 
     $settings['container_yamls'][] = DRUPAL_ROOT . '/modules/contrib/memcache/memcache.services.yml';
 
-    // Bootstrap cache.container with memcache rather than database.
+    // Define custom bootstrap container definition to use Memcache for cache.container.
     $settings['bootstrap_container_definition'] = [
       'parameters' => [],
       'services' => [
@@ -42,17 +42,13 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
           'arguments' => ['@settings'],
         ],
         'memcache.backend.cache.factory' => [
-          'class' => 'Drupal\memcache\MemcacheDriverFactory',
-          'arguments' => ['@memcache.config'],
+          'class' => 'Drupal\memcache\Driver\MemcacheDriverFactory',
+          'arguments' => ['@memcache.settings']
         ],
         'memcache.backend.cache.container' => [
           'class' => 'Drupal\memcache\DrupalMemcacheFactory',
           'factory' => ['@memcache.backend.cache.factory', 'get'],
           'arguments' => ['container'],
-        ],
-        'lock.container' => [
-          'class' => 'Drupal\memcache\Lock\MemcacheLockBackend',
-          'arguments' => ['container', '@memcache.backend.cache.container'],
         ],
         'cache_tags_provider.container' => [
           'class' => 'Drupal\Core\Cache\DatabaseCacheTagsChecksum',
@@ -60,13 +56,7 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
         ],
         'cache.container' => [
           'class' => 'Drupal\memcache\MemcacheBackend',
-          'arguments' => [
-            'container',
-            '@memcache.backend.cache.container',
-            '@lock.container',
-            '@memcache.config',
-            '@cache_tags_provider.container',
-          ],
+          'arguments' => ['container', '@memcache.backend.cache.container', '@cache_tags_provider.container'],
         ],
       ],
     ];

--- a/settings/memcache.settings.php
+++ b/settings/memcache.settings.php
@@ -24,7 +24,8 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
 
     $settings['container_yamls'][] = DRUPAL_ROOT . '/modules/contrib/memcache/memcache.services.yml';
 
-    // Define custom bootstrap container definition to use Memcache for cache.container.
+    // Define custom bootstrap container definition to use Memcache for
+    // cache.container.
     $settings['bootstrap_container_definition'] = [
       'parameters' => [],
       'services' => [
@@ -43,7 +44,7 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
         ],
         'memcache.backend.cache.factory' => [
           'class' => 'Drupal\memcache\Driver\MemcacheDriverFactory',
-          'arguments' => ['@memcache.settings']
+          'arguments' => ['@memcache.settings'],
         ],
         'memcache.backend.cache.container' => [
           'class' => 'Drupal\memcache\DrupalMemcacheFactory',
@@ -56,7 +57,11 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
         ],
         'cache.container' => [
           'class' => 'Drupal\memcache\MemcacheBackend',
-          'arguments' => ['container', '@memcache.backend.cache.container', '@cache_tags_provider.container'],
+          'arguments' => [
+            'container',
+            '@memcache.backend.cache.container',
+            '@cache_tags_provider.container',
+          ],
         ],
       ],
     ];


### PR DESCRIPTION
Changes proposed:
---------
We all know that the memcache module has changed a bunch of its class and service names lately (especially as of alpha7).

We attempted to update the memcache settings provided by BLT to match this in #3058 but it looks like we didn't go far enough. Things still fall over on Acquia Cloud:

> You have requested a non-existent service "memcache.config".

Here I take the approach of just copying the recommended settings verbatim from the [memcache readme](https://cgit.drupalcode.org/memcache/tree/README.txt?h=8.x-2.x).

Steps to replicate the issue:
----------
1. Install a vanilla BLT project on Acquia Cloud where memcache is available.
2. Try to do pretty much anything, observe the above error.

Steps to verify the solution:
-----------
1. Install a BLT project with this patch on Acquia Cloud.
2. Observe that the error goes away.
3. Further verify that the settings here match verbatim what's recommended by the memcache module itself.

 
