### PR TITLE
Fixes #3116: Suggest testing db updates.

### DIFF
--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -24,6 +24,11 @@ events:
             type: script
             script:
               - source ${BLT_DIR}/scripts/pipelines/validate
+        # Uncomment these lines to test database updates using live content.
+        # - test-updates:
+        #     type: script
+        #     script:
+        #       - blt drupal:sync:default:site
         - setup-app:
             type: script
             script:

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -57,6 +57,8 @@ install:
   - source ${BLT_DIR}/scripts/travis/setup_project
 
 script:
+  # Uncomment these lines to test database updates using live content.
+  # - blt drupal:sync:default:site
   - source ${BLT_DIR}/scripts/travis/run_tests
 
 deploy:


### PR DESCRIPTION
Fixes #3116
--------

Changes proposed:
---------
Just adding some suggested CI commands for folks who want to test db updates and config imports on live content, before installing the site from scratch and running the normal test suite.

I prefer this approach since it's a much lighter-touch solution than #3126. It also opens the door to running these tests in parallel.