### PR TITLE
Fix running Composer updates.

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -236,7 +236,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
     }
     elseif ($options['blt']['update']) {
       $this->io->write('<info>Updating BLT templated files...</info>');
-      $success = $this->executeCommand('blt blt:update --ansi -y', [], TRUE);
+      $success = $this->executeCommand('blt blt:update --ansi --no-interaction', [], TRUE);
       if (!$success) {
         $this->io->writeError("<error>BLT update script failed! Run `blt blt:update --verbose` to retry.</error>");
       }

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -286,7 +286,7 @@ class UpdateCommand extends BltTasks {
       $this->say("<comment>The following BLT updates are outstanding:</comment>");
       $updater->printUpdates($updates);
       // @todo Do not prompt if this is being run from Plugin.php.
-      $confirm = $this->confirm('Would you like to perform the listed updates?');
+      $confirm = $this->confirm('Would you like to perform the listed updates?', TRUE);
       if ($confirm) {
         try {
           $updater->executeUpdates($updates);


### PR DESCRIPTION
We removed the `-y` flag in 10.x. The problem is Composer loads the _old_ version of Plugin.php when running updates, meaning that if users of 9.2.x upgrade to 10.x, the automatic updates will fail because they'll try to run `blt update -y`.

To fix this, we need a final release on 9.2.x that does _not_ include `-y`. Users will need to upgrade to this first before upgrading to 10.x.