### PR TITLE
Add isset check on  $_SERVER['PWD'] in blt-robo.php to fix PHP notice

### DIFF
--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -19,8 +19,10 @@ require_once __DIR__ . '/blt-robo-run.php';
  * @return bool|string
  */
 function find_repo_root() {
+  // Check for PWD - some local environments will not have this key
+  $pwd = isset($_SERVER['PWD']) ? $_SERVER['PWD'] : null;
   $possible_repo_roots = [
-    $_SERVER['PWD'],
+    $pwd,
     getcwd(),
     realpath(__DIR__ . '/../'),
     realpath(__DIR__ . '/../../../'),

--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -19,8 +19,8 @@ require_once __DIR__ . '/blt-robo-run.php';
  * @return bool|string
  */
 function find_repo_root() {
-  // Check for PWD - some local environments will not have this key
-  $pwd = isset($_SERVER['PWD']) ? $_SERVER['PWD'] : null;
+  // Check for PWD - some local environments will not have this key.
+  $pwd = isset($_SERVER['PWD']) ? $_SERVER['PWD'] : NULL;
   $possible_repo_roots = [
     $pwd,
     getcwd(),


### PR DESCRIPTION
Some local environments, such as Lando, will not have a PWD key in $_SERVER, thus triggering a PHP Notice, which prevents Behat scripts from executing. Add an `isset` check on  `$_SERVER['PWD']` to allow other environments to function.

Fixes # 
--------

Changes proposed:
---------
 Add an `isset` check on `$_SERVER['PWD']` within `blt-robo.php` to prevent a PHP notice from breaking Behat scripts. 

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. Using a local Lando environment with correctly configured BLT Behat 
2. Run `lando blt tests:behat:run` command

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. There is no PHP Notice reading `Undefined index: PWD in /app/vendor/acquia/blt/bin/blt-robo.php on line 23` in your Lando environment
2. Behat tests run successfully in Lando
3. Yay

 
