### PR TITLE
Fixes #3256: Add geerlingguy/drupal-vm as default base box.

### DIFF
--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -269,6 +269,7 @@ class VmCommand extends BltTasks {
     $base_box = $this->askChoice(
       "Which base box would you like to use?",
       [
+        'geerlingguy/drupal-vm',
         'geerlingguy/ubuntu1604',
         'beet/box',
       ],
@@ -290,6 +291,7 @@ class VmCommand extends BltTasks {
         break;
 
       case 'geerlingguy/ubuntu1604':
+      case 'geerlingguy/drupal-vm':
         $config->set('workspace', '/root');
         $config->set('extra_packages', [
           'patchutils',


### PR DESCRIPTION
Fixes #3256
--------

Changes proposed
---------
- Add geerlingguy/drupal-vm as the default base box for new VMs.

Steps to replicate the issue
----------
1. Run `blt vm`

Expected behavior (after applying PR)
-----------
1. Observe that you now have the (default) option of using geerlingguy/drupal-vm as the base box, and this is functionally equivalent to the other boxes (but much faster to provision).

Additional details
-----------
@geerlingguy please review

I'm wondering if we should completely remove the option to choose a base box, and just use geerlingguy/drupal-vm? It sounds like beetbox and the older ubuntu boxes are being phased out anyway?

My only other concern here is that we lose the ability to control OS versions, so folks can't necessarily match their OS version in the VM to Acquia Cloud. As a practical matter, I'm not sure how important that is.