### PR TITLE
Alter run_tests not to use --yes as argument

### DIFF
--- a/scripts/travis/run_tests
+++ b/scripts/travis/run_tests
@@ -3,7 +3,7 @@
 set -ev
 
 blt validate:all --no-interaction
-${BLT_DIR}/scripts/blt/ci/tick-tock.sh blt setup --define drush.alias='${drush.aliases.ci}' --environment=ci --no-interaction --yes --verbose
-blt tests:all --define drush.alias='${drush.aliases.ci}' --define tests.run-server=true --environment=ci --yes --verbose
+${BLT_DIR}/scripts/blt/ci/tick-tock.sh blt setup --define drush.alias='${drush.aliases.ci}' --environment=ci --no-interaction --verbose
+blt tests:all --define drush.alias='${drush.aliases.ci}' --define tests.run-server=true --environment=ci --no-interaction --verbose
 
 set +v


### PR DESCRIPTION
Fixes #3548 
--------

Changes proposed
---------
Update the run_tests command to use --no-interaction rather than --yes on blt setup and blt tests:all

Previous (bad) behavior, before applying PR
----------
[Symfony\Component\Console\Exception\RuntimeException]  
  The "--yes" option does not exist.

Expected behavior, after applying PR and re-running test steps
-----------
Build passes 
