### PR TITLE
Don't replace sandbox instance every test.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,7 +24,7 @@
     <!-- E.g., `BLT_PRINT_COMMAND_OUTPUT=1 ./vendor/bin/phpunit` -->
     <env name="BLT_RECREATE_SANDBOX_MASTER" value="1"/>
     <env name="BLT_PRINT_COMMAND_OUTPUT" value="1"/>
-    <env name="BLT_REPLACE_SANDBOX_INSTANCE" value="1"/>
+    <env name="BLT_REPLACE_SANDBOX_INSTANCE" value="0"/>
     <env name="BLT_ENV" value="ci"/>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
   </php>

--- a/tests/phpunit/Blt/AcsfHooksTest.php
+++ b/tests/phpunit/Blt/AcsfHooksTest.php
@@ -46,4 +46,9 @@ class AcsfHooksTest extends BltProjectTestBase {
     // pre-settings-php/includes.php.
   }
 
+  public function tearDown() {
+    $this->sandboxManager->removeSandboxInstance();
+    parent::tearDown();
+  }
+
 }

--- a/tests/phpunit/BltProject/MultiSiteTest.php
+++ b/tests/phpunit/BltProject/MultiSiteTest.php
@@ -144,4 +144,9 @@ class MultiSiteTest extends BltProjectTestBase {
     $this->assertEquals('Site 2 Clone', $output_array['name']);
   }
 
+  public function tearDown() {
+    $this->sandboxManager->removeSandboxInstance();
+    parent::tearDown();
+  }
+
 }

--- a/tests/phpunit/BltProject/SetupCommandTest.php
+++ b/tests/phpunit/BltProject/SetupCommandTest.php
@@ -54,5 +54,10 @@ class SetupCommandTest extends BltProjectTestBase {
     $this->assertNotEmpty(file_get_contents($this->config->get('repo.root') . '/deployment_identifier'));
   }
 
-  // Sync strategy is tested is MultisiteTest.php.
+  // Sync strategy is tested in MultisiteTest.php.
+  public function tearDown() {
+    $this->sandboxManager->removeSandboxInstance();
+    parent::tearDown();
+  }
+
 }

--- a/tests/phpunit/BltProject/SimpleSamlPhpTest.php
+++ b/tests/phpunit/BltProject/SimpleSamlPhpTest.php
@@ -34,4 +34,9 @@ class SimpleSamlPhpTest extends BltProjectTestBase {
     $this->assertFileExists("{$this->config->get('docroot')}/simplesaml/saml2");
   }
 
+  public function tearDown() {
+    $this->sandboxManager->removeSandboxInstance();
+    parent::tearDown();
+  }
+
 }


### PR DESCRIPTION
Time savings are probably not worth the risk this introduces... could take a whitelist approach instead, but still probably not worth the effort to shave off a few seconds.

BLT_REPLACE_SANDBOX_INSTANCE contradicts code comment in bltprojecttestbase. if we don't change it, just get rid of refreshsandboxinstance.