### PR TITLE
Start testing Drupal 8.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ env:
   global:
     - COMPOSER_BIN=$TRAVIS_BUILD_DIR/vendor/bin
     - BLT_DIR=$TRAVIS_BUILD_DIR
-    - DRUPAL_CORE_HEAD=8.7.x-dev
+    - DRUPAL_CORE_HEAD=^8.7.0-alpha1
   matrix:
     - DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal,long,requires-vm'
     - DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='long' PHPUNIT_EXCLUDE_GROUP='drupal,requires-vm'
     - DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal' PHPUNIT_EXCLUDE_GROUP='long,requires-vm'
-    # - DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
+    - DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
 
 matrix:
   allow_failures:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Note that this requires the following:
 - Four local MySQL databases available with drupal, drupal2, drupal3, and drupal4 as the db names
 - A MySQL user with access to the above, with drupal as the username and password. It may be sensitive to MySQL version. In newer versions of MySQL (8+), you may need to set the user password like so: `alter user 'drupal'@'localhost' identified with mysql_native_password by 'drupal';`.
 - The PHP MySQL extension to be enabled.
-- Chromedriver in order to run `@group drupal` tests.
+- Chromedriver, sqlite, and the php-sqlite3 extension in order to run `@group drupal` tests.
 - You may want to exclude `@group requires-vm`.
 
 ## PHPUnit

--- a/tests/phpunit/Blt/TestDrupalTestCommandTest.php
+++ b/tests/phpunit/Blt/TestDrupalTestCommandTest.php
@@ -62,8 +62,6 @@ class DrupalTest extends BltProjectTestBase {
     ]);
     $results = file_get_contents($this->sandboxInstance . '/reports/drupal/run-tests-script/Drupal_Tests_action_Kernel_Migrate_d7_MigrateActionsTest.xml');
     $this->assertNotContains('failure type="failure"', $results);
-    $results = file_get_contents($this->sandboxInstance . '/reports/drupal/run-tests-script/Drupal_Tests_action_Kernel_Plugin_Action_EmailActionTest.xml');
-    $this->assertNotContains('failure type="failure"', $results);
     $results = file_get_contents($this->sandboxInstance . '/reports/drupal/run-tests-script/Drupal_Tests_action_Kernel_Plugin_migrate_source_ActionTest.xml');
     $this->assertNotContains('failure type="failure"', $results);
     $results = file_get_contents($this->sandboxInstance . '/reports/drupal/run-tests-script/Drupal_Tests_action_Unit_Menu_ActionLocalTasksTest.xml');


### PR DESCRIPTION
Now that Drupal 8.7 has an alpha release, I think we should start testing it to ensure BLT 10.x will be compatible.

The only modification I had to make was to the Drupal phpunit test, to account for this upstream change: https://www.drupal.org/node/2815379

We should also attempt to backport this to 9.2.x. Ideally both 9.2.x and 10.x will support Drupal 8.6 and 8.7, so that Drupal upgrades and BLT upgrades aren't too tightly coupled.