### PR TITLE
Fix the link of Memcache documentation page.

### DIFF
--- a/docs/memcache.md
+++ b/docs/memcache.md
@@ -6,7 +6,7 @@ Before enabling the Memcache module, it is important to understand how the Drupa
 
 ## Acquia Cloud
 
-[Using Memcached on Acquia Cloud](https://docs.acquia.com/cloud/performance/memcached) provides detailed information regarding how Acquia supports Memcached for its subscriptions and products, and is a good resource in general for information regarding Drupal and Memcache integrations. It is important that the settings for `memcache_key_prefix` and `memcache_servers` not be modified on Acquia Cloud.
+[Using Memcached on Acquia Cloud](https://docs.acquia.com/acquia-cloud/performance/memcached/) provides detailed information regarding how Acquia supports Memcached for its subscriptions and products, and is a good resource in general for information regarding Drupal and Memcache integrations. It is important that the settings for `memcache_key_prefix` and `memcache_servers` not be modified on Acquia Cloud.
 
 BLT modifies the Memcache module integration on Acquia Cloud. BLT's configuration explicitly overrides the default bins for the discovery, bootstrap, and config cache bins because Drupal core permanently caches these static bins by default. This is required for rebuilding service definitions accurately on cache rebuilds and deploys. See [caching.settings.php](/settings/cache.settings.php).
 


### PR DESCRIPTION
Fixes #3124  
--------

Changes proposed:
---------
Fix the link of Memcache documentation page.

Steps to replicate the issue:

Memcache documentation page points to a broken link. This PR is fixing it.
Please see the issue for more details #3124

