### PR TITLE
Issue 3529: Adding --ignore-unmatch parameter so deploy stops failing.

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -537,7 +537,7 @@ class DeployCommand extends BltTasks {
     $this->say("Committing artifact to <comment>{$this->branchName}</comment>...");
     $result = $this->taskExecStack()
       ->dir($this->deployDir)
-      ->exec("git rm -r --cached .")
+      ->exec("git rm -r --cached --ignore-unmatch .")
       ->exec("git add -A")
       ->exec(["git commit --quiet -m", escapeshellarg($this->commitMessage)])
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)


### PR DESCRIPTION
Fixes #3529 