### PR TITLE
Don't glob global settings by default.

### DIFF
--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -58,4 +58,41 @@ Other commonly used commands:
 
 ## Drush aliases
 
-See [BLT Drush Documentation](drush.md) for more information on Drush aliases. 
+See [BLT Drush Documentation](drush.md) for more information on Drush aliases.
+
+## Adding settings to settings.php
+
+A common practice in Drupal is to add settings to the `settings.php` file to control things like cache backends, set site variables, or other tasks which do need a specific module. BLT provides two mechanisms to add settings to settings.php. Settings files may be added to the `docroot/sites` directory for inclusion in all sites in the codebase or settings can be added via an `includes.settings.php` in the `settings` directory of an individual  site (i.e., `docroot/sites/{site-name}/settings/includes.settings.php`). Both mechanisms allow settings to be overriden by a `local.settings.php`, to support local development.
+
+> **Important**: When using BLT, settings should not be simply added directly to `settings.php`. This is especially true with Acquia Cloud Site Factory, which will ignore settings added directly to `settings.php`.
+
+The first level of BLT's settings management is the `blt.settings.php` file. When sites are created, BLT adds a require line to the standard `settings.php` file which includes the `blt.settings.php` file from BLT's location in the `vendor` directory. This file then controls the inclusion of other settings files in a hierarchy. The full hierarchy of settings files used by BLT looks like this:
+
+```
+  sites/{site-name}/settings.php
+    |
+    ---- blt.settings.php
+           |
+           ---- sites/settings/*.settings.php
+           |
+           ---- sites/{site-name}/settings/includes.settings.php
+           |       |
+           |       ---- foo.settings.php
+           |       ---- bar.settings.php
+           |       ---- ....
+           |
+           ---- sites/{site-name}/settings/local.settings.php
+ ```
+
+ > **Important**: Do not edit the `blt.settings.php` file in the `vendor` directory. If you do, the next time composer update or install is run your changes may be lost. Instead, use one of the mechanisms described below.
+
+#### Global settings for the codebase
+To allow settings to be made once and applied to all sites in a codebase, BLT [globs](http://php.net/manual/en/function.glob.php) the `docroot/sites/settings` directory to find all files matching a `*.settings.php` format and adds them via [PHP require](http://php.net/manual/en/function.require.php) statements.
+
+As not all projects will need additional global settings, BLT initially deploys a `default.global.settings.php` file into the `docroot/sites/settings` directory. To make use of this file, rename it to `global.settings.php` and settings or required files as needed.
+
+
+#### Per site
+On a per-site basis, BLT uses an `includes.settings.php` file in the `settings` directory of each individual site. Any settings made in that file, or other files required into it, will be added to the settings for that particular site only.
+
+As not all projects will need additional includes, BLT initially deploys a `default.includes.settings.php` file into the site's `docroot/sites/{site_name}/settings` directory. To make use of this file, rename it to `includes.settings.php` and add the path to the file(s) which should be added.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -49,43 +49,6 @@ As development progresses, you can use the following commands to keep your local
 
 Each of these commands is simply a wrapper for a number of more granular commands that can be run individually if desired (for instance, `blt drupal:update` just runs database updates and imports configuration changes). For a full list of available project tasks, run `blt`. See [Project Tasks](project-tasks.md) for more information.
 
-### Adding settings to settings.php
-
-A common practice in Drupal is to add settings to the `settings.php` file to control things like cache backends, set site variables, or other tasks which do need a specific module. BLT provides two mechanisms to add settings to settings.php. Settings files may be added to the `docroot/sites` directory for inclusion in all sites in the codebase or settings can be added via an `includes.settings.php` in the `settings` directory of an individual  site (i.e., `docroot/sites/{site-name}/settings/includes.settings.php`). Both mechanisms allow settings to be overriden by a `local.settings.php`, to support local development. 
-
-> **Important**: When using BLT, settings should not be simply added directly to `settings.php`. This is especially true with Acquia Cloud Site Factory, which will ignore settings added directly to `settings.php`.
-
-The first level of BLT's settings management is the `blt.settings.php` file. When sites are created, BLT adds a require line to the standard `settings.php` file which includes the `blt.settings.php` file from BLT's location in the `vendor` directory. This file then controls the inclusion of other settings files in a hierarchy. The full hierarchy of settings files used by BLT looks like this:
-
-```
-  sites/{site-name}/settings.php
-    |
-    ---- blt.settings.php
-           |
-           ---- sites/settings/*.settings.php
-           |
-           ---- sites/{site-name}/settings/includes.settings.php
-           |       |
-           |       ---- foo.settings.php
-           |       ---- bar.settings.php
-           |       ---- ....
-           |
-           ---- sites/{site-name}/settings/local.settings.php
- ```
- 
- > **Important**: Do not edit the `blt.settings.php` file in the `vendor` directory. If you do, the next time composer update or install is run your changes may be lost. Instead, use one of the mechanisms described below. 
- 
-#### Global settings for the codebase
-To allow settings to be made once and applied to all sites in a codebase, BLT [globs](http://php.net/manual/en/function.glob.php) the `docroot/sites/settings` directory to find all files matching a `*.settings.php` format and adds them via [PHP require](http://php.net/manual/en/function.require.php) statements.
-
-As not all projects will need additional global settings, BLT initially deploys a `global.settings.default.php` file into the `docroot/sites/settings` directory. To make use of this file, rename it to `global.settings.php` and settings or required files as needed.
-
- 
-#### Per site
-On a per-site basis, BLT uses an `includes.settings.php` file in the `settings` directory of each individual site. Any settings made in that file, or other files required into it, will be added to the settings for that particular site only.
-
-As not all projects will need additional includes, BLT initially deploys a `default.includes.settings.php` file into the site's `docroot/sites/{site_name}/settings` directory. To make use of this file, rename it to `includes.settings.php` and add the path to the file(s) which should be added.
-
 ### Local Git Configuration
 
 For readability of commit history, set your name and email address properly:

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -257,18 +257,16 @@ if (file_exists($deploy_id_file)) {
 }
 
 /**
- * Include custom global settings files.
+ * Include custom global settings file.
  *
- * This is intended for to provide an opportunity for applications to override
- * any previous configuration at a global or multisite level.
+ * This provides an opportunity for applications to override any previous
+ * configuration at a global or multisite level.
  *
  * This is being included before the CI and site specific files so all available
  * settings are able to be overridden in the includes.settings.php file below.
  */
-if ($settings_files = glob(DRUPAL_ROOT . "/sites/settings/*.settings.php")) {
-  foreach ($settings_files as $settings_file) {
-    require $settings_file;
-  }
+if (file_exists(DRUPAL_ROOT . "/sites/settings/global.settings.php")) {
+  require DRUPAL_ROOT . "/sites/settings/global.settings.php";
 }
 
 /*******************************************************************************

--- a/settings/default.global.settings.php
+++ b/settings/default.global.settings.php
@@ -8,6 +8,10 @@
 /**
  * An example global include file.
  *
+ * To use this file, rename to global.settings.php.
+ */
+
+/**
  * Any file placed directly in the docroot/sites/settings directory whose name
  * matches a glob pattern of *.settings.php will be incorporated to the settings
  * of every defined site.
@@ -15,3 +19,8 @@
  * If instead you want to add settings to a specific site, see BLT's includes
  * file in docroot/sites/{site-name}/settings/default.includes.settings.php.
  */
+if ($settings_files = glob(DRUPAL_ROOT . "/sites/settings/*.settings.php")) {
+  foreach ($settings_files as $settings_file) {
+    require $settings_file;
+  }
+}

--- a/settings/default.includes.settings.php
+++ b/settings/default.includes.settings.php
@@ -29,7 +29,7 @@
  *          ---- local.settings.php
  *
  * If you want to add settings to every site defined in the codebase, you can do
- * so using the global.settings.default.php file in docroot/sites/settings.
+ * so using the default.global.settings.php file in docroot/sites/settings.
  */
 
 /**

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -98,9 +98,9 @@ WARNING;
       $blt_includes_settings_file = $this->getConfigValue('blt.root') . '/settings/default.includes.settings.php';
       $default_includes_settings_file = "$multisite_dir/settings/default.includes.settings.php";
 
-      // Generate sites/settings/global.settings.default.php.
-      $blt_glob_settings_file = $this->getConfigValue('blt.root') . '/settings/global.settings.default.php';
-      $default_glob_settings_file = $this->getConfigValue('docroot') . "/sites/settings/global.settings.default.php";
+      // Generate sites/settings/default.global.settings.php.
+      $blt_glob_settings_file = $this->getConfigValue('blt.root') . '/settings/default.global.settings.php';
+      $default_glob_settings_file = $this->getConfigValue('docroot') . "/sites/settings/default.global.settings.php";
 
       // Generate local.drush.yml.
       $blt_local_drush_file = $this->getConfigValue('blt.root') . '/settings/default.local.drush.yml';


### PR DESCRIPTION
Fixes #3528
--------

Changes proposed
---------
- Rename global.settings.default.php to default.global.settings.php
- Instead of globbing all settings in `docroot/sites/settings/*.settings.php`, only include `docroot/sites/settings/global.settings.php` if it exists.
- Add a snippet to default.global.settings.php to glob any other files in `docroot/sites/settings/*.settings.php` in order to mimic the old behavior.

This is a breaking change for users that have files in docroot/sites/settings named anything other than global.settings.php, so it will require a change record. But I don't think it needs an update hook.