### PR TITLE
Failed composer create-project should exit with non-zero code.

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -169,14 +169,15 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
       }
       $success = $this->executeCommand($command, [], TRUE);
       if (!$success) {
-        $this->io->write("<error>BLT installation failed! Please execute <comment>$command --verbose</comment> to debug the issue.</error>");
+        $this->io->writeError("<error>BLT installation failed! Please execute <comment>$command --verbose</comment> to debug the issue.</error>");
+        throw new \Exception('Installation aborted due to error');
       }
     }
     elseif ($options['blt']['update']) {
       $this->io->write('<info>Updating BLT templated files...</info>');
       $success = $this->executeCommand('blt blt:update --ansi -y', [], TRUE);
       if (!$success) {
-        $this->io->write("<error>BLT update script failed! Run `blt blt:update --verbose` to retry.</error>");
+        $this->io->writeError("<error>BLT update script failed! Run `blt blt:update --verbose` to retry.</error>");
       }
     }
     else {

--- a/tests/phpunit/src/SandboxManager.php
+++ b/tests/phpunit/src/SandboxManager.php
@@ -188,6 +188,9 @@ class SandboxManager {
     $process->run(function ($type, $buffer) {
       $this->output->write($buffer);
     });
+    if (!$process->isSuccessful()) {
+      throw new \Exception("Composer installation failed.");
+    }
   }
 
   /**


### PR DESCRIPTION
If project creation fails during testing (e.g. due to invalid composer version constraints) the tests won't fail, because it returns a normal exit code.