### PR TITLE
Multisite bugfixes

### DIFF
--- a/scripts/factory-hooks/post-install/post-install.php
+++ b/scripts/factory-hooks/post-install/post-install.php
@@ -14,30 +14,21 @@
  *
  */
 
-use Drush\Drush;
-use Drupal\Component\FileCache\FileCacheFactory;
-use Drupal\Core\Database\Database;
-use Drupal\Core\Site\Settings;
-
-global $acsf_site_name;
-
-// Acquia hosting site / environment names
-/*$site = getenv('AH_SITE_GROUP');
+// Acquia hosting site / environment names.
+$site = getenv('AH_SITE_GROUP');
 $env = getenv('AH_SITE_ENVIRONMENT');
-$uri = FALSE;*/
+$uri = FALSE;
 
-$site = 'SANDBOX';
-$env = 'local';
-$uri = 'local.sandbox.com';
+global $_acsf_site_name;
 
-// ACSF Database Role
-   if (!empty($GLOBALS['gardens_site_settings']['conf']['acsf_db_name'])) {
-      $db_role = $GLOBALS['gardens_site_settings']['conf']['acsf_db_name'];
-    }
+// ACSF Database Role.
+if (!empty($GLOBALS['gardens_site_settings']['conf']['acsf_db_name'])) {
+  $db_role = $GLOBALS['gardens_site_settings']['conf']['acsf_db_name'];
+}
 
 $docroot = sprintf('/var/www/html/%s.%s/docroot', $site, $env);
 
-// BLT executable
+// BLT executable.
 $blt = sprintf('/var/www/html/%s.%s/vendor/bin/blt', $site, $env);
 
 /**
@@ -51,7 +42,7 @@ function error($message) {
   exit(1);
 }
 
-fwrite(STDERR, sprintf("Running updates on: site: %s; env: %s; db_role: %s; name: %s;\n", $site, $env, $db_role, $acsf_site_name));
+fwrite(STDERR, sprintf("Running updates on: site: %s; env: %s; db_role: %s; name: %s;\n", $site, $env, $db_role, $_acsf_site_name));
 
 include_once $docroot . '/sites/g/sites.inc';
 $sites_json = gardens_site_data_load_file();
@@ -72,13 +63,11 @@ if (!$uri) {
 
 $docroot = sprintf('/var/www/html/%s.%s/docroot', $site, $env);
 
-//$cache_directory = sprintf('/mnt/tmp/%s.%s/drush_tmp_cache/%s', $site, $env, md5($uri));
-//cacheDir=`/usr/bin/env php /mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri`
 $cache_directory = exec("/mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri");
 
 shell_exec(sprintf('mkdir -p %s', escapeshellarg($cache_directory)));
 
-// Execute the updates
+// Execute the updates.
 $command = sprintf(
   'DRUSH_PATHS_CACHE_DIRECTORY=%s %s drupal:update --environment=%s --site=%s --define drush.uri=%s --verbose --yes --no-interaction',
   escapeshellarg($cache_directory),
@@ -92,7 +81,7 @@ fwrite(STDERR, "Executing: $command with cache dir $cache_directory;\n");
 $result = 0;
 $output = array();
 exec($command, $output, $result);
-print join("\n", $output);
+print implode("\n", $output);
 
 // Clean up the drush cache directory.
 shell_exec(sprintf('rm -rf %s', escapeshellarg($cache_directory)));
@@ -101,5 +90,3 @@ if ($result) {
   fwrite(STDERR, "Command execution returned status code: $result!\n");
   exit($result);
 }
-
-

--- a/scripts/factory-hooks/post-settings-php/memcache.php
+++ b/scripts/factory-hooks/post-settings-php/memcache.php
@@ -8,11 +8,9 @@
  */
 
 // Use ACSF internal settings site flag to apply memcache settings.
-if (getenv('AH_SITE_ENVIRONMENT') && 
-	isset($site_settings['flags']['memcache_enabled']) &&
-	isset($settings['memcache']['servers'])
+if (getenv('AH_SITE_ENVIRONMENT') &&
+    isset($site_settings['flags']['memcache_enabled']) &&
+    isset($settings['memcache']['servers'])
 ) {
   require DRUPAL_ROOT . '/../vendor/acquia/blt/settings/memcache.settings.php';
 }
-
-

--- a/scripts/factory-hooks/post-sites-php/includes.php
+++ b/scripts/factory-hooks/post-sites-php/includes.php
@@ -1,12 +1,15 @@
 <?php
+
 /**
  * @file
  * Example implementation of ACSF post-sites-php hook.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
  */
+
 // The function_exists check is required as the file is included several times.
 if (!function_exists('gardens_data_get_sites_from_file')) {
+
   /**
    * Get the domains defined for the given site.
    *
@@ -32,7 +35,7 @@ if (!function_exists('gardens_data_get_sites_from_file')) {
       elseif ($map = gardens_site_data_load_file()) {
         $domains = array_filter(
           $map['sites'],
-          function($item) use ($name) {
+          function ($item) use ($name) {
             return $item['name'] == $name;
           }
         );
@@ -46,9 +49,10 @@ if (!function_exists('gardens_data_get_sites_from_file')) {
     }
     return $domains;
   }
+
 }
 // Get all the domains that are defined for the current site.
 $domains = gardens_data_get_sites_from_file($data['gardens_site_settings']['conf']['acsf_db_name']);
 // Get the site's name from the first domain.
-global $acsf_site_name;
-$acsf_site_name = explode('.', array_keys($domains)[0])[0];
+global $_acsf_site_name;
+$_acsf_site_name = explode('.', array_keys($domains)[0])[0];

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -151,7 +151,7 @@ if ($is_acsf_inited) {
     $name = array_slice($domain_fragments, 1);
     $acsf_sites = $blt_config->get('multisites');
     if (in_array($name, $acsf_sites)) {
-      $acsf_site_name = $name;
+      $_acsf_site_name = $name;
     }
   }
 }

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -96,7 +96,7 @@ if ($split != 'none') {
 $config["$split_filename_prefix.$site_dir"]['status'] = TRUE;
 
 // Set acsf site split if explicit global exists.
-if (isset($acsf_site_name)) {
+if (isset($_acsf_site_name)) {
   $config["$split_filename_prefix.$acsf_site_name"]['status'] = TRUE;
 }
 

--- a/src/Robo/Commands/Generate/MultisiteCommand.php
+++ b/src/Robo/Commands/Generate/MultisiteCommand.php
@@ -187,7 +187,7 @@ class MultisiteCommand extends BltTasks {
     $site_yml['project']['human_name'] = $site_name;
     $site_yml['project']['local']['protocol'] = $url['scheme'];
     $site_yml['project']['local']['hostname'] = $url['host'];
-    $site_yml['drush']['aliases']['local'] = $site_name . ".local";
+    $site_yml['drush']['aliases']['local'] = "self";
     $site_yml['drush']['aliases']['remote'] = $remote_alias;
     YamlMunge::mergeArrayIntoFile($site_yml, $site_yml_filename);
   }

--- a/tests/phpunit/BltProject/MultiSiteTest.php
+++ b/tests/phpunit/BltProject/MultiSiteTest.php
@@ -42,7 +42,7 @@ class MultiSiteTest extends BltProjectTestBase {
     $this->assertEquals("$this->site1Dir.clone", $site1_blt_yml['drush']['aliases']['remote']);
 
     $site2_blt_yml = YamlMunge::parseFile("$this->sandboxInstance/docroot/sites/$this->site2Dir/blt.yml");
-    $this->assertEquals("$this->site2Dir.local", $site2_blt_yml['drush']['aliases']['local']);
+    $this->assertEquals("self", $site2_blt_yml['drush']['aliases']['local']);
     $this->assertEquals("$this->site2Dir.clone", $site2_blt_yml['drush']['aliases']['remote']);
 
     // Clone.


### PR DESCRIPTION
Fixes #3207 
--------

Changes proposed:
---------
- Update local multisite drush alias because non-self aliases will cause ssh recursion to localhost within VM
- Fix alias bug for site2 alias in testMultisiteGeneratea
- Fix hard-coded Acquia Cloud environment variable overrides
- Resolve phpcs errors in ACSF and muiltisite hooks/settings

Steps to replicate the issues:
----------

To recreate errors phpunit test errors seen on https://travis-ci.org/acquia/blt/jobs/449314384#L5991-L5999: 
1. Run ./vendor/bin/robo release:tests
2. Observe:
```
1) Acquia\Blt\Tests\Blt\MultiSiteTest::testMultisiteGenerate
Exception: BLT command exited with non-zero exit code.
/home/travis/build/acquia/blt/tests/phpunit/src/BltProjectTestBase.php:276
/home/travis/build/acquia/blt/tests/phpunit/BltProject/MultiSiteTest.php:88
```
3. Run ./vendor/bin/robo sniff-code to observe phpcs and other syntax errors in factory hooks reported in #3207

Steps to verify the solution:
-----------

1. PR build passes
2. `./vendor/bin/robo release:tests` / testMultisiteGenerate passes and no phpcs errors are reported (`./vendor/bin/robo sniff-code` runs as part of the release:tests command)
 
