### PR TITLE
Prevent cache collisions in multisite install tasks

### DIFF
--- a/scripts/factory-hooks/post-install/post-install.php
+++ b/scripts/factory-hooks/post-install/post-install.php
@@ -8,20 +8,93 @@
  * in your subscription. Unlike most API-based hooks, this hook does not
  * take arguments, but instead executes the PHP code it is provided.
  *
- * This is used so that an ACSF site install will match a local BLT site
- * install. After a local site install, the update functions are run.
+ * This is used so that an ACSF site install is identical to the local BLT site
+ * install, with the environment, site, and uri CLI runtime arguments overriding
+ * all other configuration.
  *
  */
 
-$site = $_ENV['AH_SITE_GROUP'];
-$env = $_ENV['AH_SITE_ENVIRONMENT'];
-$target_env = $site . $env;
+use Drush\Drush;
+use Drupal\Component\FileCache\FileCacheFactory;
+use Drupal\Core\Database\Database;
+use Drupal\Core\Site\Settings;
 
-// The public domain name of the website.
-// Run updates against requested domain rather than acsf primary domain.
-$domain = $_SERVER['HTTP_HOST'];
+global $acsf_site_name;
 
-$domain_fragments = explode('.', $_SERVER['HTTP_HOST']);
-$site_name = array_shift($domain_fragments);
+// Acquia hosting site / environment names
+$site = getenv('AH_SITE_GROUP');
+$env = getenv('AH_SITE_ENVIRONMENT');
+$uri = FALSE;
 
-exec("/mnt/www/html/$site.$env/vendor/acquia/blt/bin/blt drupal:update --environment=$env --site=$site_name --define drush.uri=$domain --verbose --yes");
+// ACSF Database Role
+   if (!empty($GLOBALS['gardens_site_settings']['conf']['acsf_db_name'])) {
+      $db_role = $GLOBALS['gardens_site_settings']['conf']['acsf_db_name'];
+    }
+
+$docroot = sprintf('/var/www/html/%s.%s/docroot', $site, $env);
+
+// BLT executable
+$blt = sprintf('/var/www/html/%s.%s/vendor/bin/blt', $site, $env);
+
+/**
+ * Exit on error.
+ *
+ * @param string $message
+ *   A message to write to sdderr.
+ */
+function error($message) {
+  fwrite(STDERR, $message);
+  exit(1);
+}
+
+fwrite(STDERR, sprintf("Running updates on: site: %s; env: %s; db_role: %s; name: %s;\n", $site, $env, $db_role, $acsf_site_name));
+
+include_once $docroot . '/sites/g/sites.inc';
+$sites_json = gardens_site_data_load_file();
+if (!$sites_json) {
+  error('The ACSF site registry could not be loaded from the server.');
+}
+
+foreach ($sites_json['sites'] as $site_domain => $site_info) {
+  if ($site_info['conf']['acsf_db_name'] === $db_role && !empty($site_info['flags']['preferred_domain'])) {
+    $uri = $site_domain;
+    fwrite(STDERR, "Site domain: $uri;\n");
+    break;
+  }
+}
+if (!$uri) {
+  error('Could not find the preferred domain that belongs to the site.');
+}
+
+$docroot = sprintf('/var/www/html/%s.%s/docroot', $site, $env);
+
+// Create a temporary cache directory for this drush process.
+// @TODO: use the cache.php helper script.
+$cache_directory = sprintf('/mnt/tmp/%s.%s/drush_tmp_cache/%s', $site, $env, md5($uri));
+shell_exec(sprintf('mkdir -p %s', escapeshellarg($cache_directory)));
+
+// Execute the updates
+$command = sprintf(
+  'DRUSH_PATHS_CACHE_DIRECTORY=%s %s drupal:update --environment=%s --site=%s --define drush.uri=%s --verbose --yes --no-interaction',
+  escapeshellarg($cache_directory),
+  escapeshellarg($blt),
+  escapeshellarg($env),
+  escapeshellarg($acsf_site_name),
+  escapeshellarg($uri)
+);
+fwrite(STDERR, "Executing: $command with cache dir $cache_directory;\n");
+
+$result = 0;
+$output = array();
+exec($command, $output, $result);
+print join("\n", $output);
+
+// Clean up the drush cache directory.
+shell_exec(sprintf('rm -rf %s', escapeshellarg($cache_directory)));
+
+if ($result) {
+  fwrite(STDERR, "Command execution returned status code: $result!\n");
+  exit($result);
+}
+
+

--- a/scripts/factory-hooks/post-install/post-install.php
+++ b/scripts/factory-hooks/post-install/post-install.php
@@ -22,9 +22,13 @@ use Drupal\Core\Site\Settings;
 global $acsf_site_name;
 
 // Acquia hosting site / environment names
-$site = getenv('AH_SITE_GROUP');
+/*$site = getenv('AH_SITE_GROUP');
 $env = getenv('AH_SITE_ENVIRONMENT');
-$uri = FALSE;
+$uri = FALSE;*/
+
+$site = 'SANDBOX';
+$env = 'local';
+$uri = 'local.sandbox.com'
 
 // ACSF Database Role
    if (!empty($GLOBALS['gardens_site_settings']['conf']['acsf_db_name'])) {
@@ -68,9 +72,10 @@ if (!$uri) {
 
 $docroot = sprintf('/var/www/html/%s.%s/docroot', $site, $env);
 
-// Create a temporary cache directory for this drush process.
-// @TODO: use the cache.php helper script.
-$cache_directory = sprintf('/mnt/tmp/%s.%s/drush_tmp_cache/%s', $site, $env, md5($uri));
+//$cache_directory = sprintf('/mnt/tmp/%s.%s/drush_tmp_cache/%s', $site, $env, md5($uri));
+//cacheDir=`/usr/bin/env php /mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri`
+$cache_directory = exec("/mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri");
+
 shell_exec(sprintf('mkdir -p %s', escapeshellarg($cache_directory)));
 
 // Execute the updates

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -7,7 +7,6 @@
 
 use Acquia\Blt\Robo\Config\ConfigInitializer;
 use Drupal\Component\Utility\Bytes;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Host detection.

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -92,14 +92,10 @@ $is_prod_env = $is_ah_prod_env || $is_pantheon_prod_env;
  * Site directory detection.
  */
 if (!isset($site_path)) {
-  try {
-    $site_path = DrupalKernel::findSitePath(Request::createFromGlobals());
-  }
-  catch (BadRequestHttpException $e) {
-    $site_path = 'sites/default';
-  }
+  $site_path = \Drupal::service('site.path');
 }
 $site_dir = str_replace('sites/', '', $site_path);
+
 
 /*******************************************************************************
  * Acquia Cloud Site Factory settings.

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -5,12 +5,9 @@
    * Setup BLT utility variables, include required files.
    */
 
-  use Acquia\Blt\Robo\Config\ConfigInitializer;
+use Acquia\Blt\Robo\Config\ConfigInitializer;
 use Drupal\Component\Utility\Bytes;
-use Drupal\Core\DrupalKernel;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Host detection.

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -627,26 +627,3 @@ class Updates {
     $this->updater->getOutput()->writeln($formattedBlock);
     $this->updater->getOutput()->writeln("");
   }
-
-    /**
-   * 9.2.1.
-   *
-   * @Update(
-   *    version = "9002001",
-   *    description = "Factory Hooks Drush 9 bug fixes and enhancements for post-install."
-   * )
-   */
-  public function update_9002001() {
-    if (file_exists($this->updater->getRepoRoot() . '/factory-hooks')) {
-      $messages = [
-        "This update will update the files in your existing factory hooks directory.",
-        "Review the resulting files and ensure that any customizations have been re-added.",
-      ];
-      $this->updater->executeCommand("./vendor/bin/blt recipes:acsf:init:hooks");
-    }
-    $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
-    $this->updater->getOutput()->writeln("");
-    $this->updater->getOutput()->writeln($formattedBlock);
-    $this->updater->getOutput()->writeln("");
-  }
-}

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -611,10 +611,32 @@ class Updates {
    *
    * @Update(
    *    version = "9002000",
-   *    description = "Factory Hooks Drush 9 bug fixes and enhancements."
+   *    description = "Factory Hooks Drush 9 bug fixes and enhancements for db-update."
    * )
    */
   public function update_9002000() {
+    if (file_exists($this->updater->getRepoRoot() . '/factory-hooks')) {
+      $messages = [
+        "This update will update the files in your existing factory hooks directory.",
+        "Review the resulting files and ensure that any customizations have been re-added.",
+      ];
+      $this->updater->executeCommand("./vendor/bin/blt recipes:acsf:init:hooks");
+    }
+    $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
+    $this->updater->getOutput()->writeln("");
+    $this->updater->getOutput()->writeln($formattedBlock);
+    $this->updater->getOutput()->writeln("");
+  }
+
+    /**
+   * 9.2.0.
+   *
+   * @Update(
+   *    version = "9002001",
+   *    description = "Factory Hooks Drush 9 bug fixes and enhancements for post-install."
+   * )
+   */
+  public function update_9002001() {
     if (file_exists($this->updater->getRepoRoot() . '/factory-hooks')) {
       $messages = [
         "This update will update the files in your existing factory hooks directory.",

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -629,7 +629,7 @@ class Updates {
   }
 
     /**
-   * 9.2.0.
+   * 9.2.1.
    *
    * @Update(
    *    version = "9002001",

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -627,3 +627,4 @@ class Updates {
     $this->updater->getOutput()->writeln($formattedBlock);
     $this->updater->getOutput()->writeln("");
   }
+}


### PR DESCRIPTION
Fixes #3158 subtasks
--------

Changes proposed:
---------
- Creates and sets unique drush cache directory per site process for post-install site tasks on ACSF
- Adds BLT update hook to refresh hooks

Steps to replicate the issue:
----------
the original issue can be replicated by running a site install / create new site on ACSF. When the existing post-install Factory hook is executed, race conditions result from long running drush tasks such as `cc drush` which then cause failures in importing config and bootstrapping the correct database.

Steps to verify the solution:
-----------
1. Deploy PR to ACSF environment
2. Create site
2. Validate that post-install hook executes without errors. To test via the command line as if the task was run by the factory, run `CACHE_PREFIX='/mnt/tmp/sandbox.01live' \drush8 --root='/mnt/www/html/sandbox.01live/docroot' -l 'site.sandbox.acsitefactory.com' scr --script-path='/mnt/www/html/sandbox.01live/factory-hooks/post-install' 'post-install.php'`, substituting your site, environment, database role, and uri as needed.