### PR TITLE
Fixes #3272: Do not deploy files directory.

### DIFF
--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -4,9 +4,9 @@ local.*
 local.blt.yml
 
 # Ignore paths that contain user-generated content.
-/docroot/sites/*/files/
-/docroot/sites/*/private/
-/files-private/
+/docroot/sites/*/files
+/docroot/sites/*/private
+/files-private
 
 # Ignore build artifacts.
 /tmp/


### PR DESCRIPTION
Fixes #3272
--------

Changes proposed
---------
- Previously, build artifacts would ignore the contents of the files directories, but not the directories themselves. Now they will ignore the entire directory (or symlink to a directory).
- This brings deploy artifacts in line with the source repo behavior, which also ignores file directories.
