### PR TITLE
Replace includes.php $data by (stable) global variable equivalent

### DIFF
--- a/scripts/factory-hooks/post-sites-php/includes.php
+++ b/scripts/factory-hooks/post-sites-php/includes.php
@@ -5,8 +5,6 @@
  * ACSF post-sites-php hook.
  *
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
- *
- * phpcs:disable DrupalPractice.CodeAnalysis.VariableAnalysis
  */
 
 // The function_exists check is required as the file is included several times.
@@ -54,7 +52,7 @@ if (!function_exists('gardens_data_get_sites_from_file')) {
 
 }
 // Get all the domains that are defined for the current site.
-$domains = gardens_data_get_sites_from_file($data['gardens_site_settings']['conf']['acsf_db_name']);
+$domains = gardens_data_get_sites_from_file($GLOBALS['gardens_site_settings']['conf']['acsf_db_name']);
 // Get the site's name from the first domain.
 global $_acsf_site_name;
 $_acsf_site_name = explode('.', array_keys($domains)[0])[0];


### PR DESCRIPTION
Fixes #3362
--------

Changes proposed:
---------
In factory-hooks/post-sites-php/includes.php, change the usage of $data['gardens_site_settings'] into $GLOBALS['gardens_site_settings'].

At the same time, remove the PHPCS indicator that was only added because $data was used in this file.

Reasons: 
* The ACSF Connector module's sites.php, in their version *.x-*.52 has stopped using $data, along with several other variables.
* There was no indication that (non-Drupal specific) variables in the local namespace of sites.php could just be used. On the other hand, it is hopefully self evident that we will never just change the contents of the the global $gardens_site_settings variable without notification. A global variable is (explicitly meant to be) used in other places in the Drupal codebase.

_Please note:_ since $GLOBALS['gardens_site_settings'] has 'always' existed, this should be backportable without any issue to every 9.x version. (This includes.php was introduced in an early alpha version of 9.x)


Steps to replicate the issue:
----------
Can be found in a.o. [ internal tickets, known by lcatlett]. I hope you will forgive me for not having exact steps and not even reproducing the error.

But note that the issue means that includes.php does not define global $_acsf_site_name - I don't know BLT but from my viewpoint that can have any kind of effects.

Steps to verify the solution:
-----------
* Reproduce whatever issues those tickets (or any others that you know of) had.
* Notice that the PHP Notices about undefined $data and undefined indexes disappear.
* Run PHPCS (your own standards) on includes.php and check that there are no issues.