### PR TITLE
Remove PHP 5.6 from the list of tested versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.6
   - 7.1
   - 7.2
 


### PR DESCRIPTION
PHP 5.6 is no longer supported on Acquia Cloud and is rapidly approaching end of life overall. Let's simplify our project testing and no longer test against that version.


Changes proposed:
---------
(What are you proposing we change?)
- Remove PHP 5.6 from the list of versions tested by Travis.