### PR TITLE
Disable ANSI when BLT runs in Cloud Hooks.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,11 +2,11 @@
 
 Software testing has been around for decades, and it has been proven to provide many crucial benefits, including:
 
-* Reduce the number of bugs and regressions
-* Increase project velocity (in the long run)
-  * Improves accuracy of scheduling estimates
-  * Saves time and money
-* Increase user trust and satisfaction
+* Reducing the number of bugs and regressions
+* Increasing project velocity (in the long run)
+* Improving accuracy of scheduling estimates
+* Saving time and money
+* Increasing user trust and satisfaction
 
 You should use automated testing. Do not fall prey to common rationalizations and excuses relating to insufficient time, money, or resources. Time spent developing tests is repaid ten fold.
 
@@ -70,7 +70,7 @@ For more information on the commands, run:
 
 ## Behat
 
-The high-level purpose BDD is to create a strong connection between business requirements and the actual tests. Behat tests should mirror ticket acceptance criteria as closely as possible.
+The high-level purpose of BDD is to create a strong connection between business requirements and the actual tests. Behat tests should mirror ticket acceptance criteria as closely as possible.
 
 Consequently, proper Behat tests should be written using business domain language. The test should be comprehensible by the stakeholder and represent a clear business value. It should represent a typical user behavior and need not be an exhaustive representation of all possible scenarios.
 
@@ -126,6 +126,12 @@ Read through the [ScreenshotExtension documentation](https://github.com/elveteme
 * Tests are not sufficiently isolated. Making tests interdependent diminishes their value!
 * Writing tests that are exhaustive of all scenarios rather than representative of a typical scenario.
 * Writing Behat tests when a unit test should be employed.
+
+### Troubleshooting
+
+* Google Chrome is missing: BLT currently expects Google Chrome (more exactly, the `google-chrome` binary) to be available on the local setup. If you're using a Mac and Chrome is installed, you should be good to go. Similarly, BLT includes the Chrome binary in DrupalVM. If you are running BLT in another Linux environment, install `chromium-driver`.
+* Spotting bad configuration: In order to troubleshoot your Behat setup, make sure to run `blt doctor --site=mysite.local` to try and spot any obvious issue.
+* Multisite / ACSF issues: When you need to run tests with any authenticated user role, you may have to uninstall `simplesamlphp_auth`. Else, Behat tests may hang. When ready, run `blt behat --site=mysite.local` from within the project root. If running Behat tests fail, then it means you either have issues with your BLT / Behat setup or there's an issue with tests themselves.
 
 ### Resources
 

--- a/scripts/cloud-hooks/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/scripts/cloud-hooks/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -24,6 +24,6 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-blt artifact:ac-hooks:post-code-deploy $site $target_env $source_branch $deployed_tag $repo_url $repo_type --environment=$target_env -v --yes --no-interaction
+blt artifact:ac-hooks:post-code-deploy $site $target_env $source_branch $deployed_tag $repo_url $repo_type --environment=$target_env -v --yes --no-interaction --drush.ansi=false
 
 set +v

--- a/scripts/cloud-hooks/hooks/common/post-code-update/post-code-update.sh
+++ b/scripts/cloud-hooks/hooks/common/post-code-update/post-code-update.sh
@@ -27,6 +27,6 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-blt artifact:ac-hooks:post-code-update $site $target_env $source_branch $deployed_tag $repo_url $repo_type --environment=$target_env -v --yes --no-interaction
+blt artifact:ac-hooks:post-code-update $site $target_env $source_branch $deployed_tag $repo_url $repo_type --environment=$target_env -v --yes --no-interaction --drush.ansi=false
 
 set +v

--- a/scripts/cloud-hooks/hooks/common/post-db-copy/db-scrub.sh
+++ b/scripts/cloud-hooks/hooks/common/post-db-copy/db-scrub.sh
@@ -18,6 +18,6 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-blt artifact:ac-hooks:db-scrub $site $target_env $db_name $source_env --ansi=false
+blt artifact:ac-hooks:db-scrub $site $target_env $db_name $source_env --drush.ansi=false
 
 set +v

--- a/scripts/cloud-hooks/hooks/common/post-db-copy/db-scrub.sh
+++ b/scripts/cloud-hooks/hooks/common/post-db-copy/db-scrub.sh
@@ -18,6 +18,6 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-blt artifact:ac-hooks:db-scrub $site $target_env $db_name $source_env
+blt artifact:ac-hooks:db-scrub $site $target_env $db_name $source_env --ansi=false
 
 set +v

--- a/scripts/cloud-hooks/hooks/common/post-db-copy/post-db-copy.sh
+++ b/scripts/cloud-hooks/hooks/common/post-db-copy/post-db-copy.sh
@@ -19,6 +19,6 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-blt artifact:ac-hooks:post-db-copy $site $target_env $db_name $source_env --environment=$target_env -v --yes --no-interaction
+blt artifact:ac-hooks:post-db-copy $site $target_env $db_name $source_env --environment=$target_env -v --yes --no-interaction --drush.ansi=false
 
 set +v

--- a/scripts/cloud-hooks/hooks/common/post-files-copy/post-files-copy.sh
+++ b/scripts/cloud-hooks/hooks/common/post-files-copy/post-files-copy.sh
@@ -18,6 +18,6 @@ repo_root="/var/www/html/$site.$target_env"
 export PATH=$repo_root/vendor/bin:$PATH
 cd $repo_root
 
-blt artifact:ac-hooks:post-files-copy $site $target_env $source_env --environment=$target_env -v --yes --no-interaction
+blt artifact:ac-hooks:post-files-copy $site $target_env $source_env --environment=$target_env -v --yes --no-interaction --drush.ansi=false
 
 set +v


### PR DESCRIPTION
Cloud Hook task logs don't support ANSI output, causing behavior described in #3146. This builds on that PR by disabling ANSI output in Cloud Hooks.

To recreate the issue, simply view any log output in a Cloud hook task. Without this PR, it'll look like `�[37;46;1m[success]�[39;49;22m Cache rebuild complete.`. With the PR, should be much cleaner: `[success] Cache rebuild complete.`