### PR TITLE
Exclude settings.php from codesniffing.

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,5 +34,8 @@
   <exclude-pattern>*/node_modules</exclude-pattern>
   <exclude-pattern>*/vendor</exclude-pattern>
   <exclude-pattern>*/default.local.settings.php</exclude-pattern>
+  <!-- Drupal itself doesn't meet code standards. -->
+  <!-- @see https://www.drupal.org/project/drupal/issues/2571965 -->
+  <exclude-pattern>*/settings.php</exclude-pattern>
 
 </ruleset>


### PR DESCRIPTION
When upgrading to 9.2.x-dev, couldn't commit changes to settings.php because it actually isn't standards compliant.

Need to forward-port this


Also might need an update hook?