### PR TITLE
BLT 9.2.x drupal memcache 2.0 stable

### DIFF
--- a/composer.suggested.json
+++ b/composer.suggested.json
@@ -13,7 +13,7 @@
     "drupal/cog": "^1.0.0",
     "drupal/devel": "^1.0.0",
     "drupal/qa_accounts": "^1.0.0-alpha1",
-    "drupal/memcache": "2.0-alpha7",
+    "drupal/memcache": "^2.0.0",
     "drupal/seckit": "^1.0.0-alpha2",
     "drupal/security_review": "*",
     "drupal/shield": "^1.0.0",

--- a/settings/memcache.settings.php
+++ b/settings/memcache.settings.php
@@ -42,13 +42,23 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
           'class' => 'Drupal\memcache\MemcacheSettings',
           'arguments' => ['@settings'],
         ],
-        'memcache.backend.cache.factory' => [
+        'memcache.factory' => [
           'class' => 'Drupal\memcache\Driver\MemcacheDriverFactory',
           'arguments' => ['@memcache.settings'],
         ],
+        'memcache.timestamp.invalidator.bin' => [
+          'class' => 'Drupal\memcache\Invalidator\MemcacheTimestampInvalidator',
+          // Adjust tolerance factor as appropriate when not running memcache
+          // on localhost.
+          'arguments' => [
+            '@memcache.factory',
+            'memcache_bin_timestamps',
+            0.001,
+          ],
+        ],
         'memcache.backend.cache.container' => [
-          'class' => 'Drupal\memcache\DrupalMemcacheFactory',
-          'factory' => ['@memcache.backend.cache.factory', 'get'],
+          'class' => 'Drupal\memcache\DrupalMemcacheInterface',
+          'factory' => ['@memcache.factory', 'get'],
           'arguments' => ['container'],
         ],
         'cache_tags_provider.container' => [
@@ -61,6 +71,7 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
             'container',
             '@memcache.backend.cache.container',
             '@cache_tags_provider.container',
+            '@memcache.timestamp.invalidator.bin',
           ],
         ],
       ],


### PR DESCRIPTION
Fixes # 
--------

- #3220 
- #3257 

Changes proposed:
---------

- Update composer suggests to show drupal/memcache:^2.0.0 (stable)
- Provide BLT settings includes that support drupal/memcache:^2.0.0 (stable)


Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. Install BLT with drupal/memcache:^2.0.0
2. Deploy to an Acquia environment or local environment with memcache enabled


 
