### PR TITLE
Fixes 2980: Clear Twig caches on deploys patch.

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "drupal/core": "^8.0",
+    "drupal/core": "^8.6.0",
     "drupal/features": "^3.0.0",
     "drupal/config_split": "^1.0.0-beta4",
     "drupal/devel": "^1.0.0-alpha1"
@@ -43,12 +43,7 @@
         "sites/default/default.settings.php": "sites/default/settings.php"
       }
     },
-    "enable-patching": true,
-    "patches": {
-      "drupal/core": {
-        "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/2752961-90.patch"
-      }
-    }
+    "enable-patching": true
   },
   "scripts": {
     "blt-alias": "blt install-alias -y --ansi",

--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "acquia/lightning": "^2.2.7 | ^3.0.0",
+    "acquia/lightning": "^2.2.7 | ^3.2.0",
     "drupal/acquia_connector": "^1.5.0",
     "drupal/cog": "^1.0.0",
     "drupal/qa_accounts": "^1.0.0-alpha1",


### PR DESCRIPTION
Fixes # 2980
--------

Changes proposed:
---------

- Remove _Clear Twig caches on deploys_ patch.
- Update Drupal Core to ^8.6.0
- Update Lightning to ^3.2.0

Steps to replicate the issue:
----------

1. Run `composer update` on a BLT 8.9.x project when specifying `"drupal/core": "^8.6.1",` in the project `composer.json`

Result:
```
Could not apply patch! Skipping. The error was: Cannot apply patch https://www.drupal.org/files/issues/2752961-90.patch


  [Exception]
  Cannot apply patch Clear Twig caches on deploys (https://www.drupal.org/files/issues/2752961-90.patch)!
```

Steps to verify the solution:
-----------

1. Run `composer update` on a BLT 8.9.x project when specifying `"drupal/core": "^8.6.1",` in the project `composer.json`

Result: above error is not present.
 
