### PR TITLE
Remove failing cache clear

### DIFF
--- a/tests/phpunit/src/BltProjectTestBase.php
+++ b/tests/phpunit/src/BltProjectTestBase.php
@@ -87,7 +87,6 @@ abstract class BltProjectTestBase extends TestCase {
 
     // Config is overwritten for each $this->blt execution.
     $this->reInitializeConfig($this->createBltInput(NULL, []));
-    $this->drush('cache-rebuild', NULL, FALSE);
     $this->dbDump = $this->sandboxInstance . "/bltDbDump.sql";
 
     // Multisite settings.


### PR DESCRIPTION
This produces a lot of errors, and has no functional effect on the tests.