### PR TITLE
Create a valid machine name based on the local domain name.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -149,6 +149,12 @@ if ($is_acsf_inited) {
     // [sitename] is a value in the multisites array.
     $domain_fragments = explode('.', $http_host);
     $name = array_slice($domain_fragments, 1);
+    
+    // Create a valid machine name based on the local domain name.
+    $name = strtolower($name);
+    $name = preg_replace('/[^a-z0-9_]+/', '_', $name);
+    $name = preg_replace('/_+/', '_', $name);
+
     $acsf_sites = $blt_config->get('multisites');
     if (in_array($name, $acsf_sites)) {
       $acsf_site_name = $name;


### PR DESCRIPTION
Fixes #3323 
--------

Changes proposed:
---------
- Prepare local sitename detected from domain prior to asigining to acsf_site_name variable

Steps to replicate the issue:
----------
1. Create a local site called local.my-site.com
2. Create a config_split with machine name my_site, disabled by default
3. Blt will not activate it via config override mechanism.

Steps to verify the solution:
-----------
1. Apply the patch.
2. See the config_split successfully enabled.
