### PR TITLE
Fixes #3243 to clean up dry-run in deploy command.

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -73,7 +73,7 @@ See [Extending BLT](extending-blt.md) for more information on overriding default
 
 If you would like to create, commit, but _not push_ the artifact, you may do a dry run:
 
-    blt artifact:deploy -D deploy.dryRun=true
+    blt artifact:deploy --dry-run
 
 This is helpful for debugging deployment artifacts.
 


### PR DESCRIPTION
Fixes #3243 for 9.2.x.
--------

Changes proposed:
---------
(What are you proposing we change?)

- replaces the old dry run syntax with the new one

Steps to verify the solution:
----------
(How does someone verify that this does what you think does?)

1. run a deploy with ```blt artifact:deploy -D deploy.dryRun=true``` and it will actually push
2. run a deploy with ```blt artifact:deploy --dry-run``` and it won't push
