### PR TITLE
Fixes #3032: Ensure source files are clean before committing on Pipelines

### DIFF
--- a/scripts/pipelines/build_artifact
+++ b/scripts/pipelines/build_artifact
@@ -6,6 +6,7 @@ export PATH=${COMPOSER_BIN}:${PATH}
 
 # Generate artifact in a separate directory.
 export NEW_BUILD_DIR=/tmp/artifact
+blt deploy:check-dirty --ansi --verbose
 blt artifact:build -D deploy.dir=${NEW_BUILD_DIR} --ansi --verbose
 # Move git history to artifact directory. Required for pipelines to commit and push.
 mv ${SOURCE_DIR}/.git ${NEW_BUILD_DIR}/

--- a/scripts/pipelines/setup_env
+++ b/scripts/pipelines/setup_env
@@ -15,7 +15,4 @@ mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS drupal"
 nvm install v8.1.4
 npm install -g npm
 
-#  The local.hostname must be set to 127.0.0.1:8888 because we are using drush runserver to test the site.
-yaml-cli update:value blt/blt.yml project.local.hostname '127.0.0.1:8888'
-
 set +v

--- a/scripts/pipelines/tests
+++ b/scripts/pipelines/tests
@@ -4,6 +4,6 @@ set -ev
 
 export PATH=${COMPOSER_BIN}:${PATH}
 
-blt tests:all --define drush.alias='${drush.aliases.ci}' --environment=ci --define tests.run-server=true -D behat.web-driver=chrome --yes --ansi --verbose
+blt tests:all --define drush.alias='${drush.aliases.ci}' --environment=ci -D behat.web-driver=chrome --yes --ansi --verbose
 
 set +v

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -74,11 +74,13 @@ class DeployCommand extends BltTasks {
   /**
    * Checks to see if current git branch has uncommitted changes.
    *
+   * @command deploy:check-dirty
+   *
    * @throws \Exception
    *   Thrown if deploy.git.failOnDirty is TRUE and there are uncommitted
    *   changes.
    */
-  protected function checkDirty($options) {
+  public function checkDirty($options = ['ignore-dirty' => FALSE]) {
     $result = $this->taskExec('git status --porcelain')
       ->printMetadata(FALSE)
       ->printOutput(FALSE)


### PR DESCRIPTION
Fixes #3032
--------

Changes proposed:
---------
- Make checkDirty() a command that can be run on its own.
- Call checkDirty() before deploying via Pipelines.

Steps to replicate the issue:
----------
Add something to your acquia pipelines file that writes to the codebase before deploying, and observe that BLT happily sends it out despite it not being captured in your source repo (bad)

Steps to verify the solution:
-----------
Apply this patch, do the same as above, and see that BLT fails the build. 

 
