### PR TITLE
Fixed broken local tests.

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,7 +39,12 @@ To execute the same "release" testing that is performed during CI execution, run
 ./vendor/bin/robo release:test
 ```
 
-Note that this requires a local MySQL database available with drupal as the db name, username, and password. It also requires the PHP MySQL extension to be enabled. Finally, it may be sensitive to MySQL version. In newer versions of MySQL (8+), you may need to set the user password like so: `alter user 'drupal'@'localhost' identified with mysql_native_password by 'drupal';`.
+Note that this requires the following:
+- Four local MySQL databases available with drupal, drupal2, drupal3, and drupal4 as the db names
+- A MySQL user with access to the above, with drupal as the username and password. It may be sensitive to MySQL version. In newer versions of MySQL (8+), you may need to set the user password like so: `alter user 'drupal'@'localhost' identified with mysql_native_password by 'drupal';`.
+- The PHP MySQL extension to be enabled.
+- Chromedriver in order to run `@group drupal` tests.
+- You may want to exclude `@group requires-vm`.
 
 ## PHPUnit
 

--- a/src/Robo/Commands/Tests/TestsCommandBase.php
+++ b/src/Robo/Commands/Tests/TestsCommandBase.php
@@ -4,6 +4,7 @@ namespace Acquia\Blt\Robo\Commands\Tests;
 
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Wizards\TestsWizard;
+use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
 
 /**

--- a/tests/phpunit/Blt/DrushTest.php
+++ b/tests/phpunit/Blt/DrushTest.php
@@ -28,11 +28,11 @@ class DrushTest extends BltProjectTestBase {
 
       $config_file = $this->sandboxInstance . '/vendor/drush/drush/drush.yml';
       $message = "Failed asserting that the output of `drush status` contains $config_file when executed from $dir.";
-      $this->assertContains($config_file, $drush_output['drush-conf'][0], $message);
+      $this->assertContains($config_file, $drush_output['drush-conf'], $message);
 
       $config_file = $this->sandboxInstance . '/drush/drush.yml';
       $message = "Failed asserting that the output of `drush status` contains $config_file when executed from $dir.";
-      $this->assertContains($config_file, $drush_output['drush-conf'][1], $message);
+      $this->assertContains($config_file, $drush_output['drush-conf'], $message);
 
     }
   }


### PR DESCRIPTION
- When running tests, if chrome isn't found, it tries to throw an exception, except TestsCommandBase doesn't properly use BltException.
- If you have a drush.yml in your home directory, the drush test fails.