### PR TITLE
Remove support for PHPUnit 5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "grasmash/yaml-cli": "^1.0.0",
         "grasmash/yaml-expander": "^1.2.0",
         "oomphinc/composer-installers-extender": "^1.1",
-        "phpunit/phpunit": "^4.8|^5.7|^6.5",
+        "phpunit/phpunit": "^4.8|^6.5",
         "squizlabs/php_codesniffer": "^2.7",
         "symfony/console": "^3.4.0",
         "symfony/twig-bridge": "^3.3",


### PR DESCRIPTION
We originally added support for PHPUnit 5 and 6 here: https://github.com/acquia/blt/pull/2982/commits/e474afa8b640acd477ecb7fb0df14e73a210f0e7

It's unclear why we chose to support 5 specifically. We were trying to emulate core, which only supports 4 or 6.

Anyway, supporting 5 is problematic because in PHP 5.6 environments (on Travis CI specifically) Composer will install PHPUnit 5 to start with. Then when it runs updates, it realizes that Drupal Core only supports PHPUnit 4 so it downgrades, and this leads to some sort of bizarre split brain scenario.

By removing support for PHPUnit 5 here, we are getting back in line with core and hopefully avoiding the weird Travis error.