### PR TITLE
Fixes #3362 for 10.x. Explains URI failure.

### DIFF
--- a/scripts/blt/drush/cache.php
+++ b/scripts/blt/drush/cache.php
@@ -12,7 +12,9 @@ $uri = $argv[3];
 
 
 if (empty($argv[3])) {
-  echo "Error: Not enough arguments. Site, environment, and uri are required.\n";
+  echo "Warning, Site URI not identified. Ensure ACSF module is enabled.\n";
+  echo "Confirm that the module is enabled via configuration. This may live in: \n";
+  echo "config/default (core.extensions.yml) and/or specific config splits.\n";
   exit(1);
 }
 


### PR DESCRIPTION
Fixes #3362 
--------

Changes proposed:
---------
(What are you proposing we change?)

- removes exit / failure from cache.php if the URI isn't set
- randomizes a URI for drush cache use.

