### PR TITLE
Allow both supported minor versions of Drupal Core 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "drupal/coder": "^8.3.1",
         "drush/drush": "^9.5.0",
         "drupal/config_split": "^1.0.0",
-        "drupal/core": "^8.6.0",
+        "drupal/core": "^8.5.0",
         "drupal/features": "^3.8.0",
         "drupal/memcache": "2.0-alpha7",
         "drupal/seckit": "^1.0.0-alpha2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dbb71ca2256b20d47044ea0db135d2f5",
+    "content-hash": "d13acf0a616233c2c481fa29553dc1ae",
     "packages": [
         {
             "name": "acquia/drupal-spec-tool",
@@ -2843,7 +2843,7 @@
             "description": "Provides basic revert and update functionality for other modules",
             "homepage": "https://www.drupal.org/project/config_update",
             "support": {
-                "source": "http://cgit.drupalcode.org/config_update"
+                "source": "https://git.drupalcode.org/project/config_update"
             }
         },
         {
@@ -3292,7 +3292,7 @@
             "description": "Enables administrators to package configuration into modules",
             "homepage": "https://www.drupal.org/project/features",
             "support": {
-                "source": "http://cgit.drupalcode.org/features"
+                "source": "https://git.drupalcode.org/project/features"
             }
         },
         {
@@ -3363,7 +3363,7 @@
             "description": "High performance integration with memcache.",
             "homepage": "http://drupal.org/project/memcache",
             "support": {
-                "source": "http://cgit.drupalcode.org/memcache",
+                "source": "https://git.drupalcode.org/project/memcache",
                 "issues": "https://www.drupal.org/project/issues/memcache"
             }
         },
@@ -8021,12 +8021,12 @@
             "version": "v1.6.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mikey179/vfsStream.git",
+                "url": "https://github.com/bovigo/vfsStream.git",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
                 "shasum": ""
             },


### PR DESCRIPTION
[Per Drupal.org](https://www.drupal.org/drupal-security-team/general-information#supported), "Starting with the release of Drupal 8.6.0, two minor releases receive security support at a time. For example, Drupal 8.6 receives security support until the release of Drupal 8.8.0." BLT should therefore remain compatible with two minor versions. This is important for ORCA, because we want to test that our product modules are compatible with all supported versions of Drupal, but we can't do so with a BLT-based test fixture if the version constraint only allows the latest version.