### PR TITLE
Fixes #3345 to run db updates even when config strategy is none.

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -606,8 +606,7 @@ class DeployCommand extends BltTasks {
     $this->say("Deploying updates to <comment>$multisite</comment>...");
     $this->switchSiteContext($multisite);
 
-    $this->invokeCommand('drupal:config:import');
-    $this->invokeCommand('drupal:toggle:modules');
+    $this->invokeCommand('drupal:update');
 
     $this->say("Finished deploying updates to $multisite.");
   }
@@ -633,8 +632,7 @@ class DeployCommand extends BltTasks {
 
       $this->invokeCommand('drupal:sync:db');
       $this->invokeCommand('drupal:sync:files');
-      $this->invokeCommand('drupal:config:import');
-      $this->invokeCommand('drupal:toggle:modules');
+      $this->invokeCommand('drupal:update');
 
       $this->say("Finished syncing $multisite.");
     }


### PR DESCRIPTION
Fixes #3345
--------

Changes proposed:
---------
(What are you proposing we change?)

- moves updb from config-import command into drupal:update command
- refactors the deploy command to call drupal:update directly instead of config-import and toggle modules separately 

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. set config strategy to none
2. confirm db updates execute anyway

 
