### PR TITLE
Fixes #3322 to disable variable sniffs on factory hooks.

### DIFF
--- a/scripts/factory-hooks/post-install/post-install.php
+++ b/scripts/factory-hooks/post-install/post-install.php
@@ -11,6 +11,8 @@
  * This is used so that an ACSF site install is identical to the local BLT site
  * install, with the environment, site, and uri CLI runtime arguments overriding
  * all other configuration.
+ *
+ * phpcs:disable DrupalPractice.CodeAnalysis.VariableAnalysis
  */
 
 // Acquia hosting site / environment names.

--- a/scripts/factory-hooks/post-settings-php/includes.php
+++ b/scripts/factory-hooks/post-settings-php/includes.php
@@ -5,6 +5,8 @@
  * ACSF post-settings-php hook.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
+ *
+ * phpcs:disable DrupalPractice.CodeAnalysis.VariableAnalysis
  */
 
 // Set config directories to default location.

--- a/scripts/factory-hooks/post-settings-php/memcache.php
+++ b/scripts/factory-hooks/post-settings-php/memcache.php
@@ -5,6 +5,8 @@
  * Factory hook implementation for memcache.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
+ *
+ * phpcs:disable DrupalPractice.CodeAnalysis.VariableAnalysis
  */
 
 // Use ACSF internal settings site flag to apply memcache settings.

--- a/scripts/factory-hooks/post-sites-php/includes.php
+++ b/scripts/factory-hooks/post-sites-php/includes.php
@@ -5,6 +5,8 @@
  * ACSF post-sites-php hook.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
+ *
+ * phpcs:disable DrupalPractice.CodeAnalysis.VariableAnalysis
  */
 
 // The function_exists check is required as the file is included several times.

--- a/scripts/factory-hooks/pre-settings-php/includes.php
+++ b/scripts/factory-hooks/pre-settings-php/includes.php
@@ -5,6 +5,8 @@
  * ACSF pre-settings-php hook.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
+ *
+ * phpcs:disable DrupalPractice.CodeAnalysis.VariableAnalysis
  */
 
 // Configure your hash salt here.


### PR DESCRIPTION
Fixes #3322 
--------

Changes proposed:
---------
(What are you proposing we change?)

- disable Variable sniffs on the factory-hooks directory

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. update to 10x
2. regenerate factory hooks
3. attempt to commit them to your repository (you will get phpcs warnings)

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. apply this 
2. regenerate factory hooks
3. try to commit again, no warnings

 
