### PR TITLE
Fixes #3618 to set composer to 10.x instead of 10.x-dev.

### DIFF
--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "acquia/blt": "10.x-dev",
+        "acquia/blt": "^10.0",
         "acquia/drupal-spec-tool": "^2.0.0",
         "acquia/lightning": "^3.1.0",
         "drupal/acquia_connector": "^1.5.0",


### PR DESCRIPTION
Fixes #3618 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- sets the template composer.json to ^10.0 instead of 10.x-dev

