### PR TITLE
Fixes #3247: Support content_archive module.

### DIFF
--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -168,10 +168,6 @@ auto-save-list
 tramp
 .\#*
 
-# Org-mode.
-.org-id-locations
-*_archive
-
 # flymake-mode.
 *_flymake.*
 


### PR DESCRIPTION
Fixes #3247
--------

Changes proposed
---------
- Don't strip files and directories of the pattern "*_archive" from the deploy artifact. This seems pretty unlikely to negatively impact any existing users.

Steps to replicate the issue
----------
1. Add the content_archive module to your codebase via composer and run `blt deploy`.

Previous behavior (before applying PR)
----------
The module was not deployed.

Expected behavior (after applying PR)
-----------
The module is deployed.

Additional details
-----------
This rule (and many others like it) were added in #2767. I reviewed them and this certainly seems the riskiest to me, although as a whole the gitignore file is pretty zealous and I think we should try to trim it down going forward.