### PR TITLE
Update to drupal/memcache 2.0.0 @stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/config_split": "^1.0.0",
         "drupal/core": "^8.6.0",
         "drupal/features": "^3.8.0",
-        "drupal/memcache": "^2.0-alpha5",
+        "drupal/memcache": "^2.0.0",
         "drupal/seckit": "^1.0.0-alpha2",
         "drupal-composer/drupal-scaffold": "^2.5.4",
         "grasmash/drupal-security-warning": "^1.0.0",

--- a/settings/memcache.settings.php
+++ b/settings/memcache.settings.php
@@ -42,13 +42,23 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
           'class' => 'Drupal\memcache\MemcacheSettings',
           'arguments' => ['@settings'],
         ],
-        'memcache.backend.cache.factory' => [
+        'memcache.factory' => [
           'class' => 'Drupal\memcache\Driver\MemcacheDriverFactory',
           'arguments' => ['@memcache.settings'],
         ],
+        'memcache.timestamp.invalidator.bin' => [
+          'class' => 'Drupal\memcache\Invalidator\MemcacheTimestampInvalidator',
+          // Adjust tolerance factor as appropriate when not running memcache
+          // on localhost.
+          'arguments' => [
+            '@memcache.factory',
+            'memcache_bin_timestamps',
+            0.001,
+          ],
+        ],
         'memcache.backend.cache.container' => [
-          'class' => 'Drupal\memcache\DrupalMemcacheFactory',
-          'factory' => ['@memcache.backend.cache.factory', 'get'],
+          'class' => 'Drupal\memcache\DrupalMemcacheInterface',
+          'factory' => ['@memcache.factory', 'get'],
           'arguments' => ['container'],
         ],
         'cache_tags_provider.container' => [
@@ -61,6 +71,7 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
             'container',
             '@memcache.backend.cache.container',
             '@cache_tags_provider.container',
+            '@memcache.timestamp.invalidator.bin',
           ],
         ],
       ],


### PR DESCRIPTION
## Fixes 

- #3257 

Drupal memcache 2.0.0 (8.x-2.0) for Acquia BLT 10.0.x

## Changes proposed:

- Set package requirements for `drupal/memcache:^2.0.0@stable`
- Update BLT settings includes to reflect stable implementation

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. Install BLT with drupal/memcache:^2.0.0
2. Deploy to an Acquia environment or local environment with memcache enabled


 
