### PR TITLE
Fixes #3322 to fix docs and codesniffer issues in factory hooks.

### DIFF
--- a/scripts/factory-hooks/post-install/post-install.php
+++ b/scripts/factory-hooks/post-install/post-install.php
@@ -11,7 +11,6 @@
  * This is used so that an ACSF site install is identical to the local BLT site
  * install, with the environment, site, and uri CLI runtime arguments overriding
  * all other configuration.
- *
  */
 
 // Acquia hosting site / environment names.

--- a/scripts/factory-hooks/post-settings-php/includes.php
+++ b/scripts/factory-hooks/post-settings-php/includes.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Example implementation of ACSF post-settings-php hook.
+ * ACSF post-settings-php hook.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
  */

--- a/scripts/factory-hooks/post-sites-php/includes.php
+++ b/scripts/factory-hooks/post-sites-php/includes.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Example implementation of ACSF post-sites-php hook.
+ * ACSF post-sites-php hook.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
  */
@@ -15,7 +15,7 @@ if (!function_exists('gardens_data_get_sites_from_file')) {
    *
    * @param string $name
    *   The technical ACSF site name to filter on.
-   * @param $reset
+   * @param bool $reset
    *   Whetever to reset APC cache or not.
    *
    * @return array|mixed|null

--- a/scripts/factory-hooks/pre-settings-php/includes.php
+++ b/scripts/factory-hooks/pre-settings-php/includes.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Example implementation of ACSF pre-settings-php hook.
+ * ACSF pre-settings-php hook.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
  */


### PR DESCRIPTION
Fixes #3322 
--------

Changes proposed:
---------
(What are you proposing we change?)

- phpcs cleanup in the factory hooks
- removes "example" wording from doc comments.