### PR TITLE
Update CI docs for generating a Travis private key

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -70,10 +70,12 @@ To set up the [workflow described earlier](#workflow), you must configure Acquia
 1. Generate an SSH key locally that will allow Travis to authenticate to Acquia Cloud:
 
          cd ~/.ssh
-         ssh-keygen -t rsa -b 4096
+         ssh-keygen -t rsa -b 4096 -m PEM
 
     Do not use a passphrase!
-    Name this key something different than your normal Acquia Cloud key (e.g., travis)
+    Name this key something different than your normal Acquia Cloud key (e.g., travis).
+    
+    Travis currently requires legacy RSA PEM keys so you should explicitly define the format with the -m flag
 
 1. Create a new Acquia Cloud account to be used exclusively as a container for the SSH keys that will grant Travis push access to Acquia Cloud. This can be done by inviting a new team member on the "Teams" tab in Acquia Cloud. You can use an email address like `<email>+<project>.travis@acquia.com`. The team member must have SSH push access (i.e. Team Lead role). It's not recommended to use a personal account or re-use the shell account across projects, since this poses a security risk, and will also cause deployments to fail if your account is removed from the project.
 1. Login to the new Acquia Cloud account and add the public SSH key from the key pair that was generated in step 1 by editing the profile and choosing the "credentials" tab.


### PR DESCRIPTION
Travis requires legacy format for keys and new versions of OSX will by default create an openssh key which is not recognised.
-m PEM will generate a key that travis recognises
https://github.com/travis-ci/travis.rb/issues/267#issuecomment-457159336

Fixes #3542 
--------

Changes proposed
---------
Updates to the CI documentation for generating a key that travis will understand

