### PR TITLE
Fixes #3344: Support commits with apostrophes.

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -539,7 +539,7 @@ class DeployCommand extends BltTasks {
       ->dir($this->deployDir)
       ->exec("git rm -r --cached .")
       ->exec("git add -A")
-      ->exec("git commit --quiet -m '{$this->commitMessage}'")
+      ->exec(["git commit --quiet -m", escapeshellarg($this->commitMessage)])
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
 


### PR DESCRIPTION
Fixes #3344
--------

Changes proposed
---------
- Escape the commit message before passing it to `git commit` so that apostrophes don't cause it to bail.

Steps to replicate the issue
----------
1. Make a commit with an apostrophe on your source repo.
2. Run `blt deploy --dry-run` and accept the default commit message, which will also have the apostrophe.

Previous behavior (before applying PR)
----------
Error message and no commit

Expected behavior (after applying PR)
-----------
Commit works and has correct message