### PR TITLE
Recommend installing zaporylie/composer-drupal-optimizations globally.

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,7 +31,8 @@ Then install the minimum dependencies for BLT. The preferred method is via Homeb
 
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         brew install php71 git composer drush
-        composer global require "hirak/prestissimo:^0.3"
+        composer global require hirak/prestissimo:^0.3
+        composer global require zaporylie/composer-drupal-optimizations:^1.1
 
 Note that the recommended installation method for Drush has changed recently. Drush should only be installed as a dependency of individual projects, rather than being installed system-wide. BLT will manage this dependency for you on projects, but in order for you to run Drush commands independently of BLT commands you need to install the Drush Launcher: [Drush Launcher Installation](https://github.com/drush-ops/drush-launcher#installation---phar).
 
@@ -67,7 +68,8 @@ Linux is fully supported by BLT and DrupalVM and shares many of the same depende
 #### Ubuntu / Debian
 
         apt-get install git composer drush
-        composer global require "hirak/prestissimo:^0.3"
+        composer global require hirak/prestissimo:^0.3
+        composer global require zaporylie/composer-drupal-optimizations:^1.1
 
 #### Fedora
 


### PR DESCRIPTION
BLT's composer.json already depends on zaporylie/composer-drupal-optimizations, but unfortunately because of the way Composer plugins work it has no effect on the initial install (i.e. during project creation). It does work great on subsequent updates.

We should recommend that folks install it globally before installing BLT to get a much better experience. On my machine, this reduced `composer create-project` runtime from ~60s to ~15s and memory usage from 1600mb to 400mb. Huge improvement.

We already recommend that folks install the prestissimo plugin as a prerequisite, so this seems like a natural extension.

@alexxed you might think about having ADS install these global plugins before spinning up BLT projects.