### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,15 +22,7 @@ See [INSTALL.md](INSTALL.md) for a list of prequisites and links to instructions
 
 ## Releases and versioning
 
-Up to the last two most major versions of BLT are actively supported. The newest major version will receive both bug fixes and new features, while the penultimate major version will recieve bug fixes for at least two months. For example, if 8.8.1 is the most recent version of BLT:
-
-* As of the first cut tag for 8.8.x, 8.7.x will enter "LTS".
-    * 8.7.x will continue to receive bug fixes and minor features
-    * 8.7.x will not receive any major new features or backwards incompatible changes
-* Two months after the first cut tag for 8.8.x
-    * 8.7.x will no longer be supported
-    * 8.9.x will be created for major new features.
-* At some point later, 8.9.0 will be cut, and 8.8.x will enter "LTS".
+BLT generally has an LTS release, supported stable release, and unstable (HEAD) release at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive both bug fixes and new features, while the penultimate ("LTS") major version will receive bug fixes for at least two months (or longer if necessary in order to match pinned versions of Drupal or Drush).
 
 ### Release support status
 
@@ -38,22 +30,16 @@ Up to the last two most major versions of BLT are actively supported. The newest
 |---------------|-----------------------------|--------|----------------|--------------|
 | 10.x          | Unsupported (Beta)          | >=8.6  | >=9.4.0        | \*active dev |
 | 9.2.x         | Supported                   | 8.6    | >=9.4.0        | \*active dev |
-| 9.x           | LTS, EOL TBA                | 8.5    | >=9.1.0        | \*bug fixes  |
+| 9.x           | LTS, EOL May 2019           | 8.5    | >=9.1.0        | \*bug fixes  |
 | 8.9.x         | Unsupported, EOL            | <=8.5  | ~8             |              |
 | 8.8.x         | Unsupported, EOL            | <=8.3  | ~8             |              |
 | 8.7.x         | Unsupported, EOL            | <=8.3  | ~8             |              |
 
-### 10.x branch
+### Branch details
 
-The 10.x branch is currently in beta and is not currently stable or supported. It requires Drush 9.4.x, Drupal 8.6.x, and PHP 7+. It is considered a major release because it removes the Composer merge plugin that BLT previously used to manage dependencies.
+The 10.x branch is considered a major release because it requires PHP 7+ and removes the Composer merge plugin that BLT previously used to manage dependencies.
 
-### 9.2.x branch
-
-The 9.2.x branch is currently in development and supported. It requires Drush 9.4.x and Drupal 8.6.x.
-
-### 9.x branch
-
-The 9.x branch is currently in LTS and receiving bug fixes only. It requires Drush 9 and Drupal 8.5.x. It will be supported until Drupal 8.5.x is EOL.
+The 9.x branch will be supported until Drupal 8.5.x is EOL (May 2019).
 
 ## Philosophy and Purpose
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,9 +31,7 @@ BLT generally has an LTS release, supported stable release, and unstable (HEAD) 
 | 10.x          | Unsupported (Beta)          | >=8.6  | >=9.4.0        | \*active dev |
 | 9.2.x         | Supported                   | 8.6    | >=9.4.0        | \*active dev |
 | 9.x           | LTS, EOL May 2019           | 8.5    | >=9.1.0        | \*bug fixes  |
-| 8.9.x         | Unsupported, EOL            | <=8.5  | ~8             |              |
-| 8.8.x         | Unsupported, EOL            | <=8.3  | ~8             |              |
-| 8.7.x         | Unsupported, EOL            | <=8.3  | ~8             |              |
+| <=8.9.x       | Unsupported, EOL            | <=8.5  | ~8             |              |
 
 ### Branch details
 


### PR DESCRIPTION
The section on releases and versioning is pretty verbose, and could be consolidated / simplified.

Additionally, I propose May 2019 as EOL for BLT 9.x (to correspond with EOL for Drupal 8.5.)