### PR TITLE
Check if argv is set before using it

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -141,7 +141,7 @@ if ($is_acsf_inited) {
     // When developing locally, we use the host name to determine which site
     // factory site is active. The hostname must have a corresponding entry
     // under the multisites key.
-    $input = new ArgvInput($_SERVER['argv']);
+    $input = new ArgvInput(!empty($_SERVER['argv']) ? $_SERVER['argv'] : ['']);
     $config_initializer = new ConfigInitializer($repo_root, $input);
     $blt_config = $config_initializer->initialize();
 


### PR DESCRIPTION
Fixes #3281
--------

Changes proposed:
---------
(What are you proposing we change?)

- Check if `$_SERVER['argv']` is set before using it.

I checked the usage of this input in `ConfigInitializer` and I see it only uses it for `--site` and `--environment` CLI options (which doesn't make sense in a GET request). We don't need to fall back to `$_SERVER['QUERY_STRING']` for this reason.

Steps to replicate the issue:
----------

1. Setup a brand new development instance with an empty database.
2. Attempt to load the site. This would redirect to the installation page.
3. You would see the PHP notice on the installation page.
4. Ignoring the notice and continuing with the installatiton will fail with an AJAX error.


Steps to verify the solution:
-----------

1. Repeat the steps above with the patch applied.
2. There should be no notices and the installation should complete successfully.
