### PR TITLE
Updating CI settings with a default database.

### DIFF
--- a/settings/ci.settings.php
+++ b/settings/ci.settings.php
@@ -13,3 +13,23 @@ $settings['file_private_path'] = $dir . '/files-private';
 $settings['trusted_host_patterns'] = array(
   '^.+$',
 );
+
+/**
+ * Sensible CI defaults for databases.
+ *
+ * This will be overridden by system specific CI files.
+ */
+$databases = [
+  'default' => [
+    'default' => [
+      'database' => 'drupal',
+      'username' => 'drupal',
+      'password' => 'drupal',
+      'host' => '127.0.0.1',
+      'port' => '3306',
+      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+      'driver' => 'mysql',
+      'prefix' => '',
+    ],
+  ],
+];

--- a/settings/gitlab.settings.php
+++ b/settings/gitlab.settings.php
@@ -5,17 +5,9 @@
  * GitLab environment specific settings.
  */
 
-$databases = array(
-  'default' => array(
-    'default' => array(
-      'database' => 'drupal',
-      'username' => 'drupal',
-      'password' => 'drupal',
-      'host' => 'mysql',
-      'port' => '3306',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);
+/**
+ * Overwrite CI default database host name.
+ *
+ * @see ci.settings.php
+ */
+$databases['default']['default']['host'] = 'mysql';

--- a/settings/travis.settings.php
+++ b/settings/travis.settings.php
@@ -4,18 +4,3 @@
  * @file
  * Travis environment specific settings.
  */
-
-$databases = array(
-  'default' => array(
-    'default' => array(
-      'database' => 'drupal',
-      'username' => 'drupal',
-      'password' => 'drupal',
-      'host' => '127.0.0.1',
-      'port' => '3306',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ),
-  ),
-);


### PR DESCRIPTION
Found this while trying to use a BLT project with CircleCI. So CircleCI has an `$_ENV['CI']` value set to TRUE. In `blt.settings.php` the value for `$is_ci_env` gets set to TRUE b/c of that environment variable. However, there are NO database settings set by default, leaving the user to add their own. We have _defaults_ for gitlab, travis, pipelines, probo and tugboat (I think I named them all), and they're all pretty similar. I noticed travis and gitlab **were** the same, so I removed those, and added a "default" to the `ci.settings.php` file to take its place. Now, as a user of CircleCI, or the next CI tool, at least I have some default values I can rely on for the database.