### PR TITLE
Update deploy.md with correct Cloud Hooks links.

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -83,7 +83,7 @@ Instead of performing these deployments manually, you can enlist the help of a C
 
 ## Cloud Hooks
 
-On Acquia Cloud, [Cloud Hooks](https://docs.acquia.com/cloud/manage/cloud-hooks) are the preferred method to run database updates and configuration imports on each deploy. BLT provides a post-code-deploy hook that will conveniently run these updates automatically and fail the deployment task in Insight if anything goes wrong.
+On Acquia Cloud, [Cloud Hooks](https://docs.acquia.com/acquia-cloud/develop/api/cloud-hooks/) are the preferred method to run database updates and configuration imports on each deploy. BLT provides a post-code-deploy hook that will conveniently run these updates automatically and fail the deployment task in Insight if anything goes wrong.
 
 To install Acquia Cloud hooks for your BLT project:
 
@@ -91,7 +91,7 @@ To install Acquia Cloud hooks for your BLT project:
 
         blt recipes:cloud-hooks:init
 
-    This will add a hooks directory in your project root based on [BLT's default Acquia Cloud hooks](https://github.com/acquia/blt/tree/8.x/scripts/cloud-hooks/hooks).
+    This will add a hooks directory in your project root based on [BLT's default Acquia Cloud hooks](https://github.com/acquia/blt/tree/10.0.x/scripts/cloud-hooks/hooks).
 
 1. Commit the new directory and push it to your Acquia git remote. Example commands:
 


### PR DESCRIPTION
Fixes # 
--------

The Acquia docs link pointed to a stale page and the BLT one pointed to the 8.x branch, both throwing 404's. I've updated both to point to the latest iterations of each page.

Changes proposed:
---------
(What are you proposing we change?)

- Swap out old links that throw 404's with working links


Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. Navigate to https://blt.readthedocs.io/en/latest/deploy/#cloud-hooks and click on the two links in the paragraph, both links throw 404.

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. Navigate to https://blt.readthedocs.io/en/latest/deploy/#cloud-hooks and click on the two links in the paragraph, both links should now be linked to the correct doc pages.

 
