### PR TITLE
Make Behat play nicely with multisite setups

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -1,5 +1,6 @@
 # @todo Move to subkey of tests.
 behat:
+  validate: true
   config: ${repo.root}/tests/behat/local.yml
   profile: local
   # The URL of selenium server. Must correspond with setting in behat's yaml config.


### PR DESCRIPTION
Fixes #2860 
--------

Changes proposed
---------
Add a `behat.validate` configuration item to disable Behat validation and wizards and simply just run the `behat` command. Trust that, if we so choose, we know how to setup our own Behat configuration as needed.

Expected behavior, after applying PR and re-running test steps
-----------
When setting `behat.validate` to `false`, you are able to run Behat tests even if the base_url value in local.yml is not the same value as base_url included in whichever configuration file/profile you have chosen to run.

Additional details
-----------
This is just a starting point for having something tangible to help guide discussion around issue #2860. Currently built against the 9.2.x branch since this is an early prototype for this feature that some developers (me) might be leveraging in their current (non-10.x) projects.