### PR TITLE
Get BLT Project tests working.

### DIFF
--- a/subtree-splits/blt-project/.test-packages.json
+++ b/subtree-splits/blt-project/.test-packages.json
@@ -1,0 +1,11 @@
+{
+    "package": {
+        "name": "acquia/blt-project",
+        "version": "1.0.0",
+        "source": {
+          "url": "/${TRAVIS_BUILD_DIR}/.git",
+          "type": "git",
+          "reference": "${TRAVIS_COMMIT}"
+        }
+    }
+}

--- a/subtree-splits/blt-project/.travis.yml
+++ b/subtree-splits/blt-project/.travis.yml
@@ -27,7 +27,7 @@ install:
 
   # Speed up Composer operations.
   - composer global require "hirak/prestissimo:^0.3"
-  
+
   # MySQL Options
   - mysql -e 'SET GLOBAL wait_timeout = 5400;'
   - mysql -e "SHOW VARIABLES LIKE 'wait_timeout'"
@@ -44,4 +44,4 @@ install:
 script:
   # Build the code base.
   - cd ../
-  - composer create-project --repository-url=$TRAVIS_BUILD_DIR/packages.json acquia/blt-project blt-example --no-interaction
+  - COMPOSER_MEMORY_LIMIT=-1 composer create-project --repository-url=$TRAVIS_BUILD_DIR/packages.json acquia/blt-project blt-example --no-interaction


### PR DESCRIPTION
Port of https://github.com/acquia/blt-project/pull/33 into the subtree split so it doesn't get lost

I'm not sure what the workflow should be for changes to blt-project going forward, I almost forgot to port this change. It's a little unintuitive.