### PR TITLE
Fixed #2968: Show composer validation warnings and errors.

### DIFF
--- a/src/Robo/Commands/Validate/ComposerCommand.php
+++ b/src/Robo/Commands/Validate/ComposerCommand.php
@@ -4,7 +4,6 @@ namespace Acquia\Blt\Robo\Commands\Validate;
 
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Exceptions\BltException;
-use Robo\Contract\VerbosityThresholdInterface;
 
 /**
  * Defines commands in the "tests:composer:validate*" namespace.

--- a/src/Robo/Commands/Validate/ComposerCommand.php
+++ b/src/Robo/Commands/Validate/ComposerCommand.php
@@ -23,7 +23,6 @@ class ComposerCommand extends BltTasks {
     $result = $this->taskExecStack()
       ->dir($this->getConfigValue('repo.root'))
       ->exec('composer validate --no-check-all --ansi')
-      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
     if (!$result->wasSuccessful()) {
       $this->say($result->getMessage());


### PR DESCRIPTION
Fixes #2968
--------

Changes proposed:
---------
Currently, during composer validation (full test runs and pre-commit hooks) you don't get any output of warnings or errors. You only get an error from BLT if the task fails, which can be misleading and denies useful information to developers.