### PR TITLE
Fixed profile splits.

### DIFF
--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -1,5 +1,7 @@
 <?php
 
+use Acquia\Blt\Robo\Config\ConfigInitializer;
+
 /**
  * @file
  * Controls configuration management settings.
@@ -101,7 +103,7 @@ if (isset($_acsf_site_name)) {
 }
 
 // Set profile split.
-if (array_key_exists('install_profile', $settings)) {
-  $active_profile = $settings['install_profile'];
-  $config["$split_filename_prefix.$active_profile"]['status'] = TRUE;
-}
+$profile_config_initializer = new ConfigInitializer($repo_root, $input);
+$profile_blt_config = $profile_config_initializer->initialize();
+$active_profile = $profile_blt_config->get('project.profile');
+$config["$split_filename_prefix.$active_profile"]['status'] = TRUE;

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -1,12 +1,12 @@
 <?php
 
-use Acquia\Blt\Robo\Config\ConfigInitializer;
-use Symfony\Component\Console\Input\ArgvInput;
-
 /**
  * @file
  * Controls configuration management settings.
  */
+
+use Acquia\Blt\Robo\Config\ConfigInitializer;
+use Symfony\Component\Console\Input\ArgvInput;
 
 /**
  * BLT makes the assumption that, if using multisite, the default configuration

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -1,6 +1,7 @@
 <?php
 
 use Acquia\Blt\Robo\Config\ConfigInitializer;
+use Symfony\Component\Console\Input\ArgvInput;
 
 /**
  * @file
@@ -103,7 +104,8 @@ if (isset($_acsf_site_name)) {
 }
 
 // Set profile split.
+$input = new ArgvInput(!empty($_SERVER['argv']) ? $_SERVER['argv'] : ['']);
 $profile_config_initializer = new ConfigInitializer($repo_root, $input);
 $profile_blt_config = $profile_config_initializer->initialize();
-$active_profile = $profile_blt_config->get('project.profile');
+$active_profile = $profile_blt_config->get('project.profile.name');
 $config["$split_filename_prefix.$active_profile"]['status'] = TRUE;


### PR DESCRIPTION
Drupal dropped `$settings['install_profile']`, which has [caused consternation for folks](https://www.drupal.org/project/drupal/issues/2975328#comment-12711910) who need this information to dynamically set things in settings.php, such as the active config split.

This should get around it. It requires that multisite users set their profile in the multisites array or a site-specific blt.yml.

If the profile configured in blt.yml doesn't match the actually-installed profile in your active config, tough cookies, this will still set the profile split based on blt.yml. I don't think there's any way for us to determine the actual profile for an installed site. This seems like a reasonable compromise to me, but let me know if I'm missing something.