### PR TITLE
amotic -> atomic

### DIFF
--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -23,7 +23,7 @@ It is not possible to create an exhaustive list of all things that should be che
         * Use of global $language, LANGUAGE_NONE instead of 'und'
         * Use of t()
     * Does it follow basic code principles?
-        * Functions are logically amotic with low cyclomatic complexity
+        * Functions are logically atomic with low cyclomatic complexity
         * Logic is being performed at the correct layer, e.g., no logic in the presentation layer.
         * Are its components re-usable?
     * Verify best practices are being used:


### PR DESCRIPTION
Fixes a typo in the code review guide.

Fixes # 
--------
n/a 

Changes proposed:
---------
- fix a typo in code review docs

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

- Search the docs for "amotic." It should no longer be present.

 
