### PR TITLE
Add isset check on $_SERVER['PWD'] in blt-robo.php to fix PHP notice

### DIFF
--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -19,8 +19,10 @@ require_once __DIR__ . '/blt-robo-run.php';
  * @return bool|string
  */
 function find_repo_root() {
+  // Check for PWD - some local environments will not have this key.
+  $pwd = isset($_SERVER['PWD']) ? $_SERVER['PWD'] : NULL;
   $possible_repo_roots = [
-    $_SERVER['PWD'],
+    $pwd,
     getcwd(),
     realpath(__DIR__ . '/../'),
     realpath(__DIR__ . '/../../../'),

--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -19,14 +19,15 @@ require_once __DIR__ . '/blt-robo-run.php';
  * @return bool|string
  */
 function find_repo_root() {
-  // Check for PWD - some local environments will not have this key.
-  $pwd = isset($_SERVER['PWD']) ? $_SERVER['PWD'] : NULL;
   $possible_repo_roots = [
-    $pwd,
     getcwd(),
     realpath(__DIR__ . '/../'),
     realpath(__DIR__ . '/../../../'),
   ];
+    // Check for PWD - some local environments will not have this key.
+  if(isset($_SERVER['PWD'])) {
+   array_unset($possible_repo_roots, $_SERVER['PWD']);
+  }
   foreach ($possible_repo_roots as $possible_repo_root) {
     if ($repo_root = find_directory_containing_files($possible_repo_root, ['vendor/bin/blt', 'vendor/autoload.php'])) {
       return $repo_root;

--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -25,17 +25,16 @@ function find_repo_root() {
     realpath(__DIR__ . '/../'),
     realpath(__DIR__ . '/../../../'),
   ];
-    // Check for PWD - some local environments will not have this key.
-    if (isset($_SERVER['PWD'])) {
-        array_unshift($possible_repo_roots, $_SERVER['PWD']);
-    }
+  // Check for PWD - some local environments will not have this key.
+  if (isset($_SERVER['PWD'])) {
+    array_unshift($possible_repo_roots, $_SERVER['PWD']);
+  }
   foreach ($possible_repo_roots as $possible_repo_root) {
     if ($repo_root = find_directory_containing_files($possible_repo_root, ['vendor/bin/blt', 'vendor/autoload.php'])) {
       return $repo_root;
     }
   }
 }
-
 
 /**
  * Traverses file system upwards in search of a given file.

--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -19,21 +19,22 @@ require_once __DIR__ . '/blt-robo-run.php';
  * @return bool|string
  */
 function find_repo_root() {
-  $possible_repo_roots = [
-    getcwd(),
-    realpath(__DIR__ . '/../'),
-    realpath(__DIR__ . '/../../../'),
-  ];
+    $possible_repo_roots = [
+        getcwd(),
+        realpath(__DIR__ . '/../'),
+        realpath(__DIR__ . '/../../../'),
+    ];
     // Check for PWD - some local environments will not have this key.
-  if(isset($_SERVER['PWD'])) {
-   array_unshift($possible_repo_roots, $_SERVER['PWD']);
-  }
-  foreach ($possible_repo_roots as $possible_repo_root) {
-    if ($repo_root = find_directory_containing_files($possible_repo_root, ['vendor/bin/blt', 'vendor/autoload.php'])) {
-      return $repo_root;
+    if (isset($_SERVER['PWD'])) {
+        array_unshift($possible_repo_roots, $_SERVER['PWD']);
     }
-  }
+    foreach ($possible_repo_roots as $possible_repo_root) {
+        if ($repo_root = find_directory_containing_files($possible_repo_root, ['vendor/bin/blt', 'vendor/autoload.php'])) {
+            return $repo_root;
+        }
+    }
 }
+
 
 /**
  * Traverses file system upwards in search of a given file.

--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -26,7 +26,7 @@ function find_repo_root() {
   ];
     // Check for PWD - some local environments will not have this key.
   if(isset($_SERVER['PWD'])) {
-   array_unset($possible_repo_roots, $_SERVER['PWD']);
+   array_unshift($possible_repo_roots, $_SERVER['PWD']);
   }
   foreach ($possible_repo_roots as $possible_repo_root) {
     if ($repo_root = find_directory_containing_files($possible_repo_root, ['vendor/bin/blt', 'vendor/autoload.php'])) {

--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -20,7 +20,6 @@ require_once __DIR__ . '/blt-robo-run.php';
  */
 function find_repo_root() {
   $possible_repo_roots = [
-    $pwd,
     getcwd(),
     realpath(__DIR__ . '/../'),
     realpath(__DIR__ . '/../../../'),

--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -19,20 +19,21 @@ require_once __DIR__ . '/blt-robo-run.php';
  * @return bool|string
  */
 function find_repo_root() {
-    $possible_repo_roots = [
-        getcwd(),
-        realpath(__DIR__ . '/../'),
-        realpath(__DIR__ . '/../../../'),
-    ];
+  $possible_repo_roots = [
+    $pwd,
+    getcwd(),
+    realpath(__DIR__ . '/../'),
+    realpath(__DIR__ . '/../../../'),
+  ];
     // Check for PWD - some local environments will not have this key.
     if (isset($_SERVER['PWD'])) {
         array_unshift($possible_repo_roots, $_SERVER['PWD']);
     }
-    foreach ($possible_repo_roots as $possible_repo_root) {
-        if ($repo_root = find_directory_containing_files($possible_repo_root, ['vendor/bin/blt', 'vendor/autoload.php'])) {
-            return $repo_root;
-        }
+  foreach ($possible_repo_roots as $possible_repo_root) {
+    if ($repo_root = find_directory_containing_files($possible_repo_root, ['vendor/bin/blt', 'vendor/autoload.php'])) {
+      return $repo_root;
     }
+  }
 }
 
 


### PR DESCRIPTION
Some local environments, such as Lando, will not have a PWD key in $_SERVER, thus triggering a PHP Notice, which prevents Behat scripts from executing. Add an `isset` check on  `$_SERVER['PWD']` to allow other environments to function.

Fixes # 
--------

Changes proposed:
---------
 Add an `isset` check on `$_SERVER['PWD']` within `blt-robo.php` to prevent a PHP notice from breaking Behat scripts. 

Steps to replicate the issue:
----------
(If this PR is not fixing a defect/bug, you can remove this section.)

1. Using a local Lando environment with correctly configured BLT Behat 
2. Run `lando blt tests:behat:run` command

Steps to verify the solution:
-----------
(How does someone verify that this does what you think does?)

1. There is no PHP Notice reading `Undefined index: PWD in /app/vendor/acquia/blt/bin/blt-robo.php on line 23` in your Lando environment
2. Behat tests run successfully in Lando
3. Yay
