### PR TITLE
Don't allow Travis failures for Drupal 8.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
     - DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
 
 matrix:
-  allow_failures:
-    - env: DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
   fast_finish: true
 
 cache:


### PR DESCRIPTION
Now that we have committed to supporting Drupal 8.7, we need to make sure tests pass.