### PR TITLE
Fixes #3239: build-dependencies option doesn't behave as expected.

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -361,14 +361,6 @@ class DeployCommand extends BltTasks {
    * Copies files from source repo into artifact.
    */
   protected function buildCopy() {
-
-    if (!$this->getConfigValue('deploy.build-dependencies')) {
-      $this->logger->warning("Dependencies will not be built because deploy.build-dependencies is not enabled");
-      $this->logger->warning("You should define a custom deploy.exclude_file to ensure that dependencies are copied from the root repository.");
-
-      return FALSE;
-    }
-
     $exclude_list_file = $this->getExcludeListFile();
     $source = $this->getConfigValue('repo.root');
     $dest = $this->deployDir;
@@ -399,6 +391,12 @@ class DeployCommand extends BltTasks {
    * Installs composer dependencies for artifact.
    */
   protected function composerInstall() {
+    if (!$this->getConfigValue('deploy.build-dependencies')) {
+      $this->logger->warning("Dependencies will not be built because deploy.build-dependencies is not enabled");
+      $this->logger->warning("You should define a custom deploy.exclude_file to ensure that dependencies are copied from the root repository.");
+
+      return FALSE;
+    }
     $this->say("Rebuilding composer dependencies for production...");
     $this->taskDeleteDir([$this->deployDir . '/vendor'])
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)


### PR DESCRIPTION
Fixes #3239
--------

Changes proposed
---------
- If _deploy.build-dependencies_ is set to true (the default, and the case for the vast majority of projects), this PR has no effect.
- If _deploy.build-dependencies_ is false, previously the deploy command would run composer install in the build directory but not copy over any custom files. Now it will copy over custom files but not run composer install. This is the expected behavior.

Steps to replicate the issue
----------
1. Set _deploy.build-dependencies_ to false in _blt/blt.yml_
2. Run `blt deploy`.
3. Observe that composer dependencies are installed in the deploy root, but all custom files are missing.

Expected behavior
-----------
1. Custom files are copied, but composer dependencies are not installed.