### PR TITLE
Fixes #3575 to update profile split docs and functions.

### DIFF
--- a/docs/config-split.md
+++ b/docs/config-split.md
@@ -200,10 +200,7 @@ Consider that we would like site to to have different cache lifetimes then the d
 
 # Profile split
 
-If you are using multisite, you may wish to use multiple installation profiles for your application. BLT will automatically check to see if a split exists that has the same name as your active installation profile.
-
-E.g., if a given site on your application uses the `lightning` profile, BLT will set the `lightning` config split to active, if that split exists. Typically profile splits are stored in `config/profiles/[profile_name]`.
-
+BLT no longer officially supports install profile (or just profile) based splits. Our current, recommended workflow is to use the [Profile Split Enable](https://github.com/nedsbeds/profile_split_enable) module to support this capability.
 # Misc
 
 ### Exporting to a split that is not active

--- a/docs/configuration-management.md
+++ b/docs/configuration-management.md
@@ -93,7 +93,7 @@ BLT recommends using the Config Split module to manage configuration on most pro
 
 BLT uses Config Split for configuration management by default.
 
-However, BLT does not create any configuration splits for you. For detailed information on how you can create and enable configuration splits, please see [managing configuration splits](config-split.md).
+Basic environment splits are defined by default. However, we advise reading about [managing configuration splits](config-split.md).
 
 #### Troubleshooting
 

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -6,8 +6,6 @@
  */
 
 use Acquia\Blt\Robo\Common\EnvironmentDetector;
-use Acquia\Blt\Robo\Config\ConfigInitializer;
-use Symfony\Component\Console\Input\ArgvInput;
 
 /**
  * BLT makes the assumption that, if using multisite, the default configuration
@@ -92,10 +90,3 @@ $config["$split_filename_prefix.$site_dir"]['status'] = TRUE;
 if (isset($_acsf_site_name)) {
   $config["$split_filename_prefix.$_acsf_site_name"]['status'] = TRUE;
 }
-
-// Set profile split.
-$input = new ArgvInput(!empty($_SERVER['argv']) ? $_SERVER['argv'] : ['']);
-$profile_config_initializer = new ConfigInitializer($repo_root, $input);
-$profile_blt_config = $profile_config_initializer->initialize();
-$active_profile = $profile_blt_config->get('project.profile.name');
-$config["$split_filename_prefix.$active_profile"]['status'] = TRUE;

--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -57,6 +57,14 @@ class AcsfCommand extends BltTasks {
     $this->say('<comment>ACSF Tools has been added. Some post-install configuration is necessary.</comment>');
     $this->say('<comment>See /drush/Commands/acsf_tools/README.md. </comment>');
     $this->say('<info>ACSF was successfully initialized.</info>');
+    $this->say('Adding nedsbeds/profile_split_enable module as a dependency...');
+    $package_options = [
+      'package_name' => 'nedsbeds/profile_split_enable',
+      'package_version' => '^1.0',
+    ];
+    $this->invokeCommand('internal:composer:require', $package_options);
+    $this->say('<comment>nedsbeds/profile_split_enable module has been added.</comment>');
+    $this->say('<comment>Enable the module and setup profile splits to utilize.</comment>');
     $project_yml = $this->getConfigValue('blt.config-files.project');
     $project_config = YamlMunge::parseFile($project_yml);
     if (!empty($project_config['modules'])) {


### PR DESCRIPTION
Fixes #3575 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- removes profile split logic from config.settings
- adds https://github.com/nedsbeds/profile_split_enable to composer.json
- updates docs to explain that profile splits are no longer supported explicitly by BLT

