### PR TITLE
Move ACSF validate command to default config.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -211,6 +211,9 @@ tests:
     url: http://127.0.0.1:${tests.server.port}
 
 validate:
+  # You can change this to true to have blt automatically validate acsf-init.
+  acsf: false
+
   deprecated:
     filesets:
       - files.php.custom.modules

--- a/template/blt/blt.yml
+++ b/template/blt/blt.yml
@@ -37,10 +37,6 @@ drush:
     # The default drush alias to be used when no environment is specified.
   default_alias: ${drush.aliases.local}
 
-validate:
-  # You can change this to true to have blt automatically validate acsf-init.
-  acsf: false
-
 # Configuration management options, such as core CM or features.
 # cm:
 #   features:


### PR DESCRIPTION
Just thought this was a tad bit confusing to see this setting on my latest project. For most ACSF stuff, we use the BLT command to "init" that within a repo. Maybe that `recipes:acsf:init:all` command could add this to project's config file?

Anyways, I thought this would make more sense to give this setting a default value within the library config, and that can be discovered and overridden in project specific config if a user wishes.

This isn't a big deal to me if it was done on purpose, I just thought this was a suggestion to be more inline with the treatment of other default config.