### PR TITLE
Upgrade DrupalVM to 5, default PHP to 7.2, clean up DrupalVM config.

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -1,3 +1,7 @@
+# The options in this file override the defaults provided by DrupalVM. For a
+# comprehensive list of possible options, see DrupalVM's default.config.yml.
+# @see https://github.com/geerlingguy/drupal-vm/blob/master/default.config.yml
+
 # Update the hostname to the local development environment hostname.
 vagrant_hostname: ${vm.vagrant.hostname}
 vagrant_machine_name: ${project.machine_name}
@@ -21,9 +25,6 @@ vagrant_synced_folders:
     type: nfs
 
 drupal_build_composer_project: false
-# Toggling this to `true` would invoke `composer install` with the
-# projects own `composer.json` successfully.
-drupal_build_composer: false
 drupal_composer_path: false
 drupal_composer_install_dir: "/var/www/${project.machine_name}"
 drupal_core_path: "/var/www/${project.machine_name}/docroot"
@@ -70,35 +71,21 @@ drupal_install_site: false
 # this variable is 'true'.
 configure_drush_aliases: false
 
-# This is required for front-end building tools.
-nodejs_version: "8.x"
-nodejs_npm_global_packages:
-  - name: bower
-  - name: gulp-cli
-  - name: yarn
-nodejs_install_npm_user: "{{ drupalvm_user }}"
-npm_config_prefix: "/home/{{ drupalvm_user }}/.npm-global"
 extra_packages: ${extra_packages}
 installed_extras: ${installed_extras}
 
-# PHP 7.1.
-php_version: "7.1"
+# PHP 7.2.
+php_version: "7.2"
 php_packages_extra:
   - "php{{ php_version }}-bz2"
   - "php{{ php_version }}-imagick"
   - imagemagick
 
 # XDebug configuration.
-php_xdebug_version: 2.6.1
+php_xdebug_version: 2.7.1
 # Change this value to 1 in order to enable xdebug by default.
 php_xdebug_default_enable: 0
-php_xdebug_coverage_enable: 0
 php_xdebug_cli_disable: yes
-php_xdebug_remote_enable: 1
-php_xdebug_remote_connect_back: 1
-# Use PHPSTORM for PHPStorm, sublime.xdebug for Sublime Text.
-php_xdebug_idekey: PHPSTORM
-php_xdebug_max_nesting_level: 256
 php_xdebug_remote_port: "9000"
 php_memory_limit: "512M"
 

--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -2,7 +2,7 @@ version: 1.1.0
 services:
   - mysql
   - php:
-      version: 7.1
+      version: 7.2
 
 variables:
   global:

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -6,7 +6,7 @@ dist: xenial
 # Making this version number greater than the production environment can have unintended consequences
 # including a non-functional prod environment.
 php:
-  - 7.1
+  - 7.2
 
 matrix:
   fast_finish: true
@@ -71,16 +71,16 @@ deploy:
      skip_cleanup: true
      on:
        branch: develop
-       php: 7.1
+       php: 7.2
    - provider: script
      script: "${BLT_DIR}/scripts/travis/deploy_branch"
      skip_cleanup: true
      on:
        branch: master
-       php: 7.1
+       php: 7.2
    - provider: script
      script: "${BLT_DIR}/scripts/travis/deploy_tag"
      skip_cleanup: true
      on:
        tags: true
-       php: 7.1
+       php: 7.2

--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -22,6 +22,9 @@ class AcsfCommand extends BltTasks {
     $this->logger->notice("  * Adding default factory-hooks to your application.");
     $this->logger->notice("  * Adding `acsf` to `modules.local.uninstall` in your blt.yml");
     $this->logger->notice("");
+    $this->logger->notice("Note that the default version of PHP on ACSF is generally not the same as Acquia Cloud.");
+    $this->logger->notice("You may wish to adjust the PHP version of your local environment and CI tools to match.");
+    $this->logger->notice("");
     $this->logger->notice("For more information, see:");
     $this->logger->notice("<comment>http://blt.readthedocs.io/en/9.x/readme/acsf-setup</comment>");
   }

--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -34,7 +34,7 @@ class VmCommand extends BltTasks {
    */
   public function initialize() {
     $this->drupalVmAlias = $this->getConfigValue('project.machine_name') . '.local';
-    $this->drupalVmVersionConstraint = '^4.8';
+    $this->drupalVmVersionConstraint = '^5.0';
     $this->defaultDrupalVmDrushAliasesFile = $this->getConfigValue('blt.root') . '/scripts/drupal-vm/drupal-vm.site.yml';
     $this->defaultDrupalVmConfigFile = $this->getConfigValue('blt.root') . '/scripts/drupal-vm/config.yml';
     $this->defaultDrupalVmVagrantfile = $this->getConfigValue('blt.root') . '/scripts/drupal-vm/Vagrantfile';
@@ -172,7 +172,7 @@ class VmCommand extends BltTasks {
    */
   protected function boot() {
     $this->checkRequirements();
-    $this->yell(" * We have configured your new Drupal VM to use PHP 7.1 If you would like to change this, edit box/config.yml.");
+    $this->yell(" * We have configured your new Drupal VM to use PHP 7.2. If you would like to change this, edit box/config.yml.");
     $confirm = $this->confirm("Do you want to boot Drupal VM?", TRUE);
     if ($confirm) {
       $this->say("In the future, run <comment>vagrant up</comment> to boot the VM.");
@@ -271,25 +271,10 @@ class VmCommand extends BltTasks {
       [
         'geerlingguy/drupal-vm',
         'geerlingguy/ubuntu1604',
-        'beet/box',
       ],
       0);
 
     switch ($base_box) {
-      case 'beet/box':
-        $config->set('workspace', '/beetbox/workspace/{{ php_version }}');
-        $config->set('extra_packages', [
-          'patchutils',
-          'sqlite',
-        ]);
-        $config->set('installed_extras', [
-          'drush',
-          'nodejs',
-          'xdebug',
-          'selenium',
-        ]);
-        break;
-
       case 'geerlingguy/ubuntu1604':
       case 'geerlingguy/drupal-vm':
         $config->set('workspace', '/root');


### PR DESCRIPTION
Fixes #3536 
--------

Changes proposed
---------
- Upgrade the default version of DrupalVM from 4 to 5.
- Remove Beetbox base box, since IIUC the new drupal-vm base box largely supplants it.
- Upgrade default PHP version to 7.2 for Pipelines, Travis, and DrupalVM.
- Remove config options from drupal-vm/config.yml that duplicate their upstream values in order to reduce maintenance overhead going forward.