### PR TITLE
Fixed #2972: Install BLT alias after creating bash profile.

### DIFF
--- a/src/Robo/Commands/Blt/AliasCommand.php
+++ b/src/Robo/Commands/Blt/AliasCommand.php
@@ -25,17 +25,17 @@ class AliasCommand extends BltTasks {
         $this->logger->warning("Could not find your CLI configuration file.");
         $this->logger->warning("Looked in ~/.zsh, ~/.bash_profile, ~/.bashrc, ~/.profile, and ~/.functions.");
         $created = $this->createBashProfile();
-        if (!$created) {
+        $config_file = $this->getInspector()->getCliConfigFile();
+        if (!$created || is_null($config_file)) {
           $this->logger->warning("Please create one of the aforementioned files, or create the BLT alias manually.");
+          return;
         }
       }
-      else {
-        $this->say("BLT can automatically create a Bash alias to make it easier to run BLT tasks.");
-        $this->say("This alias will be created in <comment>$config_file</comment>.");
-        $confirm = $this->confirm("Install alias?");
-        if ($confirm) {
-          $this->createNewAlias();
-        }
+      $this->say("BLT can automatically create a Bash alias to make it easier to run BLT tasks.");
+      $this->say("This alias will be created in <comment>$config_file</comment>.");
+      $confirm = $this->confirm("Install alias?");
+      if ($confirm) {
+        $this->createNewAlias();
       }
     }
     elseif (!$this->isBltAliasUpToDate()) {


### PR DESCRIPTION
Fixes #2972
--------

Changes proposed:
---------
- If BLT needs to create a bash profile for you, immediately install the alias after creating it.

Steps to replicate the issue:
----------
1. In an environment without any profile files (i.e. .bash_profile, .bashrc, etc) run `./vendor/acquia/blt/bin/blt alias`
2. Observe that BLT creates the profile file but doesn't install the alias.

Steps to verify the solution:
-----------
Same as above, but verify that the profile is created _and_ the alias is installed.

 
