### PR TITLE
Drush runserver and test host fixes

### DIFF
--- a/scripts/pipelines/setup_env
+++ b/scripts/pipelines/setup_env
@@ -15,4 +15,8 @@ mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS drupal"
 nvm install v8.1.4
 npm install -g npm
 
+# The local.hostname is set to 0.0.0.0:8888 to run drush runserver on all
+# available network interfaces.
+yaml-cli update:value blt/blt.yml project.local.hostname '0.0.0.0:8888'
+
 set +v

--- a/src/Robo/Commands/Tests/TestsCommandBase.php
+++ b/src/Robo/Commands/Tests/TestsCommandBase.php
@@ -100,7 +100,7 @@ class TestsCommandBase extends BltTasks {
     $this->killChrome();
     $chrome_bin = $this->findChrome();
     $this->checkChromeVersion($chrome_bin);
-    $chrome_host = 'http://localhost';
+    $chrome_host = 'http://0.0.0.0';
     $this->logger->info("Launching headless chrome...");
     $this->getContainer()
       ->get('executor')

--- a/template/blt/ci.blt.yml
+++ b/template/blt/ci.blt.yml
@@ -7,6 +7,11 @@
 # setup.dump-file: /tmp/my-dump-file.sql
 tests.run-server: true
 tests.drupal.sudo-run-tests: false
-# The local.hostname must be set to 127.0.0.1:8888 because we are using drush runserver to test the site.
-project.local.hostname: 127.0.0.1:8888
-drush.debug: false
+
+# The tests.server.url is set to 0.0.0.0:8888 so that the test server can bind
+# to networks other than localhost.
+tests.server.url: http://0.0.0.0:8888
+
+# The local.hostname is set to 0.0.0.0:8888 to run drush runserver on all
+# available network interfaces.
+project.local.hostname: 0.0.0.0:8888

--- a/template/tests/behat/example.local.yml
+++ b/template/tests/behat/example.local.yml
@@ -46,7 +46,7 @@ local:
       sessions:
         default:
           chrome:
-            api_url: "http://localhost:9222"
+            api_url: "http://0.0.0.0:9222"
     Drupal\DrupalExtension:
       drupal:
         # This must be an absolute path.


### PR DESCRIPTION
Fixes #3513 
--------

Changes proposed
---------
The current BLT default configuration for drush run server, the test server, and local behat Chromedriver hosts use a combination of 127.0.0.1 and localhost, and binds the local project host to 127.0.0.1 and port 8888.

As discussed [in a related DrupalVM issue](https://github.com/geerlingguy/drupal-vm/issues/969), this configuration only allows for running behat and other commands via drush runserver on the localhost network interface, and in the case of using pipelines or a VM, port 8888 and other ports may not be available outside localhost and the remote ip and/or 127.0.0.1 must be used to successfully resolve curl and other requests. Changing BLT's default behat, testserver, runserver, and other hard coded host config for Chromedriver to 0.0.0.0 will make the runserver and testserver available to all available network interfaces and drush wont attempt to redispatch to a remote host and enable interactive mode for the current terminal process / `/dev/tty`

This should also unblock running BLT behat tests in separate containers for docker-based development environments, and leave networking configuration up to docker and the host rather than BLT. See relevant [ddev](https://github.com/drud/ddev/issues/1329) and [docksal](https://github.com/docksal/docksal/issues/791) issues.


Steps to replicate the issue
----------
1. Run `blt setup --environment=ci`
2. Run `blt tests:all  --environment=ci --define tests.run-server=true -D behat.web-driver=chrome --yes --ansi --verbose`
3. Alternatively, run a pipelines build with drush 9.6 and observe: 

```
[info] Waiting for response from http://127.0.0.1:8888...
[error]  Timed out.
```

Expected behavior, after applying PR and re-running test steps
-----------
Pipelines builds and drush runserver commands/tasks in BLT complete successfully
