### PR TITLE
Fixes #3332: Config imports should run for core-only after setup.

### DIFF
--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -31,7 +31,7 @@ class BuildCommand extends BltTasks {
   public function drupalInstall() {
     $commands = ['internal:drupal:install'];
     $strategy = $this->getConfigValue('cm.strategy');
-    if (in_array($strategy, ['config-split', 'features'])) {
+    if (in_array($strategy, ['core-only', 'config-split', 'features'])) {
       $commands[] = 'drupal:config:import';
     }
     $this->invokeCommands($commands);


### PR DESCRIPTION
Fixes #3332
--------

Changes proposed
---------
- If using the core-only config strategy, run imports after you do a setup, to bring it in line with other config strategies.

Steps to replicate the issue
----------
1. Use core-only strategy.
2. Run `blt setup`

Previous behavior (before applying PR)
----------
Configuration is not imported after setup

Expected behavior (after applying PR)
-----------
Configuration is imported after setup

Additional details
-----------
While this is theoretically something of a bug fix, I think it could also surprise existing users due to how finicky config imports can be, so I'm hesitant to backport it.