### PR TITLE
Do not ignore-platform-reqs for production deploy

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -406,7 +406,7 @@ class DeployCommand extends BltTasks {
       ->copy($this->getConfigValue('repo.root') . '/composer.lock', $this->deployDir . '/composer.lock', TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
-    $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader --ignore-platform-reqs")
+    $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader")
       ->stopOnFail()
       ->dir($this->deployDir)
       ->run();


### PR DESCRIPTION
Fixes #3417

Fixes #3417  
--------

Changes proposed:
---------
(What are you proposing we change?)

- Do not ignore platform requirements when installing for a production build artefact

