### PR TITLE
Fixes #2985: Remove -y flag.

### DIFF
--- a/src/Robo/Blt.php
+++ b/src/Robo/Blt.php
@@ -155,9 +155,6 @@ class Blt implements ContainerAwareInterface, LoggerAwareInterface {
   private function addDefaultArgumentsAndOptions(Application $app) {
     $app->getDefinition()
       ->addOption(
-        new InputOption('--yes', '-y', InputOption::VALUE_NONE, 'Answer all confirmations with "yes"'));
-    $app->getDefinition()
-      ->addOption(
         new InputOption('--define', '-D', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Define a configuration item value.', [])
       );
     $app->getDefinition()

--- a/src/Robo/Commands/Setup/WizardCommand.php
+++ b/src/Robo/Commands/Setup/WizardCommand.php
@@ -36,7 +36,7 @@ class WizardCommand extends BltTasks {
 
     $this->say("<comment>You have entered the following values:</comment>");
     $this->printArrayAsTable($answers);
-    $continue = $this->confirm("Continue?");
+    $continue = $this->confirm("Continue?", TRUE);
     if (!$continue) {
       return 1;
     }

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -20,7 +20,7 @@ class SyncCommand extends BltTasks {
   public function allSites() {
     $multisites = $this->getConfigValue('multisites');
     $this->printSyncMap($multisites);
-    $continue = $this->confirm("Continue?");
+    $continue = $this->confirm("Continue?", TRUE);
     if (!$continue) {
       return 0;
     }

--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -81,10 +81,6 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
     $drush_alias = $this->getConfigValue('drush.alias');
     $command_string = "'$bin/drush' @$drush_alias $command";
 
-    if ($this->input()->hasOption('yes') && $this->input()->getOption('yes')) {
-      $command_string .= ' -y';
-    }
-
     // URIs do not work on remote drush aliases in Drush 9. Instead, it is
     // expected that the alias define the uri in its configuration.
     if ($drush_alias != 'self') {

--- a/src/Robo/Common/IO.php
+++ b/src/Robo/Common/IO.php
@@ -56,9 +56,6 @@ trait IO {
   /**
    * Prompts a user to confirm an action.
    *
-   * This integrates the global --yes option and permits a default to be
-   * defined.
-   *
    * @param string $question
    *   The question text.
    * @param bool $default
@@ -68,10 +65,6 @@ trait IO {
    *   The response.
    */
   protected function confirm($question, $default = FALSE) {
-    if ($this->input()->hasOption('yes') && $this->input()->getOption('yes') !== FALSE) {
-      return TRUE;
-    }
-
     return $this->doAsk(new ConfirmationQuestion($this->formatQuestion($question . ' (y/n)'), $default));
   }
 

--- a/tests/phpunit/Blt/MultiSiteTest.php
+++ b/tests/phpunit/Blt/MultiSiteTest.php
@@ -89,7 +89,7 @@ class MultiSiteTest extends BltProjectTestBase {
         'project.profile.name=minimal',
       ],
       '--site' => 'site2',
-      '--yes' => '',
+      '--no-interaction' => '',
     ]);
 
     // Assert setup.
@@ -126,7 +126,7 @@ class MultiSiteTest extends BltProjectTestBase {
     $this->assertEquals('Site 2 Clone', $output_array['name']);
 
     list($status_code, $output, $config) = $this->blt("drupal:sync:all-sites", [
-      '--yes' => '',
+      '--no-interaction' => '',
     ]);
     $this->assertContains("You will destroy data in drupal and replace with data from drupal3", $output);
     $this->assertContains("You will destroy data in drupal2 and replace with data from drupal4", $output);

--- a/tests/phpunit/Blt/WizardTest.php
+++ b/tests/phpunit/Blt/WizardTest.php
@@ -17,7 +17,7 @@ class WizardTest extends BltProjectTestBase {
     $recipe_filepath = $this->bltDirectory . '/tests/phpunit/fixtures/recipe.yml';
     $this->blt("wizard", [
       '--recipe' => $recipe_filepath,
-      '--yes' => '',
+      '--no-interaction' => '',
     ]);
 
     $recipe = Yaml::parseFile($recipe_filepath);

--- a/tests/phpunit/src/BltProjectTestBase.php
+++ b/tests/phpunit/src/BltProjectTestBase.php
@@ -353,7 +353,7 @@ abstract class BltProjectTestBase extends TestCase {
       '--site-dir' => $site2_dir,
       '--site-uri' => "http://" . $site2_local_uri,
       '--remote-alias' => $site2_remote_drush_alias,
-      '--yes' => '',
+      '--no-interaction' => '',
     ]);
 
     $this->fs->remove($test_project_clone_dir);


### PR DESCRIPTION
Fixes #2985
--------

Changes proposed
---------
- Remove `-y` / `--yes` CLI flag

Additional details
-----------
In older versions of BLT, we had the option to run commands non-interactively with `-y` and `-n`, which meant "assume yes" or "assume no" for all prompts.

This just happened to work intuitively most of the time because we tended to structure prompts with "yes" being the default option, so semantically `-y` was more like a "greedy" version of the command, and `-n` was more conservative. But again, that's just happy coincidence, and not a great user interaction paradigm.

Symfony console doesn't make such a distinction, and only has a single `-n` / `--no-interaction` option, which chooses the default response for all prompts (which may be yes or no or non-boolean, depending on the prompt). Now things _are_ confusing because `-n` is no longer `--no`, but `--no-interaction`, which is essentially `--yes` but routed through Symfony instead of BLT.

This PR brings us in line with Symfony console and puts an end to the madness.