### PR TITLE
Speed up deploys with shallow fetching

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -315,7 +315,7 @@ class DeployCommand extends BltTasks {
       // This branch may not exist upstream, so we do not fail the build if a
       // merge fails.
       ->stopOnFail(FALSE)
-      ->exec("git fetch $remote_name {$this->branchName}")
+      ->exec("git fetch $remote_name {$this->branchName} --depth=1")
       ->exec("git merge $remote_name/{$this->branchName}")
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();


### PR DESCRIPTION
Before:
```
real	4m11.340s
user	1m3.430s
sys	1m23.638s
```

After:
```
real	3m14.776s
user	0m47.570s
sys	1m6.415s
```

23.6% faster.