### PR TITLE
Removed PHP5.6-specific APC settings.

### DIFF
--- a/settings/apcu_fix.yml
+++ b/settings/apcu_fix.yml
@@ -1,7 +1,0 @@
-# Added at the advice of Acquia Support to prevent APCu cache exhaustion.
-# Can be removed if memcache is used or APCu is given more memory.
-# See: https://docs.acquia.com/article/drupal-8-cache-backend
-services:
-  cache.backend.chainedfast:
-    class: Drupal\Core\Cache\DatabaseBackendFactory
-    arguments: ['@database', '@cache_tags.invalidator.checksum']

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -6,7 +6,6 @@
    */
 
 use Acquia\Blt\Robo\Config\ConfigInitializer;
-use Drupal\Component\Utility\Bytes;
 use Symfony\Component\Console\Input\ArgvInput;
 
 /*******************************************************************************

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -196,16 +196,6 @@ if ($is_ah_env) {
  * BLT includes & BLT default configuration.
  ******************************************************************************/
 
-// Prevent APCu memory exhaustion.
-// Acquia assigns 8 MB for APCu, which is only adequate for small cache pools.
-if (extension_loaded('apc') && ini_get('apc.enabled')) {
-  $apc_shm_size = Bytes::toInt(ini_get('apc.shm_size'));
-  $apcu_fix_size = Bytes::toInt('32M');
-  if ($apc_shm_size < $apcu_fix_size) {
-    $settings['container_yamls'][] = __DIR__ . '/apcu_fix.yml';
-  }
-}
-
 // Includes caching configuration.
 require __DIR__ . '/cache.settings.php';
 


### PR DESCRIPTION
These APC settings only ever had an effect in PHP 5.6 environments. PHP 5.6 is long since EOL, so we shouldn't keep supporting this in 10.x