### PR TITLE
Fixes #3379 to regenerate settings and hooks upon BLT 10.x update.

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -633,10 +633,11 @@ class Updates {
    *
    * @Update(
    *    version = "10000000",
-   *    description = "Remove composer merge plugin."
+   *    description = "10.x Updates."
    * )
    */
   public function update_10000000() {
+    $messages[] = "Removing composer merge plugin.";
     $composer_json = $this->updater->getComposerJson();
     $template_composer_json = $this->updater->getTemplateComposerJson();
     $blt_composer_json = json_decode(file_get_contents($this->updater->getBltRoot() . '/composer.json'), TRUE);
@@ -678,7 +679,7 @@ class Updates {
         $composer_json[$sync_composer_key] = [];
       }
       $composer_json[$sync_composer_key] = ArrayManipulator::arrayMergeRecursiveDistinct($composer_json[$sync_composer_key],
-          $template_composer_json[$sync_composer_key]);
+        $template_composer_json[$sync_composer_key]);
     }
 
     // Require blt-require-dev.
@@ -692,10 +693,41 @@ class Updates {
       $this->updater->getRepoRoot() . "/blt/composer.suggested.json",
       $this->updater->getRepoRoot() . "/blt/composer.overrides.json",
     ]);
-    $messages = [
-      "Your composer.json file has been modified to remove the Composer merge plugin.",
-      "You must execute `composer update --lock` to update your lock file.",
-    ];
+    $messages[] = "Your composer.json file has been modified to remove the Composer merge plugin.";
+    $messages[] = "You must execute `composer update --lock` to update your lock file.";
+
+    // Updates to setting and configuration files for BLT 10.0.x.
+    $messages[] = "";
+    $messages[] = "BLT 10 includes many changes to configuration and settings files. These will now be regenerated.";
+
+    // Check for presence of factory-hooks directory. Regenerate if present.
+    if (file_exists($this->updater->getRepoRoot() . '/factory-hooks')) {
+      $messages[] = "factory-hooks have been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
+      $this->updater->executeCommand("./vendor/bin/blt recipes:acsf:init:hooks");
+    }
+
+    // Check for presence of cloud-hooks directory. Regenerate if present.
+    if (file_exists($this->updater->getRepoRoot() . '/hooks')) {
+      $messages[] = "cloud-hooks have been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
+      $this->updater->executeCommand("./vendor/bin/blt recipes:cloud-hooks:init");
+    }
+
+    // Check for presence of pipelines.yml files. Regenerate if present.
+    if (file_exists($this->updater->getRepoRoot() . '/acquia-pipelines.yml')) {
+      $messages[] = "pipelines.yml has been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
+      $this->updater->executeCommand("./vendor/bin/blt recipes:ci:pipelines:init");
+    }
+
+    // Check for presence of .travis.yml files. Regenerate if present.
+    if (file_exists($this->updater->getRepoRoot() . '/.travis.yml')) {
+      $messages[] = ".travis.yml has been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
+      $this->updater->executeCommand("./vendor/bin/blt recipes:ci:travis:init");
+    }
+
+    // Regenerate local settings files.
+    $messages[] = "Local settings files have been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
+    $this->updater->executeCommand("./vendor/bin/blt blt:init:settings");
+
     $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
     $this->updater->getOutput()->writeln("");
     $this->updater->getOutput()->writeln($formattedBlock);


### PR DESCRIPTION
Fixes #3379 
--------

Changes proposed:
---------
(What are you proposing we change?)

- changes the 10.x update hook to regenerate factory hooks, cloud hooks, and settings files

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. update to blt 10.x without this patch (and or run `blt update`
2. manually run `blt:init:settings`, `recipes:cloud-hooks:init`, and `recipes:acsf:init:hooks`
3. confirm presence of new / updated files

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. update to blt 10.x without this patch (and or run `blt update`
2. confirm that the settings and hooks are automatically updated.

 
