### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To execute the same "release" testing that is performed during CI execution, run
 ./vendor/bin/robo release:test
 ```
 
-Note that this requires a local MySQL database available with drupal as the db name, username, and password. It also requires the PHP MySQL extension to be enabled.
+Note that this requires a local MySQL database available with drupal as the db name, username, and password. It also requires the PHP MySQL extension to be enabled. Finally, it may be sensitive to MySQL version. In newer versions of MySQL (8+), you may need to set the user password like so: `alter user 'drupal'@'localhost' identified with mysql_native_password by 'drupal';`.
 
 ## PHPUnit
 


### PR DESCRIPTION
I kept getting `Drupal\Core\Installer\Exception\AlreadyInstalledException` during local tests and for the life of me couldn't figure out why. Turns out that authentication mechanisms changed in MySQL 8 and it's a bit of a misleading error on Drupal's part, the error really comes from MySQL: `The server requested authentication method unknown to the client`.

Here's a similar issue with several workarounds: https://github.com/laradock/laradock/issues/1390