### PR TITLE
run_tests should not use the --yes argument on Pipelines

### DIFF
--- a/scripts/pipelines/tests
+++ b/scripts/pipelines/tests
@@ -4,6 +4,6 @@ set -ev
 
 export PATH=${COMPOSER_BIN}:${PATH}
 
-blt tests:all --define drush.alias='${drush.aliases.ci}' --environment=ci -D behat.web-driver=chrome --yes --ansi --verbose
+blt tests:all --define drush.alias='${drush.aliases.ci}' --environment=ci -D behat.web-driver=chrome --no-interaction --ansi --verbose
 
 set +v


### PR DESCRIPTION
This is a follow-up to #3549 which addressed TravisCI only.
