### PR TITLE
[9.2.x] Fix undefined trusted_reverse_proxy_ips #3214 

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -20,6 +20,12 @@ $request_method = getenv('REQUEST_METHOD');
 $request_uri = getenv('REQUEST_URI');
 $http_x_request_id = getenv('HTTP_X_REQUEST_ID');
 
+// If trusted_reverse_proxy_ips is not defined, fail gracefully.
+$trusted_reverse_proxy_ips = isset($trusted_reverse_proxy_ips) ? $trusted_reverse_proxy_ips : '';
+if (!is_array($trusted_reverse_proxy_ips)) {
+  $trusted_reverse_proxy_ips = [];
+}
+
 // Tell Drupal whether the client arrived via HTTPS. Ensure the
 // request is coming from our load balancers by checking the IP address.
 if (getenv('HTTP_X_FORWARDED_PROTO') == 'https'


### PR DESCRIPTION
Fixes #3214 
--------

Changes proposed:
---------
(What are you proposing we change?)

- check if trusted_reverse_proxy_ips is defined as an array
- if not, set an empty array

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. blt setup
2. bootstrap drupal

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. apply the patch
2. blt setup / bootstrap Drupal
3. check to ensure following warning does not appear:

```
Warning: in_array() expects parameter 2 to be array, null given in require() (line 27 of /app/vendor/acquia/blt/settings/blt.settings.php).
require('/app/vendor/acquia/blt/settings/blt.settings.php') (Line: 806)
require('/app/docroot/sites/naswa_main/settings.php') (Line: 125)
Drupal\Core\Site\Settings::initialize('/app/docroot', 'sites/naswa_main', Object) (Line: 1056)
Drupal\Core\DrupalKernel->initializeSettings(Object) (Line: 655)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```
 
