### PR TITLE
Fixes #2984 to allow admin username to be set by config.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -67,6 +67,7 @@ docroot: ${repo.root}/docroot
 
 # Drupal Account Credentials. These are used for installing Drupal.
 drupal:
+  #account.name: admin
   account.mail: no-reply@acquia.com
   locale: en
   local_settings_file: ${docroot}/sites/${site}/settings/local.settings.php

--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -26,15 +26,20 @@ class DrupalCommand extends BltTasks {
    */
   public function install() {
 
-    // Generate a random, valid username.
-    // @see \Drupal\user\Plugin\Validation\Constraint\UserNameConstraintValidator
-    $username = RandomString::string(10, FALSE,
-      function ($string) {
-        return !preg_match('/[^\x{80}-\x{F7} a-z0-9@+_.\'-]/i', $string);
-      },
-      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#%^&*()_?/.,+=><'
-    );
-
+    // Allows for installs to define custom user 0 name.
+    if ($this->getConfigValue('drupal.account.name') !== NULL) {
+      $username = $this->getConfigValue('drupal.account.name');
+    }
+    else {
+      // Generate a random, valid username.
+      // @see \Drupal\user\Plugin\Validation\Constraint\UserNameConstraintValidator
+      $username = RandomString::string(10, FALSE,
+        function ($string) {
+          return !preg_match('/[^\x{80}-\x{F7} a-z0-9@+_.\'-]/i', $string);
+        },
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#%^&*()_?/.,+=><'
+      );
+    }
     /** @var \Acquia\Blt\Robo\Tasks\DrushTask $task */
     $task = $this->taskDrush()
       ->drush("site-install")


### PR DESCRIPTION
Fixes #2984 
--------

Changes proposed:
---------
(What are you proposing we change?)

- allows config to set the admin username for drupal install

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. apply this patch
2. without changing anything else, run `blt setup:drupal:instal -y --no-interaction`
3. confirm random user name
4. add drupal.account.name to your blt.yml file
5. re-run `blt setup:drupal:instal -y --no-interaction`
6. confirm admin name is set to your custom name

 
