### PR TITLE
Fixes #3527: Change settings file include order.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -176,37 +176,25 @@ if (file_exists($deploy_id_file)) {
 }
 
 /**
- * Include custom global settings file.
+ * Include custom global and site-specific settings files.
  *
  * This provides an opportunity for applications to override any previous
  * configuration at a global or multisite level.
- *
- * This is being included before the CI and site specific files so all available
- * settings are able to be overridden in the includes.settings.php file below.
  */
 $settings_files[] = DRUPAL_ROOT . '/sites/settings/global.settings.php';
-
-/**
- * Include optional site specific includes file.
- *
- * This is intended for to provide an opportunity for applications to override
- * any previous configuration.
- *
- * This is being included before the local file so all available settings are
- * able to be overridden in the local.settings.php file below.
- */
 $settings_files[] = DRUPAL_ROOT . "/sites/$site_dir/settings/includes.settings.php";
 
 /**
- * Load CI env includes.
+ * Load CI environment settings.
  */
 if (EnvironmentDetector::isCiEnv()) {
   $settings_files[] = __DIR__ . '/ci.settings.php';
   if (EnvironmentDetector::getCiEnv()) {
     $settings_files[] = sprintf("%s/%s.settings.php", __DIR__, EnvironmentDetector::getCiEnv());
   }
-  // If you want to override these CI settings, use the following file.
+  // If you want to override these CI settings, use the following files.
   $settings_files[] = DRUPAL_ROOT . "/sites/settings/ci.settings.php";
+  $settings_files[] = DRUPAL_ROOT . "/sites/$site_dir/settings/ci.settings.php";
 }
 
 /**

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -186,21 +186,6 @@ if (file_exists($deploy_id_file)) {
  */
 $settings_files[] = DRUPAL_ROOT . '/sites/settings/global.settings.php';
 
-/*******************************************************************************
- * Environment-specific includes.
- ******************************************************************************/
-
-/**
- * Load CI env includes.
- */
-if (EnvironmentDetector::isCiEnv()) {
-  $settings_files[] = __DIR__ . '/ci.settings.php';
-}
-
-if (EnvironmentDetector::getCiEnv()) {
-  $settings_files[] = sprintf("%s/%s.settings.php", __DIR__, EnvironmentDetector::getCiEnv());
-}
-
 /**
  * Include optional site specific includes file.
  *
@@ -211,6 +196,18 @@ if (EnvironmentDetector::getCiEnv()) {
  * able to be overridden in the local.settings.php file below.
  */
 $settings_files[] = DRUPAL_ROOT . "/sites/$site_dir/settings/includes.settings.php";
+
+/**
+ * Load CI env includes.
+ */
+if (EnvironmentDetector::isCiEnv()) {
+  $settings_files[] = __DIR__ . '/ci.settings.php';
+  if (EnvironmentDetector::getCiEnv()) {
+    $settings_files[] = sprintf("%s/%s.settings.php", __DIR__, EnvironmentDetector::getCiEnv());
+  }
+  // If you want to override these CI settings, use the following file.
+  $settings_files[] = DRUPAL_ROOT . "/sites/settings/ci.settings.php";
+}
 
 /**
  * Load local development override configuration, if available.
@@ -232,7 +229,6 @@ if (EnvironmentDetector::isLocalEnv()) {
 
 foreach ($settings_files as $settings_file) {
   if (file_exists($settings_file)) {
-    /* @noinspection PhpIncludeInspection */
     require $settings_file;
   }
 }

--- a/settings/default.global.settings.php
+++ b/settings/default.global.settings.php
@@ -12,17 +12,17 @@
  */
 
 /**
- * Include all settings files in docroot/sites/settings.
- *
- * Any file placed directly in the docroot/sites/settings directory whose name
- * matches a glob pattern of *.settings.php will be incorporated to the settings
- * of every defined site.
+ * Include settings files in docroot/sites/settings.
  *
  * If instead you want to add settings to a specific site, see BLT's includes
  * file in docroot/sites/{site-name}/settings/default.includes.settings.php.
  */
-if ($settings_files = preg_grep('/global.settings.php/', glob(DRUPAL_ROOT . "/sites/settings/*.settings.php"), PREG_GREP_INVERT)) {
-  foreach ($settings_files as $settings_file) {
-    require $settings_file;
+$additionalSettingsFiles = [
+  // e.g,( DRUPAL_ROOT . "/sites/settings/foo.settings.php" )
+];
+
+foreach ($additionalSettingsFiles as $settingsFile) {
+  if (file_exists($settingsFile)) {
+    require $settingsFile;
   }
 }

--- a/tests/phpunit/Blt/MultiSiteTest.php
+++ b/tests/phpunit/Blt/MultiSiteTest.php
@@ -55,29 +55,29 @@ class MultiSiteTest extends BltProjectTestBase {
     $this->assertFileExists("$this->sandboxInstanceClone/docroot/sites/sites.php");
     $this->assertFileExists($this->sandboxInstanceClone . '/config/site2');
 
-    // Generate local.setting.php, copy to includes.settings.php since
+    // Generate local.setting.php, copy to ci.settings.php since
     // local.settings.php is not loaded in CI env.
     $this->blt("blt:init:settings");
     $this->fs->copy(
       "$this->sandboxInstance/docroot/sites/$this->site1Dir/settings/local.settings.php",
-      "$this->sandboxInstance/docroot/sites/$this->site1Dir/settings/includes.settings.php"
+      "$this->sandboxInstance/docroot/sites/$this->site1Dir/settings/ci.settings.php"
     );
     $this->fs->copy(
       "$this->sandboxInstance/docroot/sites/$this->site2Dir/settings/local.settings.php",
-      "$this->sandboxInstance/docroot/sites/$this->site2Dir/settings/includes.settings.php"
+      "$this->sandboxInstance/docroot/sites/$this->site2Dir/settings/ci.settings.php"
     );
 
-    // Generate local.setting.php, copy to includes.settings.php since
+    // Generate local.setting.php, copy to ci.settings.php since
     // local.settings.php is not loaded in CI env.
     // We cannot use $this->blt because we are not executing in sandbox.
     $this->execute('./vendor/bin/blt blt:init:settings', $this->sandboxInstanceClone);
     $this->fs->copy(
       "$this->sandboxInstanceClone/docroot/sites/$this->site1Dir/settings/local.settings.php",
-      "$this->sandboxInstanceClone/docroot/sites/$this->site1Dir/settings/includes.settings.php"
+      "$this->sandboxInstanceClone/docroot/sites/$this->site1Dir/settings/ci.settings.php"
     );
     $this->fs->copy(
       "$this->sandboxInstanceClone/docroot/sites/$this->site2Dir/settings/local.settings.php",
-      "$this->sandboxInstanceClone/docroot/sites/$this->site2Dir/settings/includes.settings.php"
+      "$this->sandboxInstanceClone/docroot/sites/$this->site2Dir/settings/ci.settings.php"
     );
 
     // Generate fixture.


### PR DESCRIPTION
Fixes #3527
--------

Changes proposed
---------
- CI-specific settings were included immediately before site-specific settings. Now CI settings are _after_ site settings.
- You can now override these CI settings by creating `sites/settings/ci.settings.php`
- Stop globbing settings files in `sites/settings/*.settings.php` to avoid picking up things like local.settings.php, ci.settings.php, etc... For consistency with how site-specific includes work, suggest that users define an array of files instead of globbing.

Additional details
-----------
@dpagini will this accommodate your use case? I need to know by tomorrow so we can get it into the release Wednesday. cc @greylabel since you were involved in the original discussion.