### PR TITLE
Note release cadence in README.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,9 +22,9 @@ See [INSTALL.md](INSTALL.md) for a list of prequisites and links to instructions
 
 ## Releases and versioning
 
-BLT generally has an LTS release, supported stable release, and unstable (HEAD) release at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive bug fixes and new features, while the penultimate ("LTS") major version will receive security fixes for six months. This is intended to coincide with the [Drupal core release cycle](https://www.drupal.org/core/release-cycle-overview), so that users can continue to use a single BLT major release through the lifecycle of a Drupal core minor release.
+BLT generally has an LTS release, supported stable release, and unstable (HEAD) release at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive bug fixes and new features, while the penultimate ("LTS") major version will receive security fixes for six months. Releases generally occur on first and third Wednesdays.
 
-Releases generally occur on first and third Wednesdays to coincide with [Drupal core and Lightning releases](https://www.drupal.org/core/release-cycle-overview) (although BLT versions are not generally bound to specific versions of core or Lightning.)
+This is intended to coincide with the [Drupal core release cycle](https://www.drupal.org/core/release-cycle-overview), so that users can continue to use a single BLT major release through the lifecycle of a Drupal core minor release.
 
 ### Release support status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,18 +22,20 @@ See [INSTALL.md](INSTALL.md) for a list of prequisites and links to instructions
 
 ## Releases and versioning
 
-BLT generally has an LTS release, supported stable release, and unstable (HEAD) release at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive both bug fixes and new features, while the penultimate ("LTS") major version will receive bug fixes for at least two months (or longer if necessary in order to match pinned versions of Drupal or Drush).
+BLT generally has an LTS release, supported stable release, and unstable (HEAD) release at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive bug fixes and new features, while the penultimate ("LTS") major version will receive security fixes for six months. This is intended to coincide with the [Drupal core release cycle](https://www.drupal.org/core/release-cycle-overview), so that users can continue to use a single BLT major release through the lifecycle of a Drupal core minor release.
 
 Releases generally occur on first and third Wednesdays to coincide with [Drupal core and Lightning releases](https://www.drupal.org/core/release-cycle-overview) (although BLT versions are not generally bound to specific versions of core or Lightning.)
 
 ### Release support status
 
-| Major Version | Support Status              | Drupal | Drush          | Dev Status   |
-|---------------|-----------------------------|--------|----------------|--------------|
-| 10.x          | Unsupported (Beta)          | >=8.6  | >=9.5.0        | \*active dev |
-| 9.2.x         | Supported                   | 8.6    | >=9.4.0        | \*active dev |
-| 9.x           | LTS, EOL May 2019           | 8.5    | >=9.1.0        | \*bug fixes  |
-| <=8.9.x       | Unsupported, EOL            | <=8.5  | ~8             |              |
+| BLT version | Support status        | End of life  |  Drupal versions* | Drush versions |
+|-------------|-----------------------|--------------|-------------------|----------------|
+| 10.x        | Unsupported (beta)    | May 2020     | 8.6, 8.7          | >=9.5.0        |
+| **9.2.x**   | **Supported, stable** | **Dec 2019** | **8.6, 8.7**      | **>=9.4.0**    |
+| 9.x         | Security fixes only   | May 2019     | 8.5               | >=9.1.0        |
+| <=8.9.x     | Unsupported           | Dec 2018     | <=8.5             | ~8             |
+
+*Note that when Drupal ends support for a minor core release, BLT will cease supporting that core release as well. For instance, as of December 2019, BLT 10.x will no longer support Drupal 8.6, and will instead support Drupal 8.7 and 8.8.
 
 ### Branch details
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ See [INSTALL.md](INSTALL.md) for a list of prequisites and links to instructions
 
 BLT generally has an LTS release, supported stable release, and unstable (HEAD) release at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive both bug fixes and new features, while the penultimate ("LTS") major version will receive bug fixes for at least two months (or longer if necessary in order to match pinned versions of Drupal or Drush).
 
-Releases generally occur every third Wednesday to coincide with Drupal core and Lightning releases (although BLT versions are not generally bound to specific versions of core or Lightning.)
+Releases generally occur on first and third Wednesdays to coincide with [Drupal core and Lightning releases](https://www.drupal.org/core/release-cycle-overview) (although BLT versions are not generally bound to specific versions of core or Lightning.)
 
 ### Release support status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ See [INSTALL.md](INSTALL.md) for a list of prequisites and links to instructions
 
 BLT generally has an LTS release, supported stable release, and unstable (HEAD) release at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive both bug fixes and new features, while the penultimate ("LTS") major version will receive bug fixes for at least two months (or longer if necessary in order to match pinned versions of Drupal or Drush).
 
+Releases generally occur every third Wednesday to coincide with Drupal core and Lightning releases (although BLT versions are not generally bound to specific versions of core or Lightning.)
+
 ### Release support status
 
 | Major Version | Support Status              | Drupal | Drush          | Dev Status   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ See [INSTALL.md](INSTALL.md) for a list of prequisites and links to instructions
 
 ## Releases and versioning
 
-BLT generally has an LTS release, supported stable release, and unstable (HEAD) release at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive bug fixes and new features, while the penultimate ("LTS") major version will receive security fixes for six months. Releases generally occur on first and third Wednesdays.
+BLT generally has two supported releases at any given time, each corresponding to a major [semantic version](https://semver.org/). The newest supported major version will receive bug fixes and new features, while the penultimate major version will receive security fixes for six months. Releases generally occur on first and third Wednesdays.
 
 This is intended to coincide with the [Drupal core release cycle](https://www.drupal.org/core/release-cycle-overview), so that users can continue to use a single BLT major release through the lifecycle of a Drupal core minor release.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ This is intended to coincide with the [Drupal core release cycle](https://www.dr
 | 9.x         | Security fixes only   | May 2019     | 8.5               | >=9.1.0        |
 | <=8.9.x     | Unsupported           | Dec 2018     | <=8.5             | ~8             |
 
-*Note that when Drupal ends support for a minor core release, BLT will cease supporting that core release as well. For instance, as of December 2019, BLT 10.x will no longer support Drupal 8.6, and will instead support Drupal 8.7 and 8.8.
+*Note that when Drupal ends support for a minor core release, BLT will cease supporting that core release as well, in accordance with [Drupal security policy](https://www.drupal.org/drupal-security-team/general-information). For instance, as of December 2019, BLT 10.x will no longer support Drupal 8.6, and will instead support Drupal 8.7 and 8.8.
 
 ### Branch details
 


### PR DESCRIPTION
@anavarre @mikemadison13 I've revamped a little more than just the release cadence here, please review.

Since we get a lot of questions about these things, I want to make it explicitly clear how long each release of BLT will be supported, what's the recommended/stable release, and how long folks will have to upgrade.

I chose this cycle to keep BLT and Drupal core upgrades decoupled. This ensures that when projects have to upgrade to the next version of BLT / Drupal core, they always have the option of upgrading _either_ BLT first or Drupal core first. They don't have to upgrade both at once, which can be more challenging.

For instance, imagine you are using BLT 9.2.x and Drupal 8.6.x, as most users are right now. When BLT 10.0 and Drupal 8.7.0 drop in April/May, you have the option of either upgrading to BLT 10.0 first and then to Drupal 8.7.0, or vice versa. And you have 6 months total to make both upgrades.