### PR TITLE
Prevent cache collisions in multisite install tasks #3171.

### DIFF
--- a/scripts/factory-hooks/post-install/post-install.php
+++ b/scripts/factory-hooks/post-install/post-install.php
@@ -64,7 +64,7 @@ if (!$uri) {
 
 $docroot = sprintf('/var/www/html/%s.%s/docroot', $site, $env);
 
-$cache_directory = exec("/mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri");
+$cache_directory = exec("/usr/bin/env php /mnt/www/html/$site.$env/vendor/acquia/blt/scripts/blt/drush/cache.php $site $env $uri");
 
 shell_exec(sprintf('mkdir -p %s', escapeshellarg($cache_directory)));
 


### PR DESCRIPTION
Fixes #3171 
--------

Changes proposed
---------
There is an issue https://github.com/acquia/blt/pull/3171 "Prevent cache collisions in multisite install tasks". It should create new temporary cache folder but actually doesn't do it.

Steps to replicate the issue
----------
When I run command similar
```
CACHE_PREFIX='/mnt/tmp/sandbox.01live' \drush8 --root='/mnt/www/html/***/docroot' -l '***.acsitefactory.com' scr --script-path='/mnt/www/html/***/factory-hooks/post-install' 'post-install.php'
```
it shows in console 

```
Running updates on: site: ***; env: 01dev; db_role: dvc***; name: ***;
Site domain:***.acsitefactory.com;
sh: 1: /mnt/www/html/***/vendor/acquia/blt/scripts/blt/drush/cache.php: Permission denied
mkdir: cannot create directory ‘’: No such file or directory
Executing: DRUSH_PATHS_CACHE_DIRECTORY='' '/var/www/html/***/vendor/bin/blt' drupal:update --environment='01dev' --site='***' --define drush.uri='***.acsitefactory.com' --verbose --yes --no-interaction with cache dir ;
``` 

Previous (bad) behavior, before applying PR
----------
Temporary cache directory isn't created.

Expected behavior, after applying PR and re-running test steps
-----------
Temporary cache directory is created.


Additional details
-----------
After applying a fix post-install.php prints:
```
Post install has been started.Running updates on: site: ***; env: 01dev; db_role: dvc***; name: ***;
Site domain: ***.acsitefactory.com;
Executing: DRUSH_PATHS_CACHE_DIRECTORY='/mnt/tmp/***.01dev/drush_tmp_cache/e6ba068946f71ed14ef1dd66d91173e2' '/var/www/html/***.01dev/vendor/bin/blt' drupal:update --environment='01dev' --site='***' --define drush.uri='***.acsitefactory.com' --verbose --yes --no-interaction with cache dir /mnt/tmp/***.01dev/drush_tmp_cache/e6ba068946f71ed14ef1dd66d91173e2;
```