### PR TITLE
Fix config message.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -198,7 +198,7 @@ class ConfigCommand extends BltTasks {
    */
   protected function checkConfigOverrides($cm_core_key) {
     if (!$this->getConfigValue('cm.allow-overrides') && !$this->getInspector()->isActiveConfigIdentical()) {
-      throw new BltException("Configuration in the database does not match configuration on disk. BLT has attempted to automatically fix this by re-exporting configuration to disk. Please read https://github.com/acquia/blt/wiki/Configuration-override-test-and-errors");
+      throw new BltException("Configuration in the database does not match configuration on disk. This indicates that your configuration on disk needs attention. Please read https://github.com/acquia/blt/wiki/Configuration-override-test-and-errors");
     }
   }
 


### PR DESCRIPTION
In later versions of Drush we use `config:status` instead of `cex` to check if configuration has changed, so we no longer write changes to disk. Messages should reflect that.