### PR TITLE
EditorConfig: Use four-space indents for Python scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Drupal editor configuration normalization
-# @see http://editorconfig.org/
+# @see https://editorconfig.org/
 
 # This is the top-most .editorconfig file; do not search in parent directories.
 root = true
@@ -17,5 +17,5 @@ insert_final_newline = true
 [Makefile,*.mk]
 indent_style = tab
 
-[composer.json]
+[{composer.json,*.py}]
 indent_size = 4


### PR DESCRIPTION
Changes proposed:
---------
(What are you proposing we change?)

- Some Python scripts are in our repo
- Python uses four spaces for indents
- https://www.python.org/dev/peps/pep-0008/#indentation

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. Edit a Python script
2. Press tab
-> Adds two spaces

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. Edit a Python script
2. Press tab
-> Adds four spaces


 
