### PR TITLE
Allow provisioning of DrupalVM while debugging BLT.

### DIFF
--- a/scripts/drupal-vm/post-provision.php
+++ b/scripts/drupal-vm/post-provision.php
@@ -5,6 +5,7 @@ $alias_locations = [
   "/vagrant/vendor/acquia/blt/scripts/blt/alias",
   // This is the location during "release:test" execution.
   "/var/www/blt/scripts/blt/alias",
+  "../../../acquia/blt/scripts/blt/alias"
 ];
 
 foreach ($alias_locations as $alias_location) {


### PR DESCRIPTION
Sometimes it's desirable to debug BLT by linking it as a Composer path repo, so there's a symlink from `vendor/acquia/blt` to wherever your BLT Git working directory is locally.

The problem is that if you want to boot a VM while debugging BLT, things get tricky, because NFS isn't going to follow that symlink outside of the repo root. You can hack that by using a relative symlink and adding something like the following to your box config:
```yaml
-
        local_path: /home/dane/packages/blt
        destination: /var/packages/blt
        type: nfs
```

... obviously ugly, but it works. Except when you first provision the VM, the post-provision script needs to look for BLT in a static location so it uses `/vagrant/vendor/acquia/blt`, and the symlink is broken from there. So a debugger could either hack yet another NFS mount, or we can just add a relative search path to the post-provision script.