### PR TITLE
Remove sql-drop since —create-db accomplishes the same thing.

### DIFF
--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -128,7 +128,6 @@ class SyncCommand extends BltTasks {
     $task = $this->taskDrush()
       ->alias('')
       ->drush('cache-clear drush')
-      ->drush('sql-drop')
       ->drush('sql-sync')
       ->arg($remote_alias)
       ->arg($local_alias)


### PR DESCRIPTION
Fixes #3317
--------

Changes proposed:
---------
Remove sql-drop from `blt drupal:sync:default:db` operation.

Steps to replicate the issue:
----------

1. With no database created for the site, run `blt drupal:sync:default:db`.
2. Confirm the operation errors out when it attempts to drop the database.

Steps to verify the solution:
-----------

1. With no database created for the site, run `blt drupal:sync:default:db`.
2. Verify that the database gets created and the site gets setup as expected.

 
