### PR TITLE
Fixed #3562: SQL sanitization should throw non-zero exit code on failure

### DIFF
--- a/src/Robo/Commands/Artifact/AcHooksCommand.php
+++ b/src/Robo/Commands/Artifact/AcHooksCommand.php
@@ -153,10 +153,13 @@ class AcHooksCommand extends BltTasks {
         },
         'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#%^&*()_?/.,+=><'
       );
-      $this->taskDrush()
+      $this->say("Scrubbing database in $target_env");
+      $result = $this->taskDrush()
         ->drush("sql-sanitize --sanitize-password=\"$password\" --yes")
         ->run();
-      $this->say("Scrubbing database in $target_env");
+      if (!$result->wasSuccessful()) {
+        throw new BltException("Failed to sanitize database!");
+      }
       $this->taskDrush()
         ->drush("cr")
         ->run();


### PR DESCRIPTION
Fixes #3562
--------

Changes proposed
---------
- If `drush sql-sanitize` errors out when called via db-scrub.sh, throw an exception so the whole hook returns a non-zero status code.

@greylabel can you please test this and let me know if it solves #3562 for you?