### PR TITLE
Fixing missing semi-colon at end of line.

### DIFF
--- a/scripts/factory-hooks/post-install/post-install.php
+++ b/scripts/factory-hooks/post-install/post-install.php
@@ -28,7 +28,7 @@ $uri = FALSE;*/
 
 $site = 'SANDBOX';
 $env = 'local';
-$uri = 'local.sandbox.com'
+$uri = 'local.sandbox.com';
 
 // ACSF Database Role
    if (!empty($GLOBALS['gardens_site_settings']['conf']['acsf_db_name'])) {


### PR DESCRIPTION
Fixes # 
--------
No issue created.  Noticed missing semi-colon at end of line in post-install.php

Changes proposed:
---------
Add the semicolon and prevent many headaches.

-
-

Steps to replicate the issue:
----------
1. Use a PHP linter on post-install.php

Steps to verify the solution:
-----------
1. Use a PHP linter on post-install.php
 
