### PR TITLE
Simplifying onboarding doc

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -9,7 +9,7 @@ You have probably been linked to this documentation by a project that is using B
 * BLT is distributed as a Composer package. This means that the project you are working on requires BLT as a dependency in its composer.json file. This also means that you don't need to install or configure BLT globally on your machine, or as a separate tool--simply run `composer install` on the parent project and install a tiny bash alias (as described below), and you're good to go.
 * You will need some project-specific information to set up your local environment, specifically whether you are using a virtual development environment (e.g., DrupalVM), and the name of your mainline development branch (`develop` or `master`). This should be referenced in your project's README.
 * If you need help, check with your project team first, since they may have already encountered any issue you are experiencing. Then post an issue in the [BLT issue queue](https://github.com/acquia/blt/issues). The issue queue isn't only for bugs--we welcome feedback on all aspects of the developer experience.
-* Verify that your local system and network meet the [BLT system requirements](INSTALL.md). Also ensure that you have dependencies installed for any virtual development environment (such as [VirtualBox and Vagrant for DrupalVM](https://github.com/geerlingguy/drupal-vm#1---install-vagrant-and-virtualbox)).
+* Verify that your local system and network meet the [BLT system requirements](INSTALL.md). Also ensure that you have dependencies installed for any virtual development environment (such as [VirtualBox and Vagrant for DrupalVM](local-development/#using-drupal-vm-for-blt-generated-projects)).
 * Because BLT makes use of a variety of best practice development tools and processes (Composer, Git, etc...), you should verify that you have the necessary [skillset(s)](skills.md) to develop with BLT.
 
 ## Initial Setup
@@ -24,7 +24,7 @@ You have probably been linked to this documentation by a project that is using B
 1. Run `composer install` (you must already have Composer installed).
 1. Install `blt` alias: `./vendor/bin/blt blt:init:shell-alias -y`. At this point you might need restart your shell in order for the alias work.
 
-If your project uses a virtual development environment such as Drupal VM:
+If your project uses a virtual development environment such as [Drupal VM](local-development/#using-drupal-vm-for-blt-generated-projects):
 
 1. Start the VM: `vagrant up`
 1. SSH into the VM: `vagrant ssh`

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -9,12 +9,11 @@ You have probably been linked to this documentation by a project that is using B
 * BLT is distributed as a Composer package. This means that the project you are working on requires BLT as a dependency in its composer.json file. This also means that you don't need to install or configure BLT globally on your machine, or as a separate tool--simply run `composer install` on the parent project and install a tiny bash alias (as described below), and you're good to go.
 * You will need some project-specific information to set up your local environment, specifically whether you are using a virtual development environment (e.g., DrupalVM), and the name of your mainline development branch (`develop` or `master`). This should be referenced in your project's README.
 * If you need help, check with your project team first, since they may have already encountered any issue you are experiencing. Then post an issue in the [BLT issue queue](https://github.com/acquia/blt/issues). The issue queue isn't only for bugs--we welcome feedback on all aspects of the developer experience.
-* You should verify that your local system and network meet [System requirements](INSTALL.md).
+* Verify that your local system and network meet the [BLT system requirements](INSTALL.md). Also ensure that you have dependencies installed for any virtual development environment (such as [VirtualBox and Vagrant for DrupalVM](https://github.com/geerlingguy/drupal-vm#1---install-vagrant-and-virtualbox)).
 * Because BLT makes use of a variety of best practice development tools and processes (Composer, Git, etc...), you should verify that you have the necessary [skillset(s)](skills.md) to develop with BLT.
 
 ## Initial Setup
 
-1. Verify that your system meets the [system requirements for BLT](INSTALL.md)
 1. [Fork](https://help.github.com/articles/fork-a-repo) the primary GitHub repository for the project you are developing
 1. Clone your fork to your local machine (by convention, BLT refers to your fork as "origin" and the primary repo as "upstream"):
 
@@ -27,8 +26,8 @@ You have probably been linked to this documentation by a project that is using B
 
 If your project uses a virtual development environment such as Drupal VM:
 
-1. Make sure you have installed any prerequisites. For DrupalVM, see the [quick start guide](https://github.com/geerlingguy/drupal-vm#quick-start-guide).
-1. If this is your first time using this project's VM on your machine, execute `blt vm` to provision the VM and set it as the default local development environment. If you've already run `blt vm` at least once, you can just use `vagrant up` to provision the VM.
+1. Make sure you have installed any prerequisites. For DrupalVM, the main dependencies are Vagrant and VirtualBox (see the [quick start guide]().
+1. Start the VM: `vagrant up`
 1. SSH into the VM: `vagrant ssh`
 1. Build and install the Drupal installation: `blt setup`
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -26,7 +26,6 @@ You have probably been linked to this documentation by a project that is using B
 
 If your project uses a virtual development environment such as Drupal VM:
 
-1. Make sure you have installed any prerequisites. For DrupalVM, the main dependencies are Vagrant and VirtualBox (see the [quick start guide]().
 1. Start the VM: `vagrant up`
 1. SSH into the VM: `vagrant ssh`
 1. Build and install the Drupal installation: `blt setup`


### PR DESCRIPTION
Just minor tweaks to make this clearer. Mainly, we no longer advise people to run `blt vm`, just go straight to `vagrant up`.

We used to suggest starting with `blt vm` because this would set your local drush alias accordingly, but since you can no longer run commands outside of the VM anyway that's a moot point.