### PR TITLE
Remove PHP 5.6 from the list of tested versions. (#3137)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.6
   - 7.1
   - 7.2
 


### PR DESCRIPTION
Backport of #3137