### PR TITLE
Fixes #3238: Removed gitignore files from git on deploy.

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -539,6 +539,7 @@ class DeployCommand extends BltTasks {
     $this->say("Committing artifact to <comment>{$this->branchName}</comment>...");
     $result = $this->taskExecStack()
       ->dir($this->deployDir)
+      ->exec("git rm -r --cached .")
       ->exec("git add -A")
       ->exec("git commit --quiet -m '{$this->commitMessage}'")
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)


### PR DESCRIPTION
Fixes #3238
--------

Changes proposed
---------
- Remove files from Git that would otherwise be ignored. Typically these are cruft that was committed prior to a change in the .gitignore file, which then never got deleted.

Steps to replicate the issue
----------
Follow steps in #3238 (requires a deployable repo, aka ACE)

Expected behavior
-----------
Ignored files get deleted on the next run of `blt deploy`.

Additional details
-----------
I tried this for myself on some personal sites and they turned up a bunch of cruft that shouldn't be there.