### PR TITLE
Improve Drush runserver error message.

### DIFF
--- a/src/Robo/Commands/Tests/ServerCommand.php
+++ b/src/Robo/Commands/Tests/ServerCommand.php
@@ -45,7 +45,7 @@ class ServerCommand extends TestsCommandBase {
     catch (\Exception $e) {
       if (!$result->wasSuccessful() && file_exists($log_file)) {
         $output = file_get_contents($log_file);
-        throw new BltException($e->getMessage() . "\n" . $output);
+        throw new BltException($e->getMessage() . "\nDrush logged the following errors while attempting to start the web server:\n" . $output);
       }
     }
   }


### PR DESCRIPTION
In debugging https://github.com/acquia/blt/issues/3513, I was confused because the error looked like this:

```
[info] Waiting for response from http://127.0.0.1:8888...
[info] Waiting for response from http://127.0.0.1:8888...
[info] Waiting for response from http://127.0.0.1:8888...
[error]  Timed out.
 [notice] HTTP server listening on 127.0.0.1, port 8888 (see http://127.0.0.1:8888/), serving site, sites/default
In Process.php line 1042:                                               
  TTY mode requires /dev/tty to be read/writable.  
```

Because of the order of the error messages, it implies that the server started successfully but that maybe curl was having a problem connecting for some reason, when in fact the problem was that the server never started at all. Let's make that a little more clear.