### PR TITLE
Backport - Replace  by (stable) global variable equivalent (#3408)

### DIFF
--- a/scripts/factory-hooks/post-sites-php/includes.php
+++ b/scripts/factory-hooks/post-sites-php/includes.php
@@ -52,7 +52,7 @@ if (!function_exists('gardens_data_get_sites_from_file')) {
 
 }
 // Get all the domains that are defined for the current site.
-$domains = gardens_data_get_sites_from_file($data['gardens_site_settings']['conf']['acsf_db_name']);
+$domains = gardens_data_get_sites_from_file($GLOBALS['gardens_site_settings']['conf']['acsf_db_name']);
 // Get the site's name from the first domain.
 global $_acsf_site_name;
 $_acsf_site_name = explode('.', array_keys($domains)[0])[0];


### PR DESCRIPTION
Fixes #3362 
--------

Changes proposed:
---------
- Backports #3408 to BLT 9.x
- This has been tested and validated in production by multiple customers

