### PR TITLE
Fixes #3617 to force cache rebuild in drupal:update.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -35,6 +35,13 @@ class ConfigCommand extends BltTasks {
       throw new BltException("Failed to execute database updates!");
     }
 
+    $task->drush("cache-rebuild");
+    $result = $task->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Failed to execute cache-rebuild!");
+    }
+
     $this->invokeCommands(['drupal:config:import', 'drupal:toggle:modules']);
   }
 


### PR DESCRIPTION
Fixes #3617 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- adds a redundant cache rebuild to drupal:update "just in case" the updb command doesn't find database updates

