### PR TITLE
Remove unreliable drush setting.

### DIFF
--- a/template/drush/drush.yml
+++ b/template/drush/drush.yml
@@ -3,11 +3,6 @@
 # ../docroot/sites/[site]/drush.yml
 drush:
   paths:
-    config:
-      # Load a drush.yml configuration file from the current working directory.
-      - ../docroot/sites/default/local.drush.yml
-      # Allow local global config overrides.
-      - local.drush.yml
     include:
       - '${env.home}/.drush'
       - /usr/share/drush/commands


### PR DESCRIPTION
I commented on this in #3010 when I found some issues with the drush config BLT provides.

As @TravisCarden points out in that issue, the include config.paths are relative to the drush command working directory. So, in the lines coming out here, these config files are loaded:
* a "relative" `local.drush.yml` will only be loaded if drush is run from the `$PROJECT/drush` directory.
* the site specific `local.drush.yml` file will be loaded if the drush command is being run from the `$PROJECT/drush` directory (for example), or even the `$PROJECT/docroot` directory, but not from the project root.

This is incredibly confusing to try and figure out. I think we should just remove these options unless there is a better way to indicate exactly where these files live...?