### PR TITLE
Adds documentation for the Docksal environment

### DIFF
--- a/docs/alternative-environment-tips/docksal.md
+++ b/docs/alternative-environment-tips/docksal.md
@@ -1,0 +1,94 @@
+# Setting up BLT with Docksal
+
+By default, BLT is set to work with Drupal VM. It is easy to set up to use with Docksal, but
+you will have to install the Docksal `blt` addon command and make some configuration changes.
+
+## Setting Your Project to Use Docksal
+
+If you already have Docksal installed on your system, setting your BLT project to use Docksal only
+requires that you add a `.docksal` directory in your project and run `fin up` in the command prompt
+of your project directory. See the [Docksal Documentation](https://docs.docksal.io) for more specific
+Docksal information.
+
+## Using the Docksal `blt` Command
+
+BLT will install a `blt alias` command on your host system. Running the `blt` command will
+then use the resources of your host system. Instead, you need to make sure you're running
+the commands through the Docksal CLI service.
+
+Install the Docksal `blt` addon command:
+```
+fin addon install blt
+```
+
+Run any blt command with `fin` and you will be running the command within the Docksal CLI, e.g.:
+```
+fin blt doctor
+```
+
+
+## Setting the Database Connection and Drush Alias
+
+### New Project Setup
+
+The default Docksal database settings are different than the BLT defaults. If you have not already 
+added special settings to the local.settings.php file that BLT creates, it is best to begin by 
+following these steps:
+
+1. remove the `docroot/sites/default/settings/local.settings.php` and the `docroot/sites/default/local.drush.yml` files
+2. update the blt.yml file in your project's blt directory:
+
+    ```
+    project:
+      machine_name: myproject
+      local:
+        hostname: '${env.VIRTUAL_HOST}'
+    drupal:
+      db:
+        database: default
+        username: user
+        password: user
+        host: db
+        port: 3306
+    ```
+3. initiate and verify blt settings
+    ```
+    fin blt blt:init:settings
+    ```
+4. setup your Drupal site
+    ```
+    fin blt setup -D setup.strategy=install
+    ```
+    
+### Existing project setup
+If you have an existing BLT project with Drupal install, you may prefer to configure your `local.settings.php` 
+file and your `local.drush.yml` file. It is best practice to also update your blt.yml as outlined above, but
+it is not necessary to delete these files. 
+
+1. configure your `docroot/sites/default/settings/local.settings.php` file with these variable values:
+
+    ```
+    $db_name = 'default';
+    
+    $databases = array(
+      'default' =>
+      array(
+        'default' =>
+        array(
+          'database' => $db_name,
+          'username' => 'user',
+          'password' => 'user',
+          'host' => 'db',
+          'port' => '3306',
+          'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+          'driver' => 'mysql',
+          'prefix' => '',
+        ),
+      ),
+    );
+    ```
+2. configure your `docroot/sites/default/local.drush.yml` file:
+    ```
+    options:
+      uri: 'http://myproject.docksal'
+    ```

--- a/docs/alternative-environment-tips/docksal.md
+++ b/docs/alternative-environment-tips/docksal.md
@@ -31,8 +31,8 @@ fin blt doctor
 
 ### New Project Setup
 
-The default Docksal database settings are different than the BLT defaults. If you have not already 
-added special settings to the local.settings.php file that BLT creates, it is best to begin by 
+The default Docksal database settings are different than the BLT defaults. If you have not already
+added special settings to the local.settings.php file that BLT creates, it is best to begin by
 following these steps:
 
 1. remove the `docroot/sites/default/settings/local.settings.php` and the `docroot/sites/default/local.drush.yml` files
@@ -59,17 +59,17 @@ following these steps:
     ```
     fin blt setup -D setup.strategy=install
     ```
-    
+
 ### Existing project setup
-If you have an existing BLT project with Drupal install, you may prefer to configure your `local.settings.php` 
+If you have an existing BLT project with Drupal install, you may prefer to configure your `local.settings.php`
 file and your `local.drush.yml` file. It is best practice to also update your blt.yml as outlined above, but
-it is not necessary to delete these files. 
+it is not necessary to delete these files.
 
 1. configure your `docroot/sites/default/settings/local.settings.php` file with these variable values:
 
     ```
     $db_name = 'default';
-    
+
     $databases = array(
       'default' =>
       array(
@@ -92,3 +92,18 @@ it is not necessary to delete these files.
     options:
       uri: 'http://myproject.docksal'
     ```
+3. Assuming your site's drush remote is @sitegroup.siteid then you can update your BLT configuration (either at the project level or site level):
+    
+    At the project level (blt/blt.yml) or site level (e.g. sites/default/blt.yml):
+    ```
+    setup:
+      strategy: sync
+    
+    drush:
+      aliases:
+        remote: sitegroup.siteid
+    ```
+So when setting up the project for the first time when running fin blt setup it will execute the sync setup strategy rather than the install strategy
+(sql:sync vs site:install), effectively executing 
+`drush sql:sync @sitegroup.siteid @self`.
+

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -105,4 +105,6 @@ It is up to each team to choose how to handle local development, but some of the
 If you choose to use a different solution than recommended here, please make sure it fits all the needs of your team and project, and will not be a hindrance to project development velocity!
 
 While the BLT team cannot officially support these alternative environments, please submit documentation of any special steps necessary with the tool you choose so that others can learn from your experience. Environments for which others have contributed tips include:
-- [Lando](alternative-environment-tips/lando.md)
+
+* [Docksal](alternative-environment-tips/docksal.md)
+* [Lando](alternative-environment-tips/lando.md)


### PR DESCRIPTION
I wasn't sure which branch to propose the PR for. It's here for 9.2.x, but should certainly be included in 10.0.x also.

At the request of @mikemadison13, I put together this documentation page on using BLT in the Docksal environment. I had a little help from @lpeabody in the direction of what should be included in this page.
