### PR TITLE
Fixes #3016: Commands run in parallel don't run to completion.

### DIFF
--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -254,20 +254,15 @@ class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerA
     $task = $this->taskParallelExec()
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERY_VERBOSE);
 
-    $chunk_size = 20;
-    $chunks = array_chunk((array) $files, $chunk_size);
-    foreach ($chunks as $chunk) {
-      foreach ($chunk as $file) {
-        $full_command = sprintf($command, $file);
-        $task->process($full_command);
-      }
+    foreach ($files as $file) {
+      $full_command = sprintf($command, $file);
+      $task->process($full_command);
+    }
 
-      $result = $task->run();
+    $result = $task->run();
 
-      if (!$result->wasSuccessful()) {
-        $this->say($result->getMessage());
-        return $result;
-      }
+    if (!$result->wasSuccessful()) {
+      $this->say($result->getMessage());
     }
     return $result;
   }


### PR DESCRIPTION
Fixes #3016
--------

Changes proposed:
---------
- When running commands in parallel, don't try to chunk them. Just send them all to Robo at once.

Steps to replicate the issue:
----------
Original steps in #3016
1. `echo "test: {" >> docroot/modules/custom/test/test.info.yml`
2. `blt tests:yaml:lint:all -vvv`
3. Observe that test.info.yml does not fail validation, or even get scanned at all.

Steps to verify the solution:
-----------
1. Apply this patch.
2. Repeat steps above
3. Observe that file fails validation as expected

The chunking wasn't behaving as intended. Instead of running the first 20 commands, then the next 20, etc... it was running 20, then the first 20 _and_ the next 20 (40 total), then the first 40 _and_ the next 20 (60), etc... At some point it blows up and fails silently.

I'm not sure why chunking was added in the first place. It was added in #1672 and there's not much context. @grasmash do you recall?