### PR TITLE
Fix multisite db permissions for new sites.

### DIFF
--- a/src/Robo/Commands/Generate/MultisiteCommand.php
+++ b/src/Robo/Commands/Generate/MultisiteCommand.php
@@ -102,7 +102,7 @@ class MultisiteCommand extends BltTasks {
           'name' => $newDBSettings['username'],
           'host' => '%',
           'password' => $newDBSettings['password'],
-          'priv' => $newDBSettings['database'] . '*:ALL',
+          'priv' => $newDBSettings['database'] . '%.*:ALL',
         ];
       }
       file_put_contents($this->projectDrupalVmConfigFile,


### PR DESCRIPTION
Changes proposed
---------
- When creating a new multisite when a VM is present, grant permissions using the format `foo%.*:ALL` instead of `foo*:ALL`. Note that `foo%.*:ALL` is the format already used in our template config.yml for the default drupal user, and `foo*:ALL` doesn't work on the VM.

Steps to replicate the issue
----------
1. Create a new BLT 10.x project.
2. Initialize a VM.
3. SSH into the VM and run `blt recipes:multisite:init`. Use 'foo' for the db username, password, and db name.
4. Re-provision the VM to pick up the new user and db.
5. SSH back into the VM and run `mysql -ufoo -pfoo foo`

Previous (bad) behavior, before applying PR
----------
Receive an access denied message.

Expected behavior, after applying PR and re-running test steps
-----------
Access the MySQL db successfully.
