### PR TITLE
Added a cache-clear to BLT to ensure memcache/db discrepancies do not…

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -51,6 +51,10 @@ class ConfigCommand extends BltTasks {
         }
       }
 
+      // Caching can interfere with config import depending on the state
+      // of DB relative to memcache.
+      $this->drush("cache-rebuild");
+
       $task = $this->taskDrush()
         ->stopOnFail()
         // Execute db updates.


### PR DESCRIPTION
When config split is used to enable DBlog in a lower env and you sync a Db from prod down on Acquia.  Memcache will think that DBLog is enabled immediately after a DB sync.  This will lead to CMI import failures as module enables will attempt to log to the nonexistent watchdog table.

A CC before a config import will solve the issue. 

