### PR TITLE
9.2.x: Upgrade to Drupal 8.6.1

### DIFF
--- a/composer.required.json
+++ b/composer.required.json
@@ -6,7 +6,7 @@
     }
   },
   "require": {
-    "drupal/core": "^8.6.0",
+    "drupal/core": "^8.6.1",
     "drupal/config_split": "^1.0.0"
   },
   "require-dev": {
@@ -19,7 +19,7 @@
     "jakoch/phantomjs-installer":   "2.1.1-p07",
     "dmore/behat-chrome-extension": "^1.0.0",
     "sensiolabs-de/deprecation-detector": "dev-master",
-    "webflo/drupal-core-require-dev": "^8.6.0"
+    "webflo/drupal-core-require-dev": "^8.6.1"
   },
   "autoload-dev": {
     "psr-4": {


### PR DESCRIPTION
Changes proposed:
---------
(What are you proposing we change?)

- Upgrade to Drupal 8.6.1
- Was released on 2018-09-10
- https://www.drupal.org/project/drupal/releases/8.6.1
