### PR TITLE
Use a unified environment detector.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -89,8 +89,8 @@ if (EnvironmentDetector::isAcsfInited()) {
     $config_initializer = new ConfigInitializer($repo_root, $input);
     $blt_config = $config_initializer->initialize();
 
-    // The hostname must match the pattern local.[sitename].com, where
-    // [sitename] is a value in the multisites array.
+    // The hostname must match the pattern local.[site-name].com, where
+    // [site-name] is a value in the multisites array.
     $domain_fragments = explode('.', $http_host);
     $name = array_slice($domain_fragments, 1);
     $acsf_sites = $blt_config->get('multisites');
@@ -130,11 +130,13 @@ if (EnvironmentDetector::isAhEnv()) {
   // @see https://docs.acquia.com/resource/secrets/#secrets-settings-php-file
   $secrets_file = EnvironmentDetector::getAhFilesRoot() . '/secrets.settings.php';
   if (file_exists($secrets_file)) {
+    /** @noinspection PhpIncludeInspection */
     require $secrets_file;
   }
   // Includes secrets file for given site.
   $site_secrets_file = EnvironmentDetector::getAhFilesRoot() . "/$site_dir/secrets.settings.php";
   if (file_exists($site_secrets_file)) {
+    /** @noinspection PhpIncludeInspection */
     require $site_secrets_file;
   }
 }
@@ -229,25 +231,9 @@ if (EnvironmentDetector::isCiEnv()) {
   require __DIR__ . '/ci.settings.php';
 }
 
-// Load Acquia Pipeline settings.
-if (EnvironmentDetector::isPipelinesEnv()) {
-  require __DIR__ . '/pipelines.settings.php';
-}
-// Load Travis CI settings.
-elseif (EnvironmentDetector::isTravisEnv()) {
-  require __DIR__ . '/travis.settings.php';
-}
-// Load Tugboat settings.
-elseif (EnvironmentDetector::isTugboatEnv()) {
-  require __DIR__ . '/tugboat.settings.php';
-}
-// Load Probo settings.
-elseif (EnvironmentDetector::isProboEnv()) {
-  require __DIR__ . '/probo.settings.php';
-}
-// Load GitLab settings.
-elseif (EnvironmentDetector::isGitlabEnv()) {
-  require __DIR__ . '/gitlab.settings.php';
+if (EnvironmentDetector::getCiEnv()) {
+  /** @noinspection PhpIncludeInspection */
+  require sprintf("%s/%s.settings.php", __DIR__, EnvironmentDetector::getCiEnv());
 }
 
 /**

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -72,13 +72,12 @@ if ($ip = array_pop($x_ips)) {
 /**
  * CI envs.
  */
-// TODO: Incorporate all of these as well?
-$is_travis_env = isset($_ENV['TRAVIS']);
-$is_pipelines_env = isset($_ENV['PIPELINE_ENV']);
-$is_probo_env = isset($_ENV['PROBO_ENVIRONMENT']);
-$is_tugboat_env = isset($_ENV['TUGBOAT_URL']);
-$is_gitlab_env = isset($_ENV['GITLAB_CI']);
-$is_ci_env = $is_travis_env || $is_pipelines_env || $is_probo_env || $is_tugboat_env || $is_gitlab_env || isset($_ENV['CI']);
+$is_travis_env = EnvironmentDetector::isTravisEnv();
+$is_pipelines_env = EnvironmentDetector::isPipelinesEnv();
+$is_probo_env = EnvironmentDetector::isProboEnv();
+$is_tugboat_env = EnvironmentDetector::isTugboatEnv();
+$is_gitlab_env = EnvironmentDetector::isGitlabEnv();
+$is_ci_env = EnvironmentDetector::isCiEnv();
 
 /**
  * Acquia envs.
@@ -110,23 +109,23 @@ $acsf_db_name = isset($GLOBALS['gardens_site_settings']) && $is_acsf_env ? $GLOB
 /**
  * Pantheon envs.
  */
-$is_pantheon_env = isset($_ENV['PANTHEON_ENVIRONMENT']);
-$pantheon_env = $is_pantheon_env ? $_ENV['PANTHEON_ENVIRONMENT'] : NULL;
-$is_pantheon_dev_env = $pantheon_env == 'dev';
-$is_pantheon_stage_env = $pantheon_env == 'test';
-$is_pantheon_prod_env = $pantheon_env == 'live';
+$is_pantheon_env = EnvironmentDetector::isPantheonEnv();
+$pantheon_env = EnvironmentDetector::getPantheonEnv();
+$is_pantheon_dev_env = EnvironmentDetector::isPantheonDevEnv();
+$is_pantheon_stage_env = EnvironmentDetector::isPantheonStageEnv();
+$is_pantheon_prod_env = EnvironmentDetector::isPantheonProdEnv();
 
 /**
  * Local envs.
  */
-$is_local_env = !$is_ah_env && !$is_pantheon_env && !$is_ci_env;
+$is_local_env = EnvironmentDetector::isLocalEnv();
 
 /**
  * Common variables.
  */
-$is_dev_env = $is_ah_dev_env || $is_pantheon_dev_env;
-$is_stage_env = $is_ah_stage_env || $is_pantheon_stage_env;
-$is_prod_env = $is_ah_prod_env || $is_pantheon_prod_env;
+$is_dev_env = EnvironmentDetector::isDevEnv();
+$is_stage_env = EnvironmentDetector::isStageEnv();
+$is_prod_env = EnvironmentDetector::isProdEnv();
 
 /**
  * Site directory detection.

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -86,7 +86,7 @@ $is_ci_env = $is_travis_env || $is_pipelines_env || $is_probo_env || $is_tugboat
  * Note that the values of environmental variables are set differently on Acquia
  * Cloud Free tier vs Acquia Cloud Professional and Enterprise.
  */
-// TODO: Just remove all of these variables and call EnvironmentDetector methods directly as needed?
+// TODO: Remove all of these variables, call detector methods directly instead?
 $repo_root = dirname(DRUPAL_ROOT);
 $ah_env = EnvironmentDetector::getAhEnv();
 $ah_group = EnvironmentDetector::getAhGroup();

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -232,7 +232,7 @@ if (EnvironmentDetector::isLocalEnv()) {
 
 foreach ($settings_files as $settings_file) {
   if (file_exists($settings_file)) {
-    /** @noinspection PhpIncludeInspection */
+    /* @noinspection PhpIncludeInspection */
     require $settings_file;
   }
 }

--- a/settings/cache.settings.php
+++ b/settings/cache.settings.php
@@ -5,7 +5,11 @@
  * Contains caching configuration.
  */
 
-if ($is_prod_env || $is_stage_env) {
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
+
+/** @var array $settings */
+
+if (EnvironmentDetector::isProdEnv() || EnvironmentDetector::isStageEnv()) {
   $config['system.logging']['error_level'] = 'hide';
 }
 
@@ -16,7 +20,7 @@ if ($is_prod_env || $is_stage_env) {
  * default and since the core service definition for these bins sets
  * the expire to CacheBackendInterface::CACHE_PERMANENT, these objects
  * are cached permanently and may result in stale configuration when
- * rebuilding the service container on deploymemnts and cache rebuilds.
+ * rebuilding the service container on deployments and cache rebuilds.
  * Uncomment the relevant lines for each bin below and configure the desired.
  *
  * $settings['cache']['bins']['bootstrap'] = 'cache.backend.null';
@@ -35,7 +39,7 @@ if ($is_prod_env || $is_stage_env) {
  *
  * @see https://www.drupal.org/node/2766509
  */
-if (($is_ah_env || $is_ci_env) &&
+if ((EnvironmentDetector::isAhEnv() || EnvironmentDetector::isCiEnv()) &&
   array_key_exists('memcache', $settings) &&
   array_key_exists('servers', $settings['memcache']) &&
   !empty($settings['memcache']['servers'])

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -5,6 +5,7 @@
  * Controls configuration management settings.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Acquia\Blt\Robo\Config\ConfigInitializer;
 use Symfony\Component\Console\Input\ArgvInput;
 
@@ -53,38 +54,27 @@ if (!isset($split)) {
   $split = 'none';
 
   // Local envs.
-  if ($is_local_env) {
+  if (EnvironmentDetector::isLocalEnv()) {
     $split = 'local';
   }
   // CI envs.
-  if ($is_ci_env) {
+  if (EnvironmentDetector::isCiEnv()) {
     $split = 'ci';
   }
   // Acquia only envs.
-  if ($is_ah_env) {
+  if (EnvironmentDetector::isAhEnv()) {
     $config_directories['vcs'] = $config_directories['sync'];
-
     $split = 'ah_other';
-    if ($is_ah_dev_env || $is_ah_ode_env) {
-      $split = 'dev';
-    }
-    elseif ($is_ah_stage_env) {
-      $split = 'stage';
-    }
-    elseif ($is_ah_prod_env) {
-      $split = 'prod';
-    }
   }
-  elseif ($is_pantheon_env) {
-    if ($pantheon_env == 'live') {
-      $split = 'prod';
-    }
-    elseif ($pantheon_env == 'test') {
-      $split = 'stage';
-    }
-    elseif ($pantheon_env == 'dev') {
-      $split = 'dev';
-    }
+
+  if (EnvironmentDetector::isDevEnv() || EnvironmentDetector::isAhOdeEnv()) {
+    $split = 'dev';
+  }
+  elseif (EnvironmentDetector::isStageEnv()) {
+    $split = 'stage';
+  }
+  elseif (EnvironmentDetector::isProdEnv()) {
+    $split = 'prod';
   }
 }
 

--- a/settings/filesystem.settings.php
+++ b/settings/filesystem.settings.php
@@ -5,14 +5,24 @@
  * Contains filesystem settings.
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
+use Acquia\Blt\Robo\Exceptions\BltException;
+
 $settings['file_public_path'] = "sites/$site_dir/files";
+
+try {
+  $acsf_db_name = EnvironmentDetector::getAcsfDbName();
+  $is_acsf_env = EnvironmentDetector::isAcsfEnv();
+}
+catch (BltException $exception) {
+  trigger_error($exception->getMessage(), E_USER_WARNING);
+}
 
 // ACSF file paths.
 if ($is_acsf_env && $acsf_db_name) {
   $settings['file_public_path'] = "sites/g/files/$acsf_db_name/files";
-  $settings['file_private_path'] = "/mnt/files/$ah_group.$ah_env/sites/g/files-private/$acsf_db_name";
-}
-// Acquia cloud file paths.
-elseif ($is_ah_env) {
-  $settings['file_private_path'] = "/mnt/files/$ah_group.$ah_env/sites/$site_dir/files-private";
+  $settings['file_private_path'] = EnvironmentDetector::getAhFilesRoot() . "/sites/g/files-private/$acsf_db_name";
+} // Acquia cloud file paths.
+elseif (EnvironmentDetector::isAhEnv()) {
+  $settings['file_private_path'] = EnvironmentDetector::getAhFilesRoot() . "/sites/$site_dir/files-private";
 }

--- a/settings/filesystem.settings.php
+++ b/settings/filesystem.settings.php
@@ -18,11 +18,12 @@ catch (BltException $exception) {
   trigger_error($exception->getMessage(), E_USER_WARNING);
 }
 
-// ACSF file paths.
 if ($is_acsf_env && $acsf_db_name) {
+  // ACSF file paths.
   $settings['file_public_path'] = "sites/g/files/$acsf_db_name/files";
   $settings['file_private_path'] = EnvironmentDetector::getAhFilesRoot() . "/sites/g/files-private/$acsf_db_name";
-} // Acquia cloud file paths.
+}
 elseif (EnvironmentDetector::isAhEnv()) {
+  // Acquia cloud file paths.
   $settings['file_private_path'] = EnvironmentDetector::getAhFilesRoot() . "/sites/$site_dir/files-private";
 }

--- a/settings/logging.settings.php
+++ b/settings/logging.settings.php
@@ -5,7 +5,9 @@
  * Display all errors for all but tests and prod envs.
  */
 
-if ($is_local_env || $is_dev_env) {
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
+
+if (EnvironmentDetector::isLocalEnv() || EnvironmentDetector::isDevEnv()) {
   // Ultimately, EVERY compiler message represents a mistake in the code.
   // Acquia Cloud isn't quite ready for E_STRICT yet.
   error_reporting(E_ALL);

--- a/settings/sample-secrets.settings.php
+++ b/settings/sample-secrets.settings.php
@@ -14,6 +14,8 @@
  * dev/stage and one for prod).
  */
 
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
+
 /**
  * The below example would set a sensitive API key.
  *
@@ -24,7 +26,7 @@
  * In addition to $ah_env, you can use other variables defined in
  * blt.settings.php such as $is_dev_env, $is_prod_env, and $ah_site.
  */
-switch ($ah_env) {
+switch (EnvironmentDetector::getAhEnv()) {
   case 'dev':
   case 'test':
     $settings['super_secret_key'] = 'DEV-1234';

--- a/src/Robo/Commands/Artifact/AcHooksCommand.php
+++ b/src/Robo/Commands/Artifact/AcHooksCommand.php
@@ -61,7 +61,7 @@ class AcHooksCommand extends BltTasks {
    *
    * @command artifact:ac-hooks:post-code-update
    *
-   * @throws \Exception
+   * @throws BltException
    */
   public function postCodeUpdate($site, $target_env, $source_branch, $deployed_tag, $repo_url, $repo_type) {
     if (!EnvironmentDetector::isAcsfEnv($site, $target_env)) {
@@ -70,7 +70,7 @@ class AcHooksCommand extends BltTasks {
         $success = TRUE;
         $this->sendPostCodeUpdateNotifications($site, $target_env, $source_branch, $deployed_tag, $success);
       }
-      catch (\Exception $e) {
+      catch (BltException $e) {
         $success = FALSE;
         $this->sendPostCodeUpdateNotifications($site, $target_env, $source_branch, $deployed_tag, $success);
         throw $e;
@@ -93,8 +93,6 @@ class AcHooksCommand extends BltTasks {
    *   The source environment. E.g., dev.
    *
    * @command artifact:ac-hooks:post-db-copy
-   *
-   * @throws \Exception
    */
   public function postDbCopy($site, $target_env, $db_name, $source_env) {
     // Do nothing for now. Allow extension of this call.
@@ -113,8 +111,6 @@ class AcHooksCommand extends BltTasks {
    *   The source environment. E.g., dev.
    *
    * @command artifact:ac-hooks:post-files-copy
-   *
-   * @throws \Exception
    */
   public function postFilesCopy($site, $target_env, $source_env) {
     // Do nothing for now. Allow extension of this call.

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -10,8 +10,8 @@ use Acquia\Blt\Robo\Exceptions\BltException;
  *
  * Attempts to detect various properties about the current hosting environment.
  */
-class EnvironmentDetector
-{
+class EnvironmentDetector {
+
   public static function isAhEnv() {
     return (bool) self::getAhEnv();
   }
@@ -24,7 +24,7 @@ class EnvironmentDetector
    * @return bool
    * @throws BltException
    */
-  public static function isAcsfEnv($ah_group = null, $ah_env = null) {
+  public static function isAcsfEnv($ah_group = NULL, $ah_env = NULL) {
     if (is_null($ah_group)) {
       $ah_group = self::getAhGroup();
     }
@@ -34,7 +34,7 @@ class EnvironmentDetector
     }
 
     if (empty($ah_group) || empty($ah_env)) {
-      return false;
+      return FALSE;
     }
 
     $is_acsf_json = file_exists("/mnt/files/$ah_group.$ah_env/files-private/sites.json");
@@ -64,7 +64,7 @@ class EnvironmentDetector
     return (preg_match('/^\d*dev\d*$/', self::getAhEnv()));
   }
 
-  public static function isAhOdeEnv($ah_env = null) {
+  public static function isAhOdeEnv($ah_env = NULL) {
     if (is_null($ah_env)) {
       $ah_env = self::getAhEnv();
     }
@@ -87,4 +87,5 @@ class EnvironmentDetector
   public static function getAhSite() {
     return isset($_ENV['AH_SITE_NAME']) ? $_ENV['AH_SITE_NAME'] : NULL;
   }
+
 }

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -84,8 +84,7 @@ class EnvironmentDetector {
     return isset($_ENV['AH_SITE_ENVIRONMENT']) ? $_ENV['AH_SITE_ENVIRONMENT'] : NULL;
   }
 
-  public static function getCiEnv()
-  {
+  public static function getCiEnv() {
     $mapping = [
       'TRAVIS' => 'travis',
       'PIPELINE_ENV' => 'pipelines',
@@ -157,4 +156,5 @@ class EnvironmentDetector {
   public static function getAcsfDbName() {
     return isset($GLOBALS['gardens_site_settings']) && self::isAcsfEnv() ? $GLOBALS['gardens_site_settings']['conf']['acsf_db_name'] : NULL;
   }
+
 }

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -88,4 +88,63 @@ class EnvironmentDetector {
     return isset($_ENV['AH_SITE_NAME']) ? $_ENV['AH_SITE_NAME'] : NULL;
   }
 
+  public static function isTravisEnv() {
+    return isset($_ENV['TRAVIS']);
+  }
+
+  public static function isPipelinesEnv() {
+    return isset($_ENV['PIPELINE_ENV']);
+  }
+
+  public static function isProboEnv() {
+    return isset($_ENV['PROBO_ENVIRONMENT']);
+  }
+
+  public static function isTugboatEnv() {
+    return isset($_ENV['TUGBOAT_URL']);
+  }
+
+  public static function isGitlabEnv() {
+    return isset($_ENV['GITLAB_CI']);
+  }
+
+  public static function isCiEnv() {
+    return self::isTravisEnv() || self::isPipelinesEnv() || self::isProboEnv() || self::isTugboatEnv() || self::isGitlabEnv() || isset($_ENV['CI']);
+  }
+
+  public static function isPantheonEnv() {
+    return isset($_ENV['PANTHEON_ENVIRONMENT']);
+  }
+
+  public static function getPantheonEnv() {
+    return self::isPantheonEnv() ? $_ENV['PANTHEON_ENVIRONMENT'] : NULL;
+  }
+
+  public static function isPantheonDevEnv() {
+    return self::getPantheonEnv() == 'dev';
+  }
+
+  public static function isPantheonStageEnv() {
+    return self::getPantheonEnv() == 'test';
+  }
+
+  public static function isPantheonProdEnv() {
+    return self::getPantheonEnv() == 'live';
+  }
+
+  public static function isLocalEnv() {
+    return !self::isAhEnv() && !self::isPantheonEnv() && !self::isCiEnv();
+  }
+
+  public static function isDevEnv() {
+    return self::isAhDevEnv() || self::isPantheonDevEnv();
+  }
+
+  public static function isStageEnv() {
+    return self::isAhStageEnv() || self::isPantheonStageEnv();
+  }
+
+  public static function isProdEnv() {
+    return self::isAhProdEnv() || self::isPantheonProdEnv();
+  }
 }

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -147,4 +147,21 @@ class EnvironmentDetector {
   public static function isProdEnv() {
     return self::isAhProdEnv() || self::isPantheonProdEnv();
   }
+
+  public static function getAhFilesRoot() {
+    return '/mnt/files/' . self::getAhGroup() . '.' . self::getAhEnv();
+  }
+
+  public static function isAcsfInited() {
+    return file_exists(DRUPAL_ROOT . "/sites/g");
+  }
+
+  /**
+   * @return string|null
+   *   ACSF db name.
+   * @throws BltException
+   */
+  public static function getAcsfDbName() {
+    return isset($GLOBALS['gardens_site_settings']) && self::isAcsfEnv() ? $GLOBALS['gardens_site_settings']['conf']['acsf_db_name'] : NULL;
+  }
 }

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -84,10 +84,6 @@ class EnvironmentDetector {
     return isset($_ENV['AH_SITE_ENVIRONMENT']) ? $_ENV['AH_SITE_ENVIRONMENT'] : NULL;
   }
 
-  public static function getAhSite() {
-    return isset($_ENV['AH_SITE_NAME']) ? $_ENV['AH_SITE_NAME'] : NULL;
-  }
-
   public static function getCiEnv()
   {
     $mapping = [

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Acquia\Blt\Robo\Common;
+
+use Acquia\Blt\Robo\Exceptions\BltException;
+
+/**
+ * Class EnvironmentDetector
+ * @package Acquia\Blt\Robo\Common
+ *
+ * Attempts to detect various properties about the current hosting environment.
+ */
+class EnvironmentDetector
+{
+  public static function isAhEnv() {
+    return (bool) self::getAhEnv();
+  }
+
+  /**
+   * @param null $ah_group
+   *   The Acquia Hosting site / group name (e.g. my_subscription).
+   * @param null $ah_env
+   *   The Acquia Hosting environment name (e.g. 01dev).
+   * @return bool
+   * @throws BltException
+   */
+  public static function isAcsfEnv($ah_group = null, $ah_env = null) {
+    if (is_null($ah_group)) {
+      $ah_group = self::getAhGroup();
+    }
+
+    if (is_null($ah_env)) {
+      $ah_env = self::getAhEnv();
+    }
+
+    if (empty($ah_group) || empty($ah_env)) {
+      return false;
+    }
+
+    $is_acsf_json = file_exists("/mnt/files/$ah_group.$ah_env/files-private/sites.json");
+    $is_acsf_env_name = preg_match('/01(dev|test|live|update)(up)?/', $ah_env);
+
+    if ($is_acsf_json != $is_acsf_env_name) {
+      throw new BltException("Cannot determine if this is an ACSF environment or not.");
+    }
+
+    return ($is_acsf_env_name && $is_acsf_json);
+  }
+
+  public static function isAhProdEnv() {
+    $ah_env = self::getAhEnv();
+    // ACE prod is 'prod'; ACSF can be '01live', '02live', ...
+    return $ah_env == 'prod' || preg_match('/^\d*live$/', $ah_env);
+  }
+
+  public static function isAhStageEnv() {
+    $ah_env = self::getAhEnv();
+    // ACE staging is 'test' or 'stg'; ACSF is '01test', '02test', ...
+    return preg_match('/^\d*test$/', $ah_env) || $ah_env == 'stg';
+  }
+
+  public static function isAhDevEnv() {
+    // ACE dev is 'dev', 'dev1', ...; ACSF dev is '01dev', '02dev', ...
+    return (preg_match('/^\d*dev\d*$/', self::getAhEnv()));
+  }
+
+  public static function isAhOdeEnv($ah_env = null) {
+    if (is_null($ah_env)) {
+      $ah_env = self::getAhEnv();
+    }
+    // CDEs (formerly 'ODEs') can be 'ode1', 'ode2', ...
+    return (preg_match('/^ode\d*$/', $ah_env));
+  }
+
+  public static function isAhDevCloud() {
+    return (!empty($_SERVER['HTTP_HOST']) && strstr($_SERVER['HTTP_HOST'], 'devcloud'));
+  }
+
+  public static function getAhGroup() {
+    return isset($_ENV['AH_SITE_GROUP']) ? $_ENV['AH_SITE_GROUP'] : NULL;
+  }
+
+  public static function getAhEnv() {
+    return isset($_ENV['AH_SITE_ENVIRONMENT']) ? $_ENV['AH_SITE_ENVIRONMENT'] : NULL;
+  }
+
+  public static function getAhSite() {
+    return isset($_ENV['AH_SITE_NAME']) ? $_ENV['AH_SITE_NAME'] : NULL;
+  }
+}

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -88,28 +88,25 @@ class EnvironmentDetector {
     return isset($_ENV['AH_SITE_NAME']) ? $_ENV['AH_SITE_NAME'] : NULL;
   }
 
-  public static function isTravisEnv() {
-    return isset($_ENV['TRAVIS']);
-  }
-
-  public static function isPipelinesEnv() {
-    return isset($_ENV['PIPELINE_ENV']);
-  }
-
-  public static function isProboEnv() {
-    return isset($_ENV['PROBO_ENVIRONMENT']);
-  }
-
-  public static function isTugboatEnv() {
-    return isset($_ENV['TUGBOAT_URL']);
-  }
-
-  public static function isGitlabEnv() {
-    return isset($_ENV['GITLAB_CI']);
+  public static function getCiEnv()
+  {
+    $mapping = [
+      'TRAVIS' => 'travis',
+      'PIPELINE_ENV' => 'pipelines',
+      'PROBO_ENVIRONMENT' => 'probo',
+      'TUGBOAT_URL' => 'tugboat',
+      'GITLAB_CI' => 'gitlab',
+    ];
+    foreach ($mapping as $env_var => $ci_name) {
+      if (isset($_ENV[$env_var])) {
+        return $ci_name;
+      }
+    }
+    return FALSE;
   }
 
   public static function isCiEnv() {
-    return self::isTravisEnv() || self::isPipelinesEnv() || self::isProboEnv() || self::isTugboatEnv() || self::isGitlabEnv() || isset($_ENV['CI']);
+    return self::getCiEnv() || isset($_ENV['CI']);
   }
 
   public static function isPantheonEnv() {


### PR DESCRIPTION
Fixes #3565
--------

This fixes #3565 and also adds a utility class to encapsulate environment detection methods so that this kind of error hopefully does not recur (it could have been avoided if we hadn't implemented three different methods of ACSF env detection in three different places).

This requires a change record since any project settings relying on these variables will no longer work.