### PR TITLE
BLT-3256: commit-msg UX improvements.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -94,6 +94,12 @@ git:
   commit-msg:
     # Commit messages must conform to this pattern.
     pattern: "/(^${project.prefix}-[0-9]+(: )[^ ].{15,}\\.)|(Merge branch (.)+)/"
+    # Human readable help description explaining the pattern/restrictions.
+    help_description: "The commit message should include your project prefix,
+                      followed by a hyphen and ticket number, followed by a colon and a space,
+                      fifteen characters or more describing the commit, and end with a period."
+    # Provide an example of a valid commit message.
+    example: "${project.prefix}-123: Update module configuration."
 
 # You may provide a list of sites for BLT to run commands against,
 # otherwise BLT will generate this sites list based on directories

--- a/src/Robo/Commands/Git/GitCommand.php
+++ b/src/Robo/Commands/Git/GitCommand.php
@@ -22,10 +22,18 @@ class GitCommand extends BltTasks {
   public function commitMsgHook($message) {
     $this->say('Validating commit message syntax...');
     $pattern = $this->getConfigValue('git.commit-msg.pattern');
+    $help_description = $this->getConfigValue('git.commit-msg.help_description');
+    $example = $this->getConfigValue('git.commit-msg.example');
     $this->logger->debug("Validing commit message with regex <comment>$pattern</comment>.");
     if (!preg_match($pattern, $message)) {
       $this->logger->error("Invalid commit message!");
       $this->say("Commit messages must conform to the regex $pattern");
+      if (!empty($help_description)) {
+        $this->say("$help_description");
+      }
+      if (!empty($example)) {
+        $this->say("Example: $example");
+      }
       $this->logger->notice("To disable this command, see http://blt.rtfd.io/en/9.x/readme/extending-blt/#git-hooks");
       $this->logger->notice("To customize git hooks, see http://blt.rtfd.io/en/9.x/readme/extending-blt/#setupgit-hooks.");
 


### PR DESCRIPTION
Fixes #3236 
--------

Changes proposed:
---------
(What are you proposing we change?)

- add `help_description` and `example` options for git commit-msg validation help
- regex pattern alone may be confusing to new developers

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. Pull down PR into an existing BLT project repo using 9.2.x
2. Make a local change to code so that there is something to commit
3. Commit change using a malformed commit message, e.g., "Test 123"
4. When git commit-msg hook fires, it should return an error that the commit message is invalid, along with the regex pattern, but now also includes "human readable help description" text describing the regex and an "example" of a valid commit message

Here's the updated error message:

```
Executing .git/hooks/pre-commit...
> tests:phpcs:sniff:files
Sniffing directories containing changed files...
[File\Write] Writing to /Users/brian.tully/Sites/mndor/tmp/phpcs-fileset.
[ExecStack] '/Users/brian.tully/Sites/mndor/vendor/bin/phpcs' --file-list='/Users/brian.tully/Sites/mndor/tmp/phpcs-fileset' --bootstrap='/Users/brian.tully/Sites/mndor/vendor/acquia/blt/src/Robo/Commands/Validate/phpcs-validate-files-bootstrap.php' -l
> tests:twig:lint:files
Linting twig files...
All Twig files contain valid syntax.
> tests:yaml:lint:files
Linting YAML files...
Your local code has passed git pre-commit validation.
Executing .git/hooks/commit-msg...
Validating commit message syntax...
[error]  Invalid commit message! 
Commit messages must conform to the regex /(^MNR-[0-9]+(: )[^ ].{15,}\.)|(Merge branch (.)+)/
The commit message should include your project prefix, followed by a hyphen and ticket number, followed by a colon and a space, fifteen characters or more describing the commit, and end with a period.
Example: MNR-123: Update module configuration.
[notice] To disable this command, see http://blt.rtfd.io/en/9.x/readme/extending-blt/#git-hooks
[notice] To customize git hooks, see http://blt.rtfd.io/en/9.x/readme/extending-blt/#setupgit-hooks.
```


 
