### PR TITLE
Support memcache on ACSF via site flags.

### DIFF
--- a/scripts/factory-hooks/post-settings-php/memcache.php
+++ b/scripts/factory-hooks/post-settings-php/memcache.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Example implementation of ACSF post-settings-php hook.
+ *
+ * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
+ */
+
+// Use ACSF internal settings site flag to apply memcache settings.
+if (getenv('AH_SITE_ENVIRONMENT') && 
+	isset($site_settings['flags']['memcache_enabled']) &&
+	isset($settings['memcache']['servers'])
+) {
+  require DRUPAL_ROOT . '/../vendor/acquia/blt/settings/memcache.settings.php';
+}
+
+


### PR DESCRIPTION
Changes proposed:
---------
- Turn on memcache for ACSF sites that are "flagged" to run memcache

Steps to replicate the issue:
----------
1. Deploy a BLT site on ACSF
2. Observe that memcache is not enabled for the site, regardless of any configuration for that particular site

Steps to verify the solution:
-----------
1. Deploy a BLT site to ACSF with this patch
2. Verify that memcache is not initially enabled
3. Edit the site node and turn on the memcache flag
4. Verify that memcache is now running for the site