### PR TITLE
#3116: Support dual setup strategies.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -137,7 +137,12 @@ project:
     uri: ${project.local.protocol}://${project.local.hostname}
 
 setup:
-  # Valid values are install, sync, import.
+  # Valid values are install, sync, import, dual.
+  # - install: installs a site using `drush si`.
+  # - sync: syncs a database from `drush.aliases.remote` and runs updates.
+  # - import: imports a static database dump.
+  # - dual: runs a sync to ensure that database updates are applied correctly
+  #   followed by a fresh install for tests.
   strategy: install
   # If setup.strategy is import, this file will be imported. File path is
   # relative to drupal docroot directory.

--- a/src/Robo/Commands/Setup/AllCommand.php
+++ b/src/Robo/Commands/Setup/AllCommand.php
@@ -40,6 +40,12 @@ class AllCommand extends BltTasks {
         $commands[] = 'drupal:sql:import';
         $commands[] = 'drupal:update';
         break;
+
+      case 'dual':
+        $commands[] = 'drupal:sync:default:site';
+        $commands[] = 'drupal:install';
+        $commands[] = 'drupal:toggle:modules';
+        break;
     }
 
     $commands[] = 'blt:init:shell-alias';

--- a/template/blt/ci.blt.yml
+++ b/template/blt/ci.blt.yml
@@ -2,6 +2,7 @@
 #   install - Installs Drupal from scratch.
 #   sync - Uses `blt drupal:sync` to pull a remote db from drush.aliases.remote.
 #   import - Imports a .sql file from setup.dump-file.
+#   dual - Runs sync to test database updates, then install for tests.
 # setup.strategy: import
 # Relative to the drupal docroot directory.
 # setup.dump-file: /tmp/my-dump-file.sql


### PR DESCRIPTION
Relates to #3116
--------

Currently there are only three strategies to "setup" a site: installing from scratch, syncing a db from a remote environment, or importing a static SQL dump. The problem is that in CI environments you might want to use multiple strategies for testing purposes.

For instance, on ACSF platforms, you want to ensure both that new sites can be installed from scratch, and that existing sites can be updated without error. This requires a combination of the "install" and "sync" strategies.

Changes proposed:
---------
- Add a "dual" setup strategy that essentially just runs a sync followed by an install. In my experience, this is one of the most common testing strategies for multisite installs (although by no means the only one). Long term, we probably want to have a discussion in #3116 about whether to be opinionated about this, or allow users to "mix and match" strategies.