### PR TITLE
Get rid of Vagrant warnings during update process.

### DIFF
--- a/src/Update/Updater.php
+++ b/src/Update/Updater.php
@@ -563,7 +563,7 @@ class Updater {
    */
   public function regenerateCloudHooks() {
     if (file_exists($this->getRepoRoot() . '/hooks') && !$this->cloudHooksAlreadyUpdated) {
-      $this->executeCommand("./vendor/bin/blt recipes:cloud-hooks:init");
+      self::executeCommand("./vendor/bin/blt recipes:cloud-hooks:init", NULL, FALSE);
       $this->cloudHooksAlreadyUpdated = TRUE;
       return TRUE;
     }

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -703,7 +703,7 @@ class Updates {
     // Check for presence of factory-hooks directory. Regenerate if present.
     if (file_exists($this->updater->getRepoRoot() . '/factory-hooks')) {
       $messages[] = "factory-hooks have been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
-      $this->updater->executeCommand("./vendor/bin/blt recipes:acsf:init:hooks");
+      $this->updater->executeCommand("./vendor/bin/blt recipes:acsf:init:hooks", NULL, FALSE);
     }
 
     if ($this->updater->regenerateCloudHooks()) {
@@ -713,18 +713,18 @@ class Updates {
     // Check for presence of pipelines.yml files. Regenerate if present.
     if (file_exists($this->updater->getRepoRoot() . '/acquia-pipelines.yml')) {
       $messages[] = "pipelines.yml has been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
-      $this->updater->executeCommand("./vendor/bin/blt recipes:ci:pipelines:init");
+      $this->updater->executeCommand("./vendor/bin/blt recipes:ci:pipelines:init", NULL, FALSE);
     }
 
     // Check for presence of .travis.yml files. Regenerate if present.
     if (file_exists($this->updater->getRepoRoot() . '/.travis.yml')) {
       $messages[] = ".travis.yml has been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
-      $this->updater->executeCommand("./vendor/bin/blt recipes:ci:travis:init");
+      $this->updater->executeCommand("./vendor/bin/blt recipes:ci:travis:init", NULL, FALSE);
     }
 
     // Regenerate local settings files.
     $messages[] = "Local settings files have been updated. Review the resulting file(s) and ensure that any customizations have been re-added.";
-    $this->updater->executeCommand("./vendor/bin/blt blt:init:settings");
+    $this->updater->executeCommand("./vendor/bin/blt blt:init:settings", NULL, FALSE);
 
     $formattedBlock = $this->updater->getFormatter()->formatBlock($messages, 'ice');
     $this->updater->getOutput()->writeln("");


### PR DESCRIPTION
For some reason that I _really_ don't understand, if the callback passed to the Symfony Process prints any output, it breaks Vagrant's ability to find Virtualbox and prints spurious warnings during the update process. Instead of wasting any more time on this, seems easier to just hide the output.

Plus this makes for a much cleaner update experience, and upgrading users are hopefully more likely to read the log output that actually matters directing them to review cloud hooks, etc