### PR TITLE
Improve logging ex and set explicit exit conditions.

### DIFF
--- a/scripts/factory-hooks/db-update/db-update.sh
+++ b/scripts/factory-hooks/db-update/db-update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Factory Hook: db-update
 #
@@ -9,6 +9,10 @@
 #
 # Usage: post-code-deploy site env db-role domain custom-arg
 # Map the script inputs to convenient names.
+
+# Exit immediately on error and enable verbose log output.
+set -ev
+
 # Acquia hosting site / environment names
 site="$1"
 env="$2"
@@ -25,7 +29,7 @@ blt="/mnt/www/html/$site.$env/vendor/acquia/blt/bin/blt"
 # locate the URI based on the site, environment and db role arguments.
 uri=`/usr/bin/env php /mnt/www/html/$site.$env/hooks/acquia/uri.php $site $env $db_role`
 
-# Create array with site name fragments from ACSF uri. 
+# Create array with site name fragments from ACSF uri.
 IFS='.' read -a name <<< "${uri}"
 
 # Create and set Drush cache to unique local temporary storage per site.
@@ -41,4 +45,6 @@ echo "Generated temporary drush cache directory: $cacheDir."
 echo "Running BLT deploy tasks on $uri domain in $env environment on the $site subscription."
 
 DRUSH_PATHS_CACHE_DIRECTORY=$cacheDir $blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --yes --no-interaction
+
+set +v
 


### PR DESCRIPTION
Fixes #3325  
--------

Changes proposed:
---------
- Properly define exit conditions and enable verbose log / per-line output for db-update factory hook tasks


Steps to replicate the issue:
----------
1. View log in ACSF of platform update/release with known failure
2. Observe mangled log output

Steps to verify the solution:
-----------
1. Run platform code update/release
2. Observe improved log output ux

 
