### PR TITLE
Resolves #3106: Add 'skip_permissions_hardening' setting to local settings file template

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -131,6 +131,18 @@ $settings['extension_discovery_scan_tests'] = FALSE;
 $settings['rebuild_access'] = FALSE;
 
 /**
+ * Skip file system permissions hardening.
+ *
+ * The system module will periodically check the permissions of your site's
+ * site directory to ensure that it is not writable by the website user. For
+ * sites that are managed with a version control system, this can cause problems
+ * when files in that directory such as settings.php are updated, because the
+ * user pulling in the changes won't have permissions to modify files in the
+ * directory.
+ */
+$settings['skip_permissions_hardening'] = TRUE;
+
+/**
  * Temporary file path:
  *
  * A local file system path where temporary files will be stored. This


### PR DESCRIPTION
Fixes #3106 
--------

Changes proposed:
---------
Add some code to the local settings file template that BLT uses when generating the real local settings file.

 
