### PR TITLE
Fixed #3618: Wrong blt version added during 10.x upgrade.

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -768,7 +768,9 @@ class Updates {
     $composer_json = $this->updater->getComposerJson();
     $template_composer_json = $this->updater->getTemplateComposerJson();
     foreach ($template_composer_json['require'] as $package_name => $package_version) {
-      $composer_json['require'][$package_name] = $package_version;
+      if (empty($composer_json['require'][$package_name])) {
+        $composer_json['require'][$package_name] = $package_version;
+      }
     }
     $this->updater->writeComposerJson($composer_json);
   }


### PR DESCRIPTION
Fixes #3618
--------

As an added bonus, I think this will prevent BLT from clobbering any different versions of packages that a project might be maintaining. I'm pretty sure that's desirable.