### PR TITLE
Removed unused site-install parameter.

### DIFF
--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -44,7 +44,6 @@ class DrupalCommand extends BltTasks {
     $task = $this->taskDrush()
       ->drush("site-install")
       ->arg($this->getConfigValue('project.profile.name'))
-      ->rawArg("install_configure_form.update_status_module='array(FALSE,FALSE)'")
       ->rawArg("install_configure_form.enable_update_status_module=NULL")
       ->option('sites-subdir', $this->getConfigValue('site'))
       ->option('site-name', $this->getConfigValue('project.human_name'))


### PR DESCRIPTION
This is legacy code from Drupal 8.2, which we most definitely do not support any more, so it can go.

See https://github.com/acquia/blt/pull/1360