### PR TITLE
Fixes #3255: On Acquia Cloud, acquia_config.php should better handle multisite

### DIFF
--- a/scripts/simplesamlphp/acquia_config.php
+++ b/scripts/simplesamlphp/acquia_config.php
@@ -44,14 +44,6 @@ $protocol = 'https://';
 $port = ':' . $_SERVER['SERVER_PORT'];*/
 
 /**
- * Support multi-site and single site installations at different base URLs.
- *
- * Overide $config['baseurlpath'] = "https://{yourdomain}/simplesaml/"
- * to customize the default Acquia configuration.
- */
-$config['baseurlpath'] = $protocol . $_SERVER['HTTP_HOST'] . $port . '/simplesaml/';
-
-/**
  * Cookies No Cache.
  *
  * Allow users to be automatically logged in if they signed in via the same
@@ -84,7 +76,14 @@ if (!getenv('AH_SITE_ENVIRONMENT')) {
 
 }
 elseif (getenv('AH_SITE_ENVIRONMENT')) {
-  // Set  ACE ad ACSF sites based on hosting database and site name.
+  /**
+   * Support multi-site and single site installations at different base URLs.
+   *
+   * Overide $config['baseurlpath'] = "https://{yourdomain}/simplesaml/"
+   * to customize the default Acquia configuration.
+   */
+  $config['baseurlpath'] = $protocol . $_SERVER['HTTP_HOST'] . $port . '/simplesaml/';
+  // Set ACE and ACSF sites based on hosting database and site name.
   $config['certdir'] = "/mnt/www/html/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/simplesamlphp/cert/";
   $config['metadatadir'] = "/mnt/www/html/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/simplesamlphp/metadata";
   $config['baseurlpath'] = 'simplesaml/';


### PR DESCRIPTION
Fixes #3255 
--------

Changes proposed
---------
- Place the multisite-friendly code right where it belongs, under `elseif (getenv('AH_SITE_ENVIRONMENT'))`

Steps to replicate the issue
----------
1. It's not easy to replicate the issue. In multisite envs, there are instances where port 443 will be missing from the constructed URL and give a permission denied without any easy way to get to the bottom of the issue. When this happens you need to know about and leverage the [SAML Chrome Panel extension](https://chrome.google.com/webstore/detail/saml-chrome-panel/paijfdbeoenhembfhkhllainmocckace) to find out port 443 isn't being passed, thus causing the issue.

Previous behavior (before applying PR)
----------
Port 443 could be missing from the constructed URL.


Expected behavior (after applying PR)
-----------
Port 443 is always being passed in the constructed URL.

Additional details
-----------
Please review carefully before merging. There might be a need to simply duplicate the `baseurlpath` config override in and out of the `AH_SITE_ENVIRONMENT` if statement to account for non-Acquia hosted users.