### PR TITLE
Fixes #3445: Pass site context when regenerating Behat config.

### DIFF
--- a/src/Robo/Wizards/TestsWizard.php
+++ b/src/Robo/Wizards/TestsWizard.php
@@ -44,8 +44,7 @@ class TestsWizard extends Wizard {
         if (file_exists($behat_local_config_file)) {
           $this->fs->remove($behat_local_config_file);
         }
-        // @todo Pass all config!
-        $this->executor->execute("$bin/blt tests:behat:init:config --environment=" . $this->getConfigValue('environment'))->run();
+        $this->invokeCommand('tests:behat:init:config');
       }
     }
   }

--- a/src/Robo/Wizards/Wizard.php
+++ b/src/Robo/Wizards/Wizard.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Blt\Robo\Wizards;
 
+use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\Executor;
 use Acquia\Blt\Robo\Common\IO;
 use Acquia\Blt\Robo\Config\ConfigAwareTrait;
@@ -25,7 +26,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *   2. Prompt the the user to resolve invalid configuration or state.
  *   3. Perform tasks to resolve the issue.
  */
-abstract class Wizard implements ConfigAwareInterface, InspectorAwareInterface, IOAwareInterface, LoggerAwareInterface {
+abstract class Wizard extends BltTasks implements ConfigAwareInterface, InspectorAwareInterface, IOAwareInterface, LoggerAwareInterface {
 
   use ConfigAwareTrait;
   use InspectorAwareTrait;


### PR DESCRIPTION
Fixes #3445 
--------

Changes proposed
---------
- Pass site context (along with all other BLT process context) when regenerating Behat config

Steps to replicate the issue
----------
1. Set up a new BLT project, and add a multisite ('foo') according to the multisite documentation.
2. Run `blt test:behat:run --site=foo`
3. Respond yes when prompted to regenerate Behat's local.yml.

Previous (bad) behavior, before applying PR
----------
When local.yml is regenerated, it still has the default (not 'foo') base URL.

Expected behavior, after applying PR and re-running test steps
-----------
When local.yml is regenerated, it has the correct base URL (local.foo.com).

Additional details
-----------
@grasmash I see you already had a todo to fix this. Is there a reason that Wizards don't inherit from BltTasks, and shell out to call BLT commands rather than using `invokeCommand()`? It seems like there must have been a reason for that.