### PR TITLE
Allow drush ansi disable execution time

### DIFF
--- a/src/Robo/Tasks/DrushTask.php
+++ b/src/Robo/Tasks/DrushTask.php
@@ -81,6 +81,13 @@ class DrushTask extends CommandStack {
   protected $include;
 
   /**
+   * Add or not the --ansi option.
+   *
+   * @var bool
+   */
+  protected $ansi;
+
+  /**
    * Drush commands to execute when task is run.
    *
    * @var array
@@ -211,6 +218,19 @@ class DrushTask extends CommandStack {
   }
 
   /**
+   * Include or not the --ansi option for drush commands.
+   *
+   * @param bool $ansi
+   *   The flag for including --ansi option.
+   *
+   * @return $this
+   */
+  public function ansi($ansi) {
+    $this->ansi = $ansi;
+    return $this;
+  }
+
+  /**
    * Sets up drush defaults using config.
    */
   protected function init() {
@@ -232,6 +252,9 @@ class DrushTask extends CommandStack {
     }
     if (!isset($this->interactive)) {
       $this->interactive(FALSE);
+    }
+    if (!isset($this->ansi)) {
+      $this->ansi(TRUE);
     }
 
     $this->defaultsInitialized = TRUE;
@@ -321,7 +344,9 @@ class DrushTask extends CommandStack {
       $this->option('include', $this->include);
     }
 
-    $this->option("ansi");
+    if ($this->ansi) {
+      $this->option("ansi");
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #3146 
--------
drush8 does not support --ansi option, causing issues when working on remote sites.

Changes proposed:
---------
- Allow to disable ansi in runtime per command

Steps to replicate the issue:
----------
- Example: 
$this->taskDrush()
->alias('my-remote-alias')
->drush('updb')
->ansi(FALSE)

Steps to verify the solution:
-----------
Apply the patch and execute the same command
- Example: 
$this->taskDrush()
->alias('my-remote-alias')
->drush('updb')
->ansi(FALSE)
As you can see, the --ansi option gets omited
 
