### PR TITLE
Issue 3014

### DIFF
--- a/docs/updating-blt.md
+++ b/docs/updating-blt.md
@@ -14,18 +14,6 @@ If you are already using BLT via Composer, you can update to the latest version 
 1. Review and commit changes to your project files.
 1. Rarely, you may need to refresh your local environment via `blt setup`. This will drop your local database and re-install Drupal.
 
-### Modifying update behavior
-
-By default BLT will modify a handful of files in your project to conform to the [upstream template](https://github.com/acquia/blt/blob/9.x/template). If you'd like to prevent this, set `extra.blt.update` to `false` in `composer.json`:
-
-      "extra": {
-        "blt": {
-            "update": false
-        }
-      }
-
-Please note that if you choose to do this, it is your responsibility to track upstream changes. This is very likely to cause issues when you upgrade BLT to a new version.
-
 ## Updating from a non-Composer-managed (very old) version
 
 If you are using an older version of BLT that was not installed using Composer, you may update to the Composer-managed version by running the following commands:

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -44,6 +44,8 @@ class UpdateCommand extends BltTasks {
    * @command internal:create-project
    *
    * @hidden
+   *
+   * @throws BltException
    */
   public function createProject() {
     $this->cleanUpProjectTemplate();
@@ -61,7 +63,7 @@ class UpdateCommand extends BltTasks {
    *
    * @command internal:add-to-project
    *
-   * @return \Robo\Result
+   * @return void
    *
    * @hidden
    */
@@ -104,12 +106,11 @@ class UpdateCommand extends BltTasks {
    * @command blt:update
    *
    * @aliases bu update
+   * @param array $options
+   * @throws BltException
    */
-  public function update($options = [
-    'since' => InputOption::VALUE_REQUIRED,
-  ]) {
+  public function update($options = ['since' => InputOption::VALUE_REQUIRED]) {
     $this->rsyncTemplate();
-    $this->mungeProjectYml();
 
     $starting_version = $options['since'] ?: $this->currentSchemaVersion;
     if ($this->executeSchemaUpdates($starting_version)) {
@@ -308,7 +309,9 @@ class UpdateCommand extends BltTasks {
   /**
    * Rsyncs files from BLT's template dir into project root dir.
    *
-   * @return \Robo\Result
+   * @return void
+   *
+   * @throws BltException
    */
   protected function rsyncTemplate() {
     $source = $this->getConfigValue('blt.root') . '/template';


### PR DESCRIPTION
Fixes #3014 
--------

Changes proposed:
---------
Don't automatically munge blt.yml every time a project runs composer update.

Steps to replicate the issue:
----------
Create a new BLT project. Remove shield from the modules array in blt.yml. Run composer update. Observe that shield has magically (and unhelpfully) reappeared.

Steps to verify the solution:
-----------
Same as above, but observe that shield stays gone.

Note to BLT maintainers (aka my future self): this requires that future changes to blt.yml have a corresponding update hook.
