### PR TITLE
Fixes #3050: Memcache stampede protection doesn't exist.

### DIFF
--- a/settings/memcache.settings.php
+++ b/settings/memcache.settings.php
@@ -10,7 +10,8 @@ use Composer\Autoload\ClassLoader;
 // Check for PHP Memcached libraries.
 $memcache_exists = class_exists('Memcache', FALSE);
 $memcached_exists = class_exists('Memcached', FALSE);
-$memcache_module_is_present = file_exists(DRUPAL_ROOT . '/modules/contrib/memcache/memcache.services.yml');
+$memcache_services_yml = DRUPAL_ROOT . '/modules/contrib/memcache/memcache.services.yml';
+$memcache_module_is_present = file_exists($memcache_services_yml);
 if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
   // Use Memcached extension if available.
   if ($memcached_exists) {
@@ -21,8 +22,7 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
     $class_loader = new ClassLoader();
     $class_loader->addPsr4('Drupal\\memcache\\', 'modules/contrib/memcache/src');
     $class_loader->register();
-
-    $settings['container_yamls'][] = DRUPAL_ROOT . '/modules/contrib/memcache/memcache.services.yml';
+    $settings['container_yamls'][] = $memcache_services_yml;
 
     // Define custom bootstrap container definition to use Memcache for
     // cache.container.
@@ -75,7 +75,5 @@ if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
     // Use memcache as the default bin.
     $settings['cache']['default'] = 'cache.backend.memcache';
 
-    // Enable stampede protection.
-    $settings['memcache']['stampede_protection'] = TRUE;
   }
 }


### PR DESCRIPTION
Fixes #3050
--------
Thanks to @bkosborne for pointing out that this cruft.

Changes proposed:
---------
- Remove the settings for memcache stampede protection, which are simply snakeoil and do nothing since [memcache removed stampede protection in 2.0-alpha7](https://cgit.drupalcode.org/memcache/commit/?h=8.x-2.x&id=7bba7982c129a0c0632b1483ab4dc0ff312e1859). This also brings us in line with the official [Acquia-recommended settings file](https://docs.acquia.com/acquia-cloud/performance/memcached/enable/#configuration-for-drupal-8).

Steps to replicate the issue:
----------
1. Observe that stampede protection wasn't actually working prior to this change.

Steps to verify the solution:
-----------
1. Observe that it still doesn't work after :smile: 

 
