### PR TITLE
Prevent cache collisions in multisite db-update tasks

### DIFF
--- a/scripts/blt/drush/cache.php
+++ b/scripts/blt/drush/cache.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Creates a unique temporary cache directory given a site, env, and uri.
+ * This is used for every blt command invocation on site install and update.
+ */
+
+$site = $argv[1];
+$env = $argv[2];
+$uri = $argv[3];
+
+
+if (empty($argv[3])) {
+  echo "Error: Not enough arguments. Site, environment, and uri are required.\n";
+  exit(1);
+}
+
+// Create a temporary cache directory for this drush process only.
+$cache_directory = sprintf('/mnt/tmp/%s.%s/drush_tmp_cache/%s', $site, $env, md5($uri));
+shell_exec(sprintf('mkdir -p %s', escapeshellarg($cache_directory)));
+
+if (!file_exists($cache_directory)) {
+  syslog(LOG_ERR, sprintf('Drush updates could not be executed, as the required cache directory [%s] is missing.', $cache_directory));
+  die('Missing or corrupted drush cache for this process.');
+}
+else {
+  echo "$cache_directory";
+}

--- a/scripts/factory-hooks/db-update/db-update.sh
+++ b/scripts/factory-hooks/db-update/db-update.sh
@@ -18,21 +18,27 @@ db_role="$3"
 domain="$4"
 
 # BLT executable:
-blt="/var/www/html/$site.$env/vendor/acquia/blt/bin/blt"
+blt="/mnt/www/html/$site.$env/vendor/acquia/blt/bin/blt"
 
 # You need the URI of the site factory website in order for drush to target that
 # site. Without it, the drush command will fail. Use the uri.php file provided by the acsf module to
 # locate the URI based on the site, environment and db role arguments.
 uri=`/usr/bin/env php /mnt/www/html/$site.$env/hooks/acquia/uri.php $site $env $db_role`
 
-# Print a statement to the cloud log.
-echo "$site.$target_env: Running BLT deploy tasks on $uri domain in $env environment on the $site subscription."
-
+# Create array with site name fragments from ACSF uri. 
 IFS='.' read -a name <<< "${uri}"
 
-# Set Drush cache to local ephemeral storage to avoid race conditions. This is
-# done on a per site basis to completely avoid race conditions.
-# @see https://github.com/acquia/blt/pull/2922
-export DRUSH_PATHS_CACHE_DIRECTORY=/tmp/.drush/${db_role}
+# Create and set Drush cache to unique local temporary storage per site.
+# This approach isolates drush processes to completely avoid race conditions
+# that persist after initial attempts at addressing in BLT: https://github.com/acquia/blt/pull/2922
 
-$blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes
+cacheDir=`/usr/bin/env php /mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri`
+
+# Print to cloud task log.
+echo "Generated temporary drush cache directory: $cacheDir."
+
+# Print to cloud task log.
+echo "Running BLT deploy tasks on $uri domain in $env environment on the $site subscription."
+
+DRUSH_PATHS_CACHE_DIRECTORY=$cacheDir $blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes --no-interaction
+

--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -53,11 +53,6 @@ class ConfigCommand extends BltTasks {
 
       $task = $this->taskDrush()
         ->stopOnFail()
-        // Sometimes drush forgets where to find its aliases.
-        ->drush("cc")->arg('drush')
-        // Rebuild caches in case service definitions have changed.
-        // @see https://www.drupal.org/node/2826466
-        ->drush("cache-rebuild")
         // Execute db updates.
         // This must happen before features are imported or configuration is
         // imported. For instance, if you add a dependency on a new extension to

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -605,5 +605,23 @@ class Updates {
     $this->updater->getOutput()->writeln($formattedBlock);
     $this->updater->getOutput()->writeln("");
   }
-
+  /**
+   * 9.1.2.
+   *
+   * @Update(
+   *    version = "9002000",
+   *    description = "Factory Hooks Drush 9 bug fixes and enhancements."
+   * )
+   */
+  public function update_9002000() {
+      if (file_exists($this->updater->getRepoRoot() . '/factory-hooks')) {
+      $messages[] = "This update will update the files in your existing factory hooks directory.";
+      $messages[] = "Review the resulting files and ensure that any customizations have been re-added.";
+      $this->updater->executeCommand("./vendor/bin/blt recipes:acsf:init:hooks");
+    }
+    $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
+    $this->updater->getOutput()->writeln("");
+    $this->updater->getOutput()->writeln($formattedBlock);
+    $this->updater->getOutput()->writeln("");
+  }
 }


### PR DESCRIPTION
Fixes #3158 subtasks
--------

Changes proposed:
---------

- Adds utility script for generating unique drush cache directory per site / environment 
- Creates and sets unique drush cache directory per site process for db update tasks on ACSF
- Removes redundant cache clears resetting site context
- Adds BLT update hook

Steps to replicate the issue:
----------
the original issue can be replicated by running a site update on ACSF. When the db-update Factory hook is executed, updates and config impport  will fail because the site context is being reset by cache race conditions:

```
[ded-000|10677] - The db-update.sh script has completed: Completed in 27 seconds. Exit code: 0. Standard out: Found installation profile profile1.
sandboxacsf.01live: Running BLT deploy tasks on commercialus.sandboxacsf.acsitefactory.com domain in 01live environemnt on the sandboxacsf subscription.
> drupal:config:import
Executing pre-config-import target hook...
No pre-config-import configured.
 [37;46;1m[info][39;49;22m Executing: mysql --defaults-file=/mnt/tmp/sandboxacsf01live/drush_mmFoqe --database=sandboxacsdb216364 --host=dbmaster-1028 --port=3306 --silent  < /mnt/tmp/sandboxacsf01live/drush_8GA1Hh > /dev/null
 [37;46;1m[info][39;49;22m Executing: mysql --defaults-file=/mnt/tmp/sandboxacsf01live/drush_zNbUU7 --database=sandboxacsdb216364 --host=dbmaster-1028 --port=3306 --silent  < /mnt/tmp/sandboxacsf01live/drush_0NVDab > /dev/null
 [37;46;1m[success][39;49;22m 'drush' cache was cleared.

[33mIn EntityTypeManager.php line 133:[39m
[37;41m                                                               [39;49m
[37;41m  [Drupal\Component\Plugin\Exception\PluginNotFoundException]  [39;49m
[37;41m  The "" entity type does not exist.                           [39;49m
[37;41m                        ...nt/www/html/sandboxacsf01live/docroot
[ExecStack] Done in 0.002s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandboxacsf01live/vendor/bin/drush @self cc drush --uri=commercialus-site.sandboxdigital.net --no-interaction -v --ansi in /mnt/www/html/sandboxacsf01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask] Done in 0.767s
[Acquia\Blt\Robo\Tasks\DrushTask] Running /mnt/www/html/sandboxacsf01live/vendor/bin/drush @self cache-rebuild --uri=commercialus-site.sandboxdigital.net --no-interaction -v --ansi in /mnt/www/html/sandboxacsf01live/docroot
[Acquia\Blt\Robo\Tasks\DrushTask]  Exit code 1  Time 8.993s
[error]  Failed to import configuration! 
[error]  Command `drupal:config:import ` exited with code 1. 
 [error]  Drupal\Core\Entity\EntityStorageException: Exception thrown while performing a schema update. SQLSTATE[22004]: Null value not allowed: 1138 Invalid use of NULL value: ALTER TABLE {taxonomy_term_field_data} CHANGE `status` `status` TINYINT NOT NULL; Array
(
)
 in Drupal\Core\Entity\Sql\SqlContentEntityStorage->wrapSchemaException() (line 1481 of /mnt/www/html/sandboxacsf01live/docroot/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php). 
 [success] Cache rebuild complete.
 [success] Finished performing updates.
```
Steps to verify the solution:
-----------
1. Deploy PR to ACSF environment
2. Run site update at admin/gardens/site-update/update, selecting the branch or tag of this PR
2. Validate that db-update hook in site update executes without errors. To test via the command line as if the task was run by the factory, run `/mnt/www/html/sandbox.01live/factory-hooks/db-update/db-update.sh' 'sandbox' '01live' '[db_role]' [uri]'`, substituting your site, environment, database role, and uri as needed.

 
