### PR TITLE
Fix coding standards in settings warning comment

### DIFF
--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -24,12 +24,14 @@ class SettingsCommand extends BltTasks {
    * docs on how to include settings.
    */
   private $settingsWarning = <<<WARNING
-#
-# IMPORTANT
-# Do not include additional settings here. Instead, add them to settings included
-# by `blt.settings.php`. See [BLT's documentation](http://blt.readthedocs.io)
-# for more detail.
-#
+/**
+ * IMPORTANT.
+ *
+ * Do not include additional settings here. Instead, add them to settings
+ * included by `blt.settings.php`. See BLT's documentation for more detail.
+ *
+ * @link http://blt.readthedocs.io
+ */
 WARNING;
 
   /**


### PR DESCRIPTION
Resolve #3523
--------

Changes proposed
---------

- Address coding standards violations in a comment injected by BLT to settings.php 
- This update does not remove the old comment if it already existed in a project settings.php
- As this is only a comment, the impact to end-users is low

Steps to replicate the issue
----------

See linked issues:

#3523 
#3496 

Previous (bad) behavior, before applying PR
----------

Starting with a settings.php file that has passes php coding standards checks, I run:
```
composer install
blt -y blt:init:settings
```

BLT injects code into my settings.php that cannot pass phpcs checks.


Expected behavior, after applying PR and re-running test steps
-----------

phpcs checks can be run on settings.php without requiring an exception.
I run `blt blt:init:settings` and do the checks again, and they still pass without an exception.

Additional details
-----------
