### PR TITLE
Fixes #2938: Support running BLT outside of a VM.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -264,5 +264,9 @@ validate:
 vm:
   enable: false
   config: ${repo.root}/box/config.yml
+  # By default, BLT should only be run from inside a VM, if it exists. You can
+  # choose to run it on the host instead by setting this to false, and changing
+  # drush.aliases.local to an alias that can SSH into the VM.
+  blt-in-vm: true
   vagrant:
       hostname: ${project.local.hostname}

--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -22,7 +22,6 @@ class BuildCommand extends BltTasks {
    * @interactGenerateSettingsFiles
    *
    * @validateDrushConfig
-   * @validateMySqlAvailable
    * @validateDocrootIsPresent
    * @executeInVm
    *

--- a/src/Robo/Commands/Setup/DrupalCommand.php
+++ b/src/Robo/Commands/Setup/DrupalCommand.php
@@ -16,7 +16,6 @@ class DrupalCommand extends BltTasks {
    *
    * @command internal:drupal:install
    *
-   * @validateMySqlAvailable
    * @validateDrushConfig
    * @hidden
    *

--- a/src/Robo/Commands/Tests/BehatCommand.php
+++ b/src/Robo/Commands/Tests/BehatCommand.php
@@ -44,7 +44,6 @@ class BehatCommand extends TestsCommandBase {
    * @interactGenerateSettingsFiles
    * @interactInstallDrupal
    * @interactConfigureBehat
-   * @validateMySqlAvailable
    * @validateDrupalIsInstalled
    * @validateBehatIsConfigured
    * @validateVmConfig
@@ -78,7 +77,6 @@ class BehatCommand extends TestsCommandBase {
    *
    * @aliases tbd tests:behat:definitions
    *
-   * @validateMySqlAvailable
    * @executeInVm
    */
   public function behatDefinitions($options = ['mode' => 'l']) {

--- a/src/Robo/Commands/Tests/DrupalTestCommand.php
+++ b/src/Robo/Commands/Tests/DrupalTestCommand.php
@@ -96,7 +96,6 @@ class DrupalTestCommand extends TestsCommandBase {
    *
    * @interactGenerateSettingsFiles
    * @interactInstallDrupal
-   * @validateMySqlAvailable
    * @validateDrupalIsInstalled
    * @validateVmConfig
    * @launchWebServer

--- a/src/Robo/Hooks/DrupalVmHook.php
+++ b/src/Robo/Hooks/DrupalVmHook.php
@@ -3,9 +3,6 @@
 namespace Acquia\Blt\Robo\Hooks;
 
 use Acquia\Blt\Robo\BltTasks;
-use Consolidation\AnnotatedCommand\AnnotationData;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Acquia\Blt\Robo\Exceptions\BltException;
 
 /**
@@ -17,13 +14,10 @@ class DrupalVmHook extends BltTasks {
    * Ask whether user would like to execute on host machine.
    *
    * @hook interact @executeInVm
+   * @throws BltException
    */
-  public function interactExecuteOnHost(
-    InputInterface $input,
-    OutputInterface $output,
-    AnnotationData $annotationData
-  ) {
-    if (!$this->getInspector()->isVmCli() && $this->getInspector()->isDrupalVmLocallyInitialized()) {
+  public function interactExecuteOnHost() {
+    if (!$this->getInspector()->isVmCli() && $this->getInspector()->isDrupalVmLocallyInitialized() && $this->getConfigValue('vm.blt-in-vm')) {
       $this->logger->warning("Drupal VM is locally initialized, but you are not inside the VM.");
       $this->logger->warning("You should execute all BLT commands from within Drupal VM.");
       $this->logger->warning("Use <comment>vagrant ssh</comment> to enter the VM.");

--- a/src/Robo/Hooks/ValidateHook.php
+++ b/src/Robo/Hooks/ValidateHook.php
@@ -95,17 +95,6 @@ class ValidateHook implements ConfigAwareInterface, LoggerAwareInterface, Inspec
   }
 
   /**
-   * Validates that MySQL is available.
-   *
-   * @hook validate @validateMySqlAvailable
-   */
-  public function validateMySqlAvailable() {
-    if (!$this->getInspector()->isMySqlAvailable()) {
-      throw new BltException("MySql is not available. Please run `blt doctor` to diagnose the issue.");
-    }
-  }
-
-  /**
    * Validates that required settings files exist.
    *
    * @hook validate @validateSettingsFilesPresent


### PR DESCRIPTION
Fixes #2938
--------

Changes proposed
---------
- Add a configuration parameter `vm.blt-in-vm` (default: true) that you can disable if you want to run BLT on the host machine instead. This will just get rid of the warnings when you run commands on the host.
- Get rid of the validateMysqlAvailable hook, which was kind of a clumsy check to begin with. Not just in this use case, but other ones too (such as running blt commands against a remote alias). If that's really something we need, there are probably more targeted ways to do it.

Steps to replicate the issue
----------
1. Apply this patch.
2. In blt.yml, change `drush.aliases.local` to match the alias for your VM (i.e. `foo.local`)
3. In blt.yml, set `vm.blt-in-vm` to false.
4. Try running commands like `blt setup` from the host machine.