### PR TITLE
Fixed travis output.

### DIFF
--- a/scripts/travis/exit_early
+++ b/scripts/travis/exit_early
@@ -10,3 +10,5 @@ then
     exit 0
   fi
 fi
+
+set +v


### PR DESCRIPTION
I'm trying to figure out why Travis logs look like this:
![screenshot-travis-ci org-2018 10 08-13-59-42](https://user-images.githubusercontent.com/1984514/46633415-6c2c0f00-cb02-11e8-9ca9-d6897f6ecba1.png)

My theory is that the problem is that this script is not properly cleaning up after itself by disabling `-v` (print shell input lines)