### PR TITLE
Fix broken link to Cloud Hooks docs.

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -50,7 +50,7 @@ You can configure various tools to provide notifications of deployment related e
 
 * [Travis CI](https://docs.travis-ci.com/user/notifications/) can notify you about your build results through email, IRC, and/or webhooks.
 * Jenkins has plugins to provide build notifications via [Slack](https://wiki.jenkins-ci.org/display/JENKINS/Slack+Plugin), [IRC](https://wiki.jenkins-ci.org/display/JENKINS/IRC+Plugin), and many more services.
-* You can use [Acquia Cloud Hooks](https://docs.acquia.com/cloud/manage/cloud-hooks#animated) to provide deployment, db, or code related notification to service such as:
+* You can use [Acquia Cloud Hooks](https://docs.acquia.com/acquia-cloud/develop/api/cloud-hooks/) to provide deployment, db, or code related notification to service such as:
     * New Relic
     * Slack
     * HipChat


### PR DESCRIPTION
Fixes # NA
--------

Changes proposed:
---------
- Update link to Cloud Hooks in docs/release-process.md

Steps to replicate the issue:
----------

1. Visit docs/release-process.md and then visit the link the the Cloud Hooks docs at the bottom
2. Docs currently link to https://docs.acquia.com/acquia-cloud/develop/api/cloud-hooks/

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. visit docs/release-process.md and then visit the link the the Cloud Hooks docs at the bottom
2. Docs should link to live docs page for Cloud Hooks

 
