### PR TITLE
Ignore platform requirements when running composer install on blt deploy

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -406,7 +406,7 @@ class DeployCommand extends BltTasks {
       ->copy($this->getConfigValue('repo.root') . '/composer.lock', $this->deployDir . '/composer.lock', TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
-    $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader")
+    $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader --ignore-platform-reqs")
       ->stopOnFail()
       ->dir($this->deployDir)
       ->run();


### PR DESCRIPTION
A possible fix for #3304.

Fixes # 3304
--------

Changes proposed:
---------
(What are you proposing we change?)

- Ignore platform requirements when running blt deploy

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. See #3304 for preconditions
2. Apply the patch and run `blt deploy`. It should be able to run composer install without any platform errors.