### PR TITLE
Use optimized classloader to resolve notices

### DIFF
--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -101,7 +101,7 @@ class BuildCommand extends BltTasks {
    * @aliases sbc setup:composer:install
    */
   public function composerInstall() {
-    $result = $this->taskExec("export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --ansi --no-interaction")
+    $result = $this->taskExec("export COMPOSER_EXIT_ON_PATCH_FAILURE=1; composer install --ansi --no-interaction --optimize-autoloader --apcu-autoloader ")
       ->dir($this->getConfigValue('repo.root'))
       ->interactive($this->input()->isInteractive())
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)

--- a/template/composer.json
+++ b/template/composer.json
@@ -2,7 +2,9 @@
     "license": "proprietary",
     "type": "project",
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "optimize-autoloader": true,
+        "apcu-autoloader": true
     },
     "require": {},
     "require-dev": {},

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,1 +1,15 @@
 memory_limit = -1
+opcache.interned_strings_buffer=16
+opcache.log_verbosity_level=2
+opcache.max_accelerated_files=10000
+opcache.memory_consumption=96
+opcache.optimization_level=0
+opcache.revalidate_freq=0
+opcache.validate_timestamps=1
+opcache.revalidate_path=0
+opcache.max_file_size=0
+opcache.use_cwd=1
+opcache.load_comments=1
+opcache.save_comments=1
+opcache.fast_shutdown=1
+opcache.max_file_size=0


### PR DESCRIPTION
Fixes #3148 
--------

Changes proposed:
---------

- Using a PSR-0 class loader requires a file_exists() check on paths to make sure the class exists when it's to be loaded. This is inefficient and also can result in "Could not scan for classes inside" notices each time a class is missing when the autoloader is dumped. BLT should use Composer's optimized ClassLoader to resolve this 

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. 
2. 

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1.
2. 

 
