### PR TITLE
Turn off ssh strict host checking when drush is connecting to drupal vm

### DIFF
--- a/scripts/drupal-vm/drupal-vm.site.yml
+++ b/scripts/drupal-vm/drupal-vm.site.yml
@@ -4,4 +4,4 @@ local:
   host: ${project.local.hostname}
   user: vagrant
   ssh:
-    options: -o PasswordAuthentication=no -i $HOME/.vagrant.d/insecure_private_key
+    options: -o StrictHostKeyChecking=no -o PasswordAuthentication=no -i $HOME/.vagrant.d/insecure_private_key


### PR DESCRIPTION
Fixes # 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

When drush connects to the vm, turn strict host checking to off. This avoids prompting the user like this:

The authenticity of host 'local.aszaszbltproject.com (192.168.114.250)' can't be established.
ECDSA key fingerprint is SHA256:ujyiJ45p0pxPhacRWHlXGDA797msE7X4G6lWBDWQhGI.
Are you sure you want to continue connecting (yes/no)

Steps to replicate the issue
----------
1. temporarily remove your ssh known hosts file
2. run drush browse 
3. you should get prompted like above

While using this branch, you should not get prompted