### PR TITLE
Fixes #3574: Git tag needs author info, should stop deploy.

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -5,7 +5,6 @@ namespace Acquia\Blt\Robo\Commands\Deploy;
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
-use Robo\Exception\TaskException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Finder\Finder;
 
@@ -545,7 +544,6 @@ class DeployCommand extends BltTasks {
    * @param $options
    * @return bool
    * @throws BltException
-   * @throws TaskException
    */
   protected function push($identifier, $options) {
     if ($options['dry-run']) {
@@ -575,7 +573,6 @@ class DeployCommand extends BltTasks {
    * @param $repo
    *   The repo in which a tag should be cut.
    * @throws BltException
-   * @throws TaskException
    */
   protected function cutTag($repo = 'build') {
     $taskGit = $this->taskGit()

--- a/src/Robo/Tasks/GitTask.php
+++ b/src/Robo/Tasks/GitTask.php
@@ -31,4 +31,23 @@ class GitTask extends GitStack {
     return $this->exec($command);
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function tag($message, $tag_name) {
+    $message = escapeshellarg($message);
+    $tag_name = escapeshellarg($tag_name);
+    $git_name = $this->getConfig()->get('git.user.name');
+    $git_email = $this->getConfig()->get('git.user.email');
+
+    $command = ['git'];
+    if ($git_name && $git_email) {
+      $command[] = '-c user.name=' . escapeshellarg($git_name);
+      $command[] = '-c user.email=' . escapeshellarg($git_email);
+    }
+    $command[] = 'tag';
+    $command[] = "-a $tag_name";
+    $command[] = "-m $message";
+    return $this->exec($command);
+  }
 }

--- a/src/Robo/Tasks/GitTask.php
+++ b/src/Robo/Tasks/GitTask.php
@@ -50,4 +50,5 @@ class GitTask extends GitStack {
     $command[] = "-m $message";
     return $this->exec($command);
   }
+
 }


### PR DESCRIPTION
Fixes #3574  
--------

Changes proposed
---------
- Use provided or dummy author info when creating Git tags, same as we do for commits
- Stop deployment on failure

Steps to replicate the issue
----------
See #3574
