### PR TITLE
[9.2.x] Add patchutils through extra_packages in VM config (#3191)

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -78,6 +78,7 @@ nodejs_npm_global_packages:
   - name: yarn
 nodejs_install_npm_user: "{{ drupalvm_user }}"
 npm_config_prefix: "/home/{{ drupalvm_user }}/.npm-global"
+extra_packages: ${extra_packages}
 installed_extras: ${installed_extras}
 
 # PHP 7.1.

--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -277,6 +277,10 @@ class VmCommand extends BltTasks {
     switch ($base_box) {
       case 'beet/box':
         $config->set('workspace', '/beetbox/workspace/{{ php_version }}');
+        $config->set('extra_packages', [
+          'patchutils',
+          'sqlite',
+        ]);
         $config->set('installed_extras', [
           'drush',
           'nodejs',
@@ -287,6 +291,10 @@ class VmCommand extends BltTasks {
 
       case 'geerlingguy/ubuntu1604':
         $config->set('workspace', '/root');
+        $config->set('extra_packages', [
+          'patchutils',
+          'sqlite',
+        ]);
         $config->set('installed_extras', [
           'adminer',
           'selenium',


### PR DESCRIPTION
Fixes #3191 
--------

Changes proposed:
---------
- Add `patchutils` through `extra_packages` in VM config.

Steps to verify the solution:
-----------

1. Create new project with `composer create-project --no-interaction acquia/blt-project my-project` then `cd my-project/`
2. Apply changes from this PR to `acquia/blt`
3. Run `blt vm` and proceed with `y`, choose either `beet/box` or `geerlingguy/ubuntu1604`
4. When provision  is complete, `vagrant ssh`
5. `interdiff` should return output like:
```
usage: interdiff [OPTIONS] patch1 patch2
       interdiff --version|--help

{...}

```

 