### PR TITLE
Fixes #3185 to bring install and local docs inline.

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,7 +8,7 @@ You must have the following tools on the command line of your *host operating sy
 
 * [Git](https://git-scm.com/)
 * [Composer](https://getcomposer.org/download/)
-* [PHP 5.6+](http://php.net/manual/en/install.php) (though PHP 7.1+ is recommended)
+* [PHP 7.1+](http://php.net/manual/en/install.php)
 
 Instructions for installing _all_ requirements for various operating systems are listed below. In general, make sure all installed tools are the most recent version unless otherwise noted.
 
@@ -20,7 +20,7 @@ If you need to make requests via a proxy server, please [configure git to use a 
 
 ## Installing requirements
 
-### Mac OSX
+### macOS
 
 Ensure that [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) is installed (primarily in order to support Homebrew). On OSX 10.9+ you can install Xcode with:
 
@@ -30,16 +30,12 @@ Ensure that [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12) is 
 Then install the minimum dependencies for BLT. The preferred method is via Homebrew, though you could install these yourself without a package manager.
 
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-        brew install php71 git composer
+        brew install php71 git composer drush
         composer global require "hirak/prestissimo:^0.3"
 
 Note that the recommended installation method for Drush has changed recently. Drush should only be installed as a dependency of individual projects, rather than being installed system-wide. BLT will manage this dependency for you on projects, but in order for you to run Drush commands independently of BLT commands you need to install the Drush Launcher: [Drush Launcher Installation](https://github.com/drush-ops/drush-launcher#installation---phar).
 
-If you'd like to create a [Drupal VM](https://www.drupalvm.com/) with BLT, you will require the following additional libraries. If you'd like to use a LAMP stack other than Drupal VM, see [Local Development](local-development.md).
-
-        brew tap caskroom/cask
-        brew cask install virtualbox vagrant
-        vagrant plugin install vagrant-hostsupdater
+If you'd like to use [Drupal VM](https://www.drupalvm.com/) with BLT, Drupal VM has additional requirements. See the [Drupal VM Requirements](https://blt.readthedocs.io/en/latest/local-development/#using-drupal-vm-for-blt-generated-projects) to add these. If you'd like to use a LAMP stack other than Drupal VM, see [Local Development](local-development.md).
 
 If you are not using a VM, and you'd like to execute Behat tests from the host machine, you will need Java:
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -18,10 +18,10 @@ Acquia developers use [PHPStorm](http://www.jetbrains.com/phpstorm/) and recomme
 
 To use [Drupal VM](http://www.drupalvm.com/) with a Drupal project that is generated with BLT:
 
-1. Download the Drupal VM dependencies listed in [Drupal VM's README](https://github.com/geerlingguy/drupal-vm#quick-start-guide). If you're running [Homebrew](http://brew.sh/index.html) on Mac OSX, this is as simple as:
+1. Download the Drupal VM dependencies listed in [Drupal VM's README](https://github.com/geerlingguy/drupal-vm#quick-start-guide). If you're running [Homebrew](http://brew.sh/index.html) on macOS, this is as simple as:
 
         brew tap caskroom/cask
-        brew install php56 git composer ansible drush
+        brew install php71 git composer ansible drush
         brew cask install virtualbox vagrant
 
 1. Create & boot the VM
@@ -33,7 +33,7 @@ To use [Drupal VM](http://www.drupalvm.com/) with a Drupal project that is gener
         git add -A
         git commit -m <your commit meessage>
 
-1. Install Drupal
+1. Install Drupal and finalize BLT setup
 
         vagrant ssh
         blt setup


### PR DESCRIPTION
Fixes #3185 
--------

Changes proposed:
---------
(What are you proposing we change?)

- updates php requirements in install docs to be php71
- removes specific drupal vm requirements from install docs and instead links to drupal vm docs (currently install and local docs are not in sync, ansible was missing from install docs, etc.)
- adds drush as a minimum dependency for blt


 
