### PR TITLE
Fixes #3015: Cannot run Twig or Yaml validators multiple times.

### DIFF
--- a/src/Robo/Commands/Validate/TwigCommand.php
+++ b/src/Robo/Commands/Validate/TwigCommand.php
@@ -49,7 +49,7 @@ class TwigCommand extends BltTasks {
     /** @var \Acquia\Blt\Robo\Filesets\FilesetManager $fileset_manager */
     $fileset_manager = $this->getContainer()->get('filesetManager');
     $fileset_ids = $this->getConfigValue('validate.twig.filesets');
-    $filesets = $fileset_manager->getFilesets($fileset_ids);
+    $filesets = $fileset_manager->getFilesets($fileset_ids, TRUE);
     foreach ($filesets as $fileset_id => $fileset) {
       $filesets[$fileset_id] = $fileset_manager->filterFilesByFileset($files, $fileset);
     }

--- a/src/Robo/Commands/Validate/YamlCommand.php
+++ b/src/Robo/Commands/Validate/YamlCommand.php
@@ -22,7 +22,7 @@ class YamlCommand extends BltTasks {
     /** @var \Acquia\Blt\Robo\Filesets\FilesetManager $fileset_manager */
     $fileset_manager = $this->getContainer()->get('filesetManager');
     $fileset_ids = $this->getConfigValue('validate.yaml.filesets');
-    $filesets = $fileset_manager->getFilesets($fileset_ids);
+    $filesets = $fileset_manager->getFilesets($fileset_ids, TRUE);
     $bin = $this->getConfigValue('composer.bin');
     $command = "'$bin/yaml-cli' lint '%s'";
     $this->executeCommandAgainstFilesets($filesets, $command, TRUE);

--- a/src/Robo/Filesets/FilesetManager.php
+++ b/src/Robo/Filesets/FilesetManager.php
@@ -119,8 +119,8 @@ class FilesetManager implements ConfigAwareInterface, LoggerAwareInterface {
    *
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  public function getFilesets($fileset_ids = []) {
-    if (!$this->filesets) {
+  public function getFilesets($fileset_ids = [], $resetFinder = FALSE) {
+    if (!$this->filesets || $resetFinder) {
       $this->registerFilesets();
     }
 


### PR DESCRIPTION
Fixes #3015
--------

Changes proposed:
---------
- Add a 'reset' parameter to the method that loads filesets, which will reset filesets to their default values
- Use this reset parameter for the Yaml and Twig validators so that subsequent runs don't contaminate each other.

Steps to replicate the issue:
----------
Follow steps in #3015. Verify that only the first Twig error is reported.

Steps to verify the solution:
-----------
Same as above, but verify that errors in both files are reported all ten times.

An upstream issue (https://github.com/symfony/symfony/issues/8871) indicates this is a common problem and offers alternative solutions, but this one seems simple enough.