### PR TITLE
Fix PHP syntax error in acquia simplesamlphp config.

### DIFF
--- a/scripts/simplesamlphp/acquia_config.php
+++ b/scripts/simplesamlphp/acquia_config.php
@@ -115,4 +115,3 @@ elseif (getenv('AH_SITE_ENVIRONMENT')) {
   $config['store.sql.password'] = $creds['pass'];
   $config['store.sql.prefix'] = 'simplesaml';
 }
-}


### PR DESCRIPTION
Fixes #3142
--------

Changes proposed:
---------

- Remove unexpected `}` at the end of the acquia_config.php file.

Steps to replicate the issue:
----------

1. Install BLT and setup simplsamlphp
2. Load example.com/simplesaml
3. See configuration error reported by simplesamlphp library

```
The debug information below may be of interest to the administrator / help desk:

SimpleSAML\Error\CriticalConfigurationError: The configuration is invalid: The configuration (config/config.php) is invalid: syntax error, unexpected '}', expecting end of file

Backtrace:
1 www/_include.php:70 (require_once)
0 www/index.php:3 (N/A)
```

Steps to verify the solution:
-----------

1. Patch acquia_config.php
2. Load example.com/simplesaml
3. Profit with working simplesamlphp admin pages


 
