### PR TITLE
Update onboarding.md

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,6 +1,8 @@
 # Onboarding
 
-Here is a quick-start guide to getting your local development environment set up and getting oriented with the project standards and workflows.
+This document is intended for developers who have joined a project that *already has BLT installed.* It is a quick-start guide for getting your local development environment set up and getting oriented with the project standards and workflows.
+
+*If you are attempting to add BLT to a project or create a new BLT-based project, do not use this document.* Instead, refer to [INSTALL.md](INSTALL.md).
 
 ## Before you start...
 


### PR DESCRIPTION
At Engage 2018, I received feedback from developers who tried to follow the steps in onboarding.md to create a new BLT-based project, rather than following the steps in INSTALL.md and creating-new-project.md. Obviously this didn't result in great success.

I could see how this would be confusing if you somehow jumped past all of the other documentation and landed on the onboarding page (presumably via a Google search or something).

Seems like a disclaimer is probably the best approach, unless someone can think of a better way to name/organize the whole document, and/or make it less likely to get deep-linked from Google.