### PR TITLE
Travis CI Memcache Service and Settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ cache:
   - "$HOME/.nvm"
   -  "/tmp/blt-sandbox-instance/.rules"
 
+services:
+- memcached
+
 addons:
   ssh_known_hosts: []
   chrome: stable
@@ -44,6 +47,7 @@ before_install:
   - source ${BLT_DIR}/scripts/travis/exit_early
   # Decrypt private SSH key id_rsa_blt.enc, save as ~/.ssh/id_rsa_blt.
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then openssl aes-256-cbc -K $encrypted_c0b166e924da_key -iv $encrypted_c0b166e924da_iv -in id_rsa_blt.enc -out ~/.ssh/id_rsa -d; chmod 600 ~/.ssh/id_rsa; ls -lash ~/.ssh; eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa; fi
+  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini || echo "Added memcached php extension";
   - phpenv config-rm xdebug.ini
   - phpenv config-add travis.php.ini
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,8 @@ before_install:
   - source ${BLT_DIR}/scripts/travis/exit_early
   # Decrypt private SSH key id_rsa_blt.enc, save as ~/.ssh/id_rsa_blt.
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then openssl aes-256-cbc -K $encrypted_c0b166e924da_key -iv $encrypted_c0b166e924da_iv -in id_rsa_blt.enc -out ~/.ssh/id_rsa -d; chmod 600 ~/.ssh/id_rsa; ls -lash ~/.ssh; eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa; fi
-  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini || echo "Added memcached php extension";
+  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - sudo service memcached status
   - phpenv config-rm xdebug.ini
   - phpenv config-add travis.php.ini
   - composer self-update

--- a/settings/cache.settings.php
+++ b/settings/cache.settings.php
@@ -35,7 +35,7 @@ if ($is_prod_env || $is_stage_env) {
  *
  * @see https://www.drupal.org/node/2766509
  */
-if ($is_ah_env $is_ci_env &&
+if (($is_ah_env || $is_ci_env) &&
   array_key_exists('memcache', $settings) &&
   array_key_exists('servers', $settings['memcache']) &&
   !empty($settings['memcache']['servers'])

--- a/settings/cache.settings.php
+++ b/settings/cache.settings.php
@@ -35,7 +35,7 @@ if ($is_prod_env || $is_stage_env) {
  *
  * @see https://www.drupal.org/node/2766509
  */
-if ($is_ah_env &&
+if ($is_ah_env $is_ci_env &&
   array_key_exists('memcache', $settings) &&
   array_key_exists('servers', $settings['memcache']) &&
   !empty($settings['memcache']['servers'])


### PR DESCRIPTION
Fixes #3077 
--------

Changes proposed:
---------

Start the memcache service on Travis and add the memcached.so php extension to php.ini to allow for using memcache in Travis. Enable memcache for CI if the service is available. 

Note: In looking over the travis config, it doesnt look like apc is installed or configured which may impact this work. I will open a separate issue if it looks like there is a bug. 

Steps to test
----------
1. Start travis build
2. Observe that memcache successfully started in the logs which should have output such as:

```
* memcached.service - memcached daemon
   Loaded: loaded (/lib/systemd/system/memcached.service; enabled; vendor preset: enabled)
   Active: active (running) since Fri 2018-09-07 18:42:58 UTC; 21h ago
 Main PID: 894 (memcached)
   CGroup: /system.slice/memcached.service
           `-894 /usr/bin/memcached -m 64 -p 11211 -u memcache -l 127.0.0.1 -c 1024

Sep 07 18:42:58 local systemd[1]: Started memcached daemon.
```
