### PR TITLE
Fixing updates 9002000 message.

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -621,10 +621,11 @@ class Updates {
         "Review the resulting files and ensure that any customizations have been re-added.",
       ];
       $this->updater->executeCommand("./vendor/bin/blt recipes:acsf:init:hooks");
+      $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
+      $this->updater->getOutput()->writeln("");
+      $this->updater->getOutput()->writeln($formattedBlock);
+      $this->updater->getOutput()->writeln("");
     }
-    $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
-    $this->updater->getOutput()->writeln("");
-    $this->updater->getOutput()->writeln($formattedBlock);
-    $this->updater->getOutput()->writeln("");
   }
+
 }


### PR DESCRIPTION
When update command runs and no factory hooks exist, this command errors.

This is against `9.2.x` - is that right? It's such a small error, but this gave me...

```sh
Notice: Undefined variable: messages in /var/www/project/vendor/acquia/blt/src/Update/Updates.php on line 625
```