### PR TITLE
Pipelines pr-closed event doesn't fire.

### DIFF
--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -44,7 +44,7 @@ events:
       - deploy:
           script:
             - pipelines-deploy
-  pre-closed:
+  pr-closed:
     steps:
       - deploy:
           script:


### PR DESCRIPTION
Changes proposed:
---------
- Fix a tiny typo that prevents Pipelines from tearing down CDEs when a PR is closed. [reference](https://docs.acquia.com/acquia-cloud/develop/pipelines/yaml/#pr-closed)

Steps to replicate the issue:
----------
1. On a BLT project using Pipelines and CDEs, open a new PR and verify that a CDE is created.
2. Close the PR.
3. Observe that the CDE is not torn down, and an error appears in the Cloud logs about the "pr-closed" event not being found.

Steps to verify the solution:
-----------
1. Apply this change and repeat the steps above.
2. Observe that the CDE is properly torn down.

 Should backport to 9.2 if approved.
