### PR TITLE
See what breaks if we unpin Behat version

### DIFF
--- a/src/Robo/Commands/Tests/BehatCommand.php
+++ b/src/Robo/Commands/Tests/BehatCommand.php
@@ -154,11 +154,11 @@ class BehatCommand extends TestsCommandBase {
       // @todo replace base_url in behat config when internal server is being used.
       $task = $this->taskBehat($this->getConfigValue('composer.bin') . '/behat')
         ->format('pretty')
-        ->arg($behat_path)
         ->option('colors')
         ->noInteraction()
         ->printMetadata(FALSE)
         ->stopOnFail()
+        ->dir($behat_path)
         ->option('strict')
         ->option('config', $this->getConfigValue('behat.config'))
         ->option('profile', $this->getConfigValue('behat.profile'))

--- a/subtree-splits/blt-require-dev/composer.json
+++ b/subtree-splits/blt-require-dev/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-only",
     "minimum-stability": "dev",
     "require": {
-        "behat/behat": ">=3.1 <3.4",
+        "behat/behat": "~3.1",
         "bex/behat-screenshot": "^1.2",
         "drupal/drupal-extension": "~3.2",
         "jarnaiz/behat-junit-formatter": "^1.3.2",


### PR DESCRIPTION
Fixes #3559
--------

Changes proposed
---------
- Allow BLT users to use Behat 3.4 or 3.5, and potentially future minor releases as well.

I have no idea what might break with this. As far as I know, no one has tested Behat versions above 3.3 with BLT. I don't see anything obviously risky in the Behat release notes. Lightning tests with Behat 3.5.0 so we should probably shoot for that as well.