### PR TITLE
Downgrade config override error to warning.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -196,7 +196,7 @@ class ConfigCommand extends BltTasks {
    */
   protected function checkConfigOverrides($cm_core_key) {
     if (!$this->getConfigValue('cm.allow-overrides') && !$this->getInspector()->isActiveConfigIdentical()) {
-      throw new BltException("Configuration in the database does not match configuration on disk. BLT has attempted to automatically fix this by re-exporting configuration to disk. Please read https://github.com/acquia/blt/wiki/Configuration-override-test-and-errors");
+      $this->logger->warning("Configuration in the database does not match configuration on disk. BLT has attempted to automatically fix this by re-exporting configuration to disk. Please read https://github.com/acquia/blt/wiki/Configuration-override-test-and-errors");
     }
   }
 


### PR DESCRIPTION
Changes proposed:
---------
- When BLT detects that configuration is overridden following a configuration import, it currently throws an error and fails the process. Instead, this changes it to a warning and doesn't fail the process.

Steps to replicate the issue:
----------
1. Follow the steps in #3095 (_without_ applying the core patch) to install Drupal, export config, and attempt to install Drupal again to get the error.

Steps to verify the solution:
-----------
1. Follow the same steps, but note that it's now a warning instead of an error.

It's regrettable that we should make this change, since this error is trying to save users from a lot of potential trouble. But it seems like no one really understood what it meant and just ended up blaming BLT, which isn't good for anyone.

 
