### PR TITLE
9.2.x: Travis CI: Fix for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   # Exit build early if only documentation was changed in a Pull Request.
   - source ${BLT_DIR}/scripts/travis/exit_early
   # Decrypt private SSH key id_rsa_blt.enc, save as ~/.ssh/id_rsa_blt.
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then openssl aes-256-cbc -K $encrypted_c0b166e924da_key -iv $encrypted_c0b166e924da_iv -in id_rsa_blt.enc -out ~/.ssh/id_rsa -d; chmod 600 ~/.ssh/id_rsa; ls -lash ~/.ssh; eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa; fi
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && -n "$encrypted_c0b166e924da_key" ]]; then openssl aes-256-cbc -K $encrypted_c0b166e924da_key -iv $encrypted_c0b166e924da_iv -in id_rsa_blt.enc -out ~/.ssh/id_rsa -d; chmod 600 ~/.ssh/id_rsa; ls -lash ~/.ssh; eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa; fi
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - sudo service memcached status
   - phpenv config-rm xdebug.ini


### PR DESCRIPTION
Changes proposed:
---------
(What are you proposing we change?)

- Fix Travis CI config so forks can build before submitting PRs to this repo
- (To fail fast, and check results before bothering you :)
- Only call the `openssl` command if one of the secret env vars it uses (`$encrypted_c0b166e924da_key`) is set

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. Create a fork of this repo
2. Make a build on Travis CI without setting secret encrypted env vars

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. Create a fork of this repo
2. Make a build on Travis CI without setting secret encrypted env vars
-> Build passes

Or check my fork: https://travis-ci.org/hugovk/blt/builds/479469643

----

This has been happening for at least 5 months (see below), and this change will allow contributors to contribute more easily and with fewer failing PRs submitted.

![image](https://user-images.githubusercontent.com/1324225/51125207-cf77bc80-1828-11e9-8f3b-5dc910741515.png)


