### PR TITLE
Remove cruft from travis ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,13 @@ php:
 
 env:
   global:
-    - DEPLOY_SOURCE_BRANCH=8.x
     - COMPOSER_BIN=$TRAVIS_BUILD_DIR/vendor/bin
     - BLT_DIR=$TRAVIS_BUILD_DIR
-    - IS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
-    - BUILD_DIR=$TRAVIS_BUILD_DIR
     - DRUPAL_CORE_HEAD=8.7.x-dev
   matrix:
     - DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal,long,requires-vm'
     - DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='long' PHPUNIT_EXCLUDE_GROUP='drupal,requires-vm'
-    # - DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal' PHPUNIT_EXCLUDE_GROUP='long,requires-vm'
+    - DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal' PHPUNIT_EXCLUDE_GROUP='long,requires-vm'
     # - DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
 
 matrix:
@@ -35,20 +32,15 @@ cache:
   -  "/tmp/blt-sandbox-instance/.rules"
 
 services:
-- memcached
 - mysql
 - xvfb
 
 addons:
-  ssh_known_hosts: []
   chrome: stable
 
 before_install:
   # Exit build early if only documentation was changed in a Pull Request.
   - source ${BLT_DIR}/scripts/travis/exit_early
-  # Decrypt private SSH key id_rsa_blt.enc, save as ~/.ssh/id_rsa_blt.
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && -n "$encrypted_c0b166e924da_key" ]]; then openssl aes-256-cbc -K $encrypted_c0b166e924da_key -iv $encrypted_c0b166e924da_iv -in id_rsa_blt.enc -out ~/.ssh/id_rsa -d; chmod 600 ~/.ssh/id_rsa; ls -lash ~/.ssh; eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa; fi
-  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - phpenv config-rm xdebug.ini
   - phpenv config-add travis.php.ini
   - composer validate --no-check-all --ansi
@@ -63,31 +55,3 @@ install:
 
 script:
   - ${BLT_DIR}/vendor/bin/robo release:test
-
-before_deploy:
-  - cd ${TRAVIS_BUILD_DIR}/../blted8
-  # The BLTed8 project will need its ssh_known_hosts configured to push to ACF.
-  - yaml-cli update:value .travis.yml addons.ssh_known_hosts.0 svn-5223.devcloud.hosting.acquia.com
-  # Add encrypted SSH key to BLTed8 project.
-  - yaml-cli update:value .travis.yml before_deploy.0 'openssl aes-256-cbc -K $encrypted_065fa5839cf8_key -iv $encrypted_065fa5839cf8_iv -in id_rsa_blted8.enc -out ~/.ssh/id_rsa -d; chmod 600 ~/.ssh/id_rsa; eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_rsa;'
-  - cp ${TRAVIS_BUILD_DIR}/id_rsa_blted8.enc .
-  # Remove the symlink definition for BLT from composer.json and require this specific commit for BLT.
-  - composer config --unset repositories.blt
-  - composer require acquia/blt:8.x-dev#${TRAVIS_COMMIT}
-  - composer update --lock
-  - echo "[![Build Status](https://travis-ci.org/acquia-pso/blted8.svg?branch=8.x)](https://travis-ci.org/acquia-pso/blted8)" >> README.md
-  - git add -A
-  - git commit -m "Automated commit for BLT repo by Travis CI for Build ${TRAVIS_BUILD_ID}" -n
-
-after_success:
-  # - ./vendor/bin/coveralls -vvv
-
-deploy:
-  - provider: script
-    # Deploys build artifact's source branch to acquia-pso/blted8 on GitHub.
-    script: ${BLT_DIR}/scripts/blt/ci/internal/deploy_blted8.sh
-    skip_cleanup: true
-    on:
-      branch: $DEPLOY_SOURCE_BRANCH
-      php: 7.1
-      condition: $DRUPAL_CORE_VERSION = default


### PR DESCRIPTION
We've accumulated a lot of cruft in our .travis.yml file over the years, and not coincidentally our build times get longer and longer (#3436). The cruft has also directly caused problems when we want to add new features (#3444). Time for some housecleaning.

Some of these features we may want to add back later once we can actually use them (deployments, memcache) but there's no point in them taking up precious build time if they aren't being used today.