### PR TITLE
Adding Scans for Deprecated Function in Core

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -359,7 +359,7 @@ class RoboFile extends Tasks implements LoggerAwareInterface {
   }
 
   /**
-   * Sniffs BLT internal code via PHPCS.
+   * Sniffs BLT internal code via PHPCS, and PHPStan.
    *
    * @command sniff-code
    */
@@ -367,6 +367,7 @@ class RoboFile extends Tasks implements LoggerAwareInterface {
     $task = $this->taskExecStack()
       ->dir($this->bltRoot)
       ->exec("{$this->bin}/phpcs")
+      ->exec("{$this->bin}/phpstan")
       ->exec("composer validate");
     $result = $task->run();
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -359,7 +359,7 @@ class RoboFile extends Tasks implements LoggerAwareInterface {
   }
 
   /**
-   * Sniffs BLT internal code via PHPCS, and PHPStan.
+   * Sniffs BLT internal code via PHPCS.
    *
    * @command sniff-code
    */
@@ -367,7 +367,6 @@ class RoboFile extends Tasks implements LoggerAwareInterface {
     $task = $this->taskExecStack()
       ->dir($this->bltRoot)
       ->exec("{$this->bin}/phpcs")
-      ->exec("{$this->bin}/phpstan")
       ->exec("composer validate");
     $result = $task->run();
 

--- a/composer.json
+++ b/composer.json
@@ -55,10 +55,12 @@
     "require-dev": {
         "composer/composer": "^1.6.4",
         "knplabs/github-api": "^2.6",
+        "mglaman/phpstan-drupal": "^0.11.1",
         "php-http/guzzle6-adapter": "^1.1",
-        "webflo/drupal-core-require-dev": "^8.6.0",
+        "phpstan/phpstan": "^0.11.1",
+        "phpstan/phpstan-deprecation-rules": "^0.11.0",
         "phpunit/phpunit": "^4.8|^6.5",
-        "squizlabs/php_codesniffer": "^3.0.1"
+        "squizlabs/php_codesniffer": "^3.0.1",
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "phpstan/phpstan": "^0.11.1",
         "phpstan/phpstan-deprecation-rules": "^0.11.0",
         "phpunit/phpunit": "^4.8|^6.5",
-        "squizlabs/php_codesniffer": "^3.0.1",
+        "squizlabs/php_codesniffer": "^3.0.1"
     },
     "autoload": {
         "psr-4": {

--- a/config/build.yml
+++ b/config/build.yml
@@ -239,6 +239,11 @@ validate:
     filters: { }
     # Add any custom Twig functions for linter to ignore.
     functions: { }
+  phpstan:
+    filesets:
+    - files.php.custom.modules
+    - files.php.custom.themes
+    - files.php.tests
   yaml:
     filesets:
       - files.yaml

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,6 +13,7 @@ A general warning: BLT provides automation for numerous other applications inclu
 * Gulp
 * NPM / Yarn
 * PHPCS
+* PHPStan
 * PHPUnit
 
 As a result, numerous "issues with BLT" are in fact "issues with one of the bundled applications." We strongly recommend a careful review of the errors presented with your project, which frequently direct you more appropriately to the underlying system that is the true cause (and not BLT itself).

--- a/docs/extending-blt.md
+++ b/docs/extending-blt.md
@@ -46,6 +46,8 @@ This snippet would cause the `tests:phpcs:sniff:all` and `tests:phpcs:sniff:file
 
 To modify the behavior of PHPCS, see [tests:phpcs:sniff:all](#testsphpcssniffall) documentation.
 
+To modify the behavior of PHPStan, see [tests:phpstan:sniff:all](#testsphpstansniffall) documentation.
+
 To modify the filesets that are used in other commands, such as `tests:twig:lint:all`, `tests:yaml:lint:all`, and `tests:php:lint`:
 
 1. Generate an example `Filesets.php` file by executing `blt example:init`. You may use the generated file as a guide for writing your own filesite.
@@ -176,6 +178,10 @@ To modify the behavior of the tests:behat:run target, you may override BLT's `be
 #### tests:phpcs:sniff:all
 
 To modify the behavior of the tests:phpcs:sniff:all target, you may copy `phpcs.xml.dist` to `phpcs.xml` in your repository root directory and modify the XML. Please see the [official PHPCS documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file) for more information.
+
+#### tests:phpstan:sniff:all
+
+To modify the behavior of the tests:phpstan:sniff:all target, edit `phpstan.neon` in your repository root directory. Please see the [official PHPStan documentation](https://github.com/phpstan/phpstan#configuration) for more information.
 
 #### tests:twig:lint:all
 

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -32,7 +32,7 @@ Other commonly used commands:
         # list targets
         blt
 
-        # validate code via phpcs, php lint, composer validate, etc.
+        # validate code via phpcs, phpstan, php lint, composer validate, etc.
         blt validate
 
         # run phpunit tests

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -29,6 +29,7 @@ These tools are installed automatically by BLT via Composer.
 | [Behat](#behat)            |
 | [PHPUnit](#phpunit)        |
 | [PHP Code Sniffer](#phpcs) |
+| [PHPStan Static Analysis Tool](#phpstan) |
 
 
 

--- a/src/Robo/Commands/Git/GitCommand.php
+++ b/src/Robo/Commands/Git/GitCommand.php
@@ -62,6 +62,7 @@ class GitCommand extends BltTasks {
       function () use ($changed_files) {
         return $this->invokeCommands([
           'tests:phpcs:sniff:files' => ['file_list' => $changed_files],
+          'tests:phpstan:sniff:files' => ['file_list' => $changed_files],
           'tests:twig:lint:files' => ['file_list' => $changed_files],
           'tests:yaml:lint:files' => ['file_list' => $changed_files],
         ]);

--- a/src/Robo/Commands/Validate/AllCommand.php
+++ b/src/Robo/Commands/Validate/AllCommand.php
@@ -21,6 +21,7 @@ class AllCommand extends BltTasks {
       'tests:composer:validate',
       'tests:php:lint',
       'tests:phpcs:sniff:all',
+      'tests:phpstan:sniff:all',
       'tests:yaml:lint:all',
       'tests:twig:lint:all',
     ];

--- a/src/Robo/Commands/Validate/PHPStanCommand.php
+++ b/src/Robo/Commands/Validate/PHPStanCommand.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Acquia\Blt\Robo\Commands\Validate;
+
+use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Exceptions\BltException;
+
+/**
+ * Defines commands in the "tests:phpstan:sniff:all*" namespace.
+ */
+class PhpstanCommand extends BltTasks {
+
+  /**
+   * Executes PHPStan: Static Analysis Tool against all phpstan.filesets files.
+   *
+   * By default, these include custom themes, modules, and tests.
+   *
+   * @command tests:phpstan:sniff:all
+   *
+   * @aliases tptsa phpstan tests:phpstan:sniff validate:phpstan
+   */
+  public function sniffFileSets() {
+    /** @var \Acquia\Blt\Robo\Filesets\FilesetManager $fileset_manager */
+    $fileset_manager = $this->getContainer()->get('filesetManager');
+    $fileset_ids = $this->getConfigValue('validate.phpstan.filesets');
+    $filesets = $fileset_manager->getFilesets($fileset_ids);
+    $bin = $this->getConfigValue('composer.bin');
+    $repo_root = $this->getConfigValue('repo.root');
+    $stringOfFiles = $this->fileSetToList($filesets);
+
+    $command = "$bin/phpstan analyse $stringOfFiles --configuration=$repo_root/phpstan.neon";
+
+    $result = $this->taskExecStack()
+      ->dir($this->getConfigValue('repo.root'))
+      ->exec($command)
+      ->run();
+    $exit_code = $result->getExitCode();
+    if ($exit_code) {
+      throw new BltException("Execution of PHPStan failed.");
+    }
+  }
+
+  /**
+   * Executes PHPStan against a list of files, if in phpstan.filesets.
+   *
+   * This command will execute PHPStan against a list of files if those
+   * files are a subset of the phpstan.filesets filesets.
+   *
+   * @command tests:phpstan:sniff:files
+   * @aliases tptsf
+   *
+   * @param string $file_list
+   *   A list of files to scan, separated by \n.
+   *
+   * @return int
+   */
+  public function sniffFileList($file_list) {
+    $repo_root = $this->getConfigValue('repo.root');
+
+    $this->say("Sniffing directories containing changed files...");
+    $files = explode(" ", $file_list);
+    if ($files) {
+      $command = "analyse $file_list --configuration=$repo_root/phpstan.neon";
+      $exit_code = $this->doSniff($command);
+
+      return $exit_code;
+    }
+
+    return 0;
+  }
+
+  /**
+   * Executes PHPStan against (unstaged) modified or untracked files in repo.
+   *
+   * This command will execute PHPStan against modified/untracked files
+   * if those files are a subset of the phpstan.filesets filesets.
+   *
+   * @command tests:phpstan:sniff:modified
+   * @aliases tpsm
+   *
+   * @return int
+   */
+  public function sniffModified() {
+    $this->say("Sniffing modified and untracked files in repo...");
+    $arguments = "--filter=gitmodified " . $this->getConfigValue('repo.root');
+    $exit_code = $this->doSniff($arguments);
+
+    return $exit_code;
+  }
+
+  /**
+   * Executes PHPStan using specified options/arguments.
+   *
+   * @param string $arguments
+   *   The command arguments/options.
+   *
+   * @return int
+   */
+  protected function doSniff($arguments) {
+    $bin = $this->getConfigValue('composer.bin') . '/phpstan';
+    $command = "'$bin' $arguments";
+    if ($this->output()->isVerbose()) {
+      $command .= ' -v';
+    }
+    elseif ($this->output()->isVeryVerbose()) {
+      $command .= ' -vv';
+    }
+    $result = $this->taskExecStack()
+      ->exec($command)
+      ->printMetadata(FALSE)
+      ->run();
+
+    return $result->getExitCode();
+  }
+
+  /**
+   * Converts fileset to a string of all the files.
+   *
+   * @param \Symfony\Component\Finder\Finder[] $filesets
+   *
+   * @return string | NULL
+   *   A space delimeted string of files.
+   */
+  protected function fileSetToList(array $filesets) {
+    $stringOfFiles = '';
+    foreach ($filesets as $fileset_id => $fileset) {
+      if (is_null($fileset) || iterator_count($fileset) == 0) {
+        $this->logger->info("No files were found in fileset $fileset_id. Skipped.");
+        continue;
+      }
+
+      $files = iterator_to_array($fileset);
+      foreach ($files as $filesname => $file) {
+        $stringOfFiles = $stringOfFiles . "$filesname ";
+      }
+    }
+
+    return $stringOfFiles;
+  }
+
+}

--- a/src/Robo/Commands/Validate/PHPStanCommand.php
+++ b/src/Robo/Commands/Validate/PHPStanCommand.php
@@ -35,8 +35,9 @@ class PhpstanCommand extends BltTasks {
       ->exec($command)
       ->run();
     $exit_code = $result->getExitCode();
+
     if ($exit_code) {
-      throw new BltException("Execution of PHPStan failed.");
+      throw new BltException('PHPStan Failed.  To disable PHPStan scans, set disable-targets.tests.phpstan.sniff.files to true in blt.yml.');
     }
   }
 

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -728,6 +728,10 @@ class Updates {
     $messages[] = "Local settings files have been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
     $this->updater->executeCommand("./vendor/bin/blt blt:init:settings");
 
+    // Copy in phpstan config.
+    $messages[] = "Copying PHPStan.neon into the repo.";
+    $this->updater->syncWithTemplate('phpstan.neon');
+
     $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
     $this->updater->getOutput()->writeln("");
     $this->updater->getOutput()->writeln($formattedBlock);

--- a/subtree-splits/blt-require-dev/composer.json
+++ b/subtree-splits/blt-require-dev/composer.json
@@ -9,11 +9,14 @@
         "bex/behat-screenshot": "^1.2",
         "drupal/drupal-extension": "~3.2",
         "jarnaiz/behat-junit-formatter": "^1.3.2",
-        "se/selenium-server-standalone": "^2.53",
         "dmore/behat-chrome-extension": "^1.0.0",
-        "webflo/drupal-core-require-dev": "^8.6.1",
+        "mglaman/phpstan-drupal": "^0.11.1",
+        "phpstan/phpstan": "^0.11.1",
+        "phpstan/phpstan-deprecation-rules": "^0.11.0",
         "phpunit/phpunit": "^4.8|^6.5",
-        "squizlabs/php_codesniffer": "^3.0.1"
+        "se/selenium-server-standalone": "^2.53",
+        "squizlabs/php_codesniffer": "^3.0.1",
+        "webflo/drupal-core-require-dev": "^8.6.1"
     },
     "extra": {
         "branch-alias": {

--- a/template/phpstan.neon
+++ b/template/phpstan.neon
@@ -6,12 +6,15 @@ parameters:
   excludes_analyse:
   # See https://github.com/mglaman/phpstan-drupal/issues/33.
   - blazy_test.module
+  # Excluding this because its a sample file that by its nature will never pass.
+  - tests/phpunit/ExampleTest.php
   ignoreErrors:
   - '#\Drupal calls should be avoided in classes, use dependency injection instead#'
   - '#Plugin definitions cannot be altered.#'
   - '#Missing cache backend declaration for performance.#'
   - '#Plugin manager has cache backend specified but does not declare cache tags.#'
   autoload_files:
+  # See https://github.com/mglaman/phpstan-drupal/issues/33
   - docroot/modules/contrib/token/token.module
 includes:
 - vendor/mglaman/phpstan-drupal/extension.neon

--- a/template/phpstan.neon
+++ b/template/phpstan.neon
@@ -1,0 +1,19 @@
+parameters:
+  customRulesetUsed: true
+  memory_limit: 1G
+  reportUnmatchedIgnoredErrors: false
+  # Ignore phpstan-drupal extension's rules.
+  excludes_analyse:
+  # See https://github.com/mglaman/phpstan-drupal/issues/33.
+  - blazy_test.module
+  ignoreErrors:
+  - '#\Drupal calls should be avoided in classes, use dependency injection instead#'
+  - '#Plugin definitions cannot be altered.#'
+  - '#Missing cache backend declaration for performance.#'
+  - '#Plugin manager has cache backend specified but does not declare cache tags.#'
+  autoload_files:
+  - docroot/modules/contrib/token/token.module
+includes:
+- vendor/mglaman/phpstan-drupal/extension.neon
+- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+

--- a/tests/phpunit/Blt/PhpStanTest.php
+++ b/tests/phpunit/Blt/PhpStanTest.php
@@ -32,6 +32,36 @@ class PhpStanTest extends BltProjectTestBase {
   }
 
   /**
+   * Tests recipes:ci:pipelines:init command.
+   *
+   * @group blted8
+   */
+  public function testPhpStanSniffAll() {
+    $this->blt('tests:phpstan:sniff:all');
+    $this->assertFileExists($this->sandboxInstance . '/acquia-pipelines.yml');
+  }
+
+  /**
+   * Tests recipes:ci:pipelines:init command.
+   *
+   * @group blted8
+   */
+  public function testPhpStanSniffFiles() {
+    $this->blt('tests:phpstan:sniff:files');
+    $this->assertFileExists($this->sandboxInstance . '/acquia-pipelines.yml');
+  }
+
+  /**
+   * Tests recipes:ci:pipelines:init command.
+   *
+   * @group blted8
+   */
+  public function testsPhpstanSniffModified() {
+    $this->blt('tests:phpstan:sniff:modified');
+    $this->assertFileExists($this->sandboxInstance . '/acquia-pipelines.yml');
+  }
+
+  /**
    * @return array
    */
   public function providerPhpStanFilesBootstrapProvider() {

--- a/tests/phpunit/Blt/PhpStanTest.php
+++ b/tests/phpunit/Blt/PhpStanTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Acquia\Blt\Tests\Blt;
+
+use Acquia\Blt\Tests\BltProjectTestBase;
+use Symfony\Component\Process\Process;
+
+/**
+ * Class PhpStanTest.
+ *
+ * Verifies that PhpStan works as expected.
+ */
+class PhpStanTest extends BltProjectTestBase {
+
+  /**
+   * @group blt
+   *
+   * @dataProvider providerPhpStanFilesBootstrapProvider
+   */
+  public function testPhpStanFilesBootstrap($filename, $needle, $contains) {
+    $process = new Process("./vendor/bin/phpstan analyse $filename --configuration=phpstan.neon");
+    $process->setWorkingDirectory($this->sandboxInstance);
+    $process->run();
+    $output = $process->getOutput();
+
+    if ($contains) {
+      $this->assertContains($needle, $output);
+    }
+    else {
+      $this->assertNotContains($needle, $output);
+    }
+  }
+
+  /**
+   * @return array
+   */
+  public function providerPhpStanFilesBootstrapProvider() {
+    return [
+      // Test non-php extension.
+      ['README.md', '[OK] No errors', TRUE],
+      // Test included file.
+      ['docroot/index.php', '[OK] No errors', TRUE],
+      // Test file expected to fail.
+      ['vendor/acquia/blt/RoboFile.php', 'Class RoboFile was not found', TRUE],
+    ];
+  }
+
+}

--- a/tests/phpunit/Blt/SetupGitHooksTest.php
+++ b/tests/phpunit/Blt/SetupGitHooksTest.php
@@ -95,7 +95,8 @@ class GitTasksTest extends BltProjectTestBase {
   /**
    * Tests operation of scripts/git-hooks/pre-commit.
    *
-   * Should assert that code validation via phpcs is functioning.
+   * Should assert that code validation via phpcs, phpstan, yaml,
+   * and twig linting is functioning.
    */
   public function testGitPreCommitHook() {
     $this->blt("blt:init:git-hooks");
@@ -105,6 +106,7 @@ class GitTasksTest extends BltProjectTestBase {
     $output = $process->getOutput();
     // @todo Assert only changed files are validated.
     $this->assertContains('tests:phpcs:sniff:files', $output);
+    $this->assertContains('tests:phpstan:sniff:files', $output);
     $this->assertContains('tests:yaml:lint:files', $output);
     $this->assertContains('tests:twig:lint:files', $output);
   }


### PR DESCRIPTION
This PR will scan custom code in the standard locations for deprecated functions and fail the build if they are found.  This will help the progression to D9! 

It should the same patterns as PHPCS or Symfony Security Scans