### PR TITLE
Updates release and readme docs.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,8 +9,15 @@ To perform a release:
 
 ## Check build statuses
 
-* [BLT 9.x](https://github.com/acquia/blt): [![Build Status](https://travis-ci.org/acquia/blt.svg?branch=9.x)](https://travis-ci.org/acquia/blt)
-* [![Documentation Status](https://readthedocs.org/projects/blt/badge/?version=9.x)](http://blt.readthedocs.io/en/9.x/?badge=9.x)
+* [BLT 10.x](https://github.com/acquia/blt):  
+[![Build Status](https://travis-ci.org/acquia/blt.svg?branch=10.0.x)](https://travis-ci.org/acquia/blt)
+[![Documentation Status](https://readthedocs.org/projects/blt/badge/?version=10.0.x)](http://blt.readthedocs.io/en/10.0.x/?badge=10.0.x)
+* [BLT 9.2.x](https://github.com/acquia/blt):  
+[![Build Status](https://travis-ci.org/acquia/blt.svg?branch=9.2.x)](https://travis-ci.org/acquia/blt)
+[![Documentation Status](https://readthedocs.org/projects/blt/badge/?version=9.2.x)](http://blt.readthedocs.io/en/9.2.x/?badge=9.2.x)
+* [BLT 9.x](https://github.com/acquia/blt):  
+[![Build Status](https://travis-ci.org/acquia/blt.svg?branch=9.x)](https://travis-ci.org/acquia/blt)
+[![Documentation Status](https://readthedocs.org/projects/blt/badge/?version=9.x)](http://blt.readthedocs.io/en/9.x/?badge=9.x)
 
 ## Update Canary
 
@@ -26,6 +33,7 @@ To perform a release:
 * BLT's dependencies must be installed by running `composer install` in the BLT directory.
 * If you don't have one, procure a [github personal access token](https://github.com/settings/tokens). Optionall save in a password vault for future use.
 * Determine the version of your future release, e.g., 9.1.0-alpha1.
+* Warning: Ensure that the BLT repository exists in your local git as orgin *NOT* upstream
 * To both generate release notes and also create a new _draft_ release on GitHub, execute:
 
       ./vendor/bin/robo release [tag] [token]

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ Up to the last two most major versions of BLT are actively supported. The newest
 
 | Major Version | Support Status              | Drupal | Drush          | Dev Status   |
 |---------------|-----------------------------|--------|----------------|--------------|
-| 10.0.x        | Unsupported (pre-alpha)     | >=8.6  | >=9.4.0        | \*active dev |
+| 10.0.x        | Unsupported (Beta)          | >=8.6  | >=9.4.0        | \*active dev |
 | 9.2.x         | Supported                   | 8.6    | >=9.4.0        | \*active dev |
 | 9.x           | LTS, EOL TBA                | 8.5    | >=9.1.0        | \*bug fixes  |
 | 8.9.x         | Unsupported, EOL            | <=8.5  | ~8             |              |
@@ -45,7 +45,7 @@ Up to the last two most major versions of BLT are actively supported. The newest
 
 ### 10.0.x branch
 
-The 10.0.x branch is in active development and is not currently stable or supported. It requires Drush 9.4.x, Drupal 8.6.x, and PHP 7+. It is considered a major release because it removes the Composer merge plugin that BLT previously used to manage dependencies.
+The 10.0.x branch is currently in beta and is not currently stable or supported. It requires Drush 9.4.x, Drupal 8.6.x, and PHP 7+. It is considered a major release because it removes the Composer merge plugin that BLT previously used to manage dependencies.
 
 ### 9.2.x branch
 


### PR DESCRIPTION
Updates:

* Release docs to include warning about "origin" repo naming (and adds new badges for current versions of BLT)
* Updates Readme doc to update status of Beta