### PR TITLE
Added command to symlink to BLT from projects for development.

### DIFF
--- a/src/Robo/Commands/Blt/DevCommand.php
+++ b/src/Robo/Commands/Blt/DevCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Acquia\Blt\Robo\Commands\Blt;
+
+use Acquia\Blt\Robo\BltTasks;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Defines commands for developing BLT.
+ */
+class DevCommand extends BltTasks {
+
+  /**
+   * Links to a local BLT package via a Composer path repository.
+   *
+   * @command blt:dev:link-composer
+   * @param array $options
+   */
+  public function linkComposer($options = ['blt-path' => InputOption::VALUE_REQUIRED]) {
+    $composer_json_filepath = $this->getConfigValue('repo.root') . '/composer.json';
+    $composer_json = json_decode(file_get_contents($composer_json_filepath));
+    $composer_json->repositories->blt = [
+      'type' => 'path',
+      'url' => $options['blt-path'],
+    ];
+    $composer_json->require->{'acquia/blt'} = '*';
+
+    file_put_contents($composer_json_filepath, json_encode($composer_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    $this->taskExec('composer update acquia/blt --with-dependencies')
+      ->dir($this->getConfigValue('repo.root'))
+      ->run();
+  }
+
+  // @todo add a command to mount BLT in DrupalVM (see RoboFile::createFromSymlink for example).
+  // Problem is that the symlink placed above has to _also_ be valid within VM.
+}

--- a/src/Robo/Commands/Blt/DevCommand.php
+++ b/src/Robo/Commands/Blt/DevCommand.php
@@ -32,6 +32,4 @@ class DevCommand extends BltTasks {
       ->run();
   }
 
-  // @todo add a command to mount BLT in DrupalVM (see RoboFile::createFromSymlink for example).
-  // Problem is that the symlink placed above has to _also_ be valid within VM.
 }


### PR DESCRIPTION
When developing BLT itself or troubleshooting support issues, we often need to run a local development version of BLT. The best way to do this is via a Composer path repo, which links to BLT via a symlink.

This automates the task, which will be a real time-saver.

The other time-suck is mounting BLT within the VM in situations where we have to actually run it inside the VM. It's possible but tricky because the Composer symlink placed above has to _also_ be valid within the VM. Might be nice to have a task to automate that too, although maybe it's no longer necessary after we merge this: https://github.com/acquia/blt/pull/3613