### PR TITLE
Fix drush alias generator for acp servers (#3114)

### DIFF
--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -247,7 +247,8 @@ class AliasesCommand extends BltTasks {
       $remoteHost = $ssh_split[1];
       $remoteUser = $ssh_split[0];
 
-      if ($hosting == 'ace' || $hosting == 'acp') {
+      // Get aliases for non `acsf` hosting environments
+      if ($hosting != 'acsf') {
 
         $siteID = $site_split[1];
         $uri = $env->domains[0];

--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -247,7 +247,7 @@ class AliasesCommand extends BltTasks {
       $remoteHost = $ssh_split[1];
       $remoteUser = $ssh_split[0];
 
-      // Get aliases for non `acsf` hosting environments
+      // Get aliases for non `acsf` hosting environments.
       if ($hosting != 'acsf') {
 
         $siteID = $site_split[1];

--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -247,7 +247,7 @@ class AliasesCommand extends BltTasks {
       $remoteHost = $ssh_split[1];
       $remoteUser = $ssh_split[0];
 
-      if ($hosting == 'ace') {
+      if ($hosting == 'ace' || $hosting == 'acp') {
 
         $siteID = $site_split[1];
         $uri = $env->domains[0];


### PR DESCRIPTION
Fixes # 
--------
#3114 

Changes proposed:
---------
This more than likely needs work. Currently we simply add an additional condition to check for `acp` hosting vs only `ace` and `acsf`.

Steps to replicate the issue:
----------
1. See #3114 for details

Steps to verify the solution:
-----------
1. After running `blt recipes:aliases:init:acquia` and `drush sa` you should see drush aliases.
1. Verify they were installed correctly in the `drush/sites` directory of your Drupal project.

 
