### PR TITLE
Deprecate RTD documentation.

### DIFF
--- a/docs/rtd-deprecated.md
+++ b/docs/rtd-deprecated.md
@@ -1,0 +1,3 @@
+BLT’s documentation on Read the Docs has been deprecated. Instead, please refer to compiled documentation on docs.acquia.com: https://docs.acquia.com/blt/
+
+You may also continue to reference source documentation or contribute to BLT’s documentation on Github.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,46 +15,4 @@ markdown_extensions:
       permalink: True
 
 pages:
-  - Home: 'index.md'
-  - Overview: 'README.md'
-  - Getting started:
-    - Installation:
-       - System requirements:  'INSTALL.md'
-       - Running BLT in Ubuntu on Bash on Windows: 'windows-install.md'
-       - Alternative LAMP stacks: 'local-development.md'
-       - Alternative Environment Tips:
-           - DDEV: 'alternative-environment-tips/ddev.md'
-           - Docksal: 'alternative-environment-tips/docksal.md'
-           - Lando: 'alternative-environment-tips/lando.md'
-    - Create a new project: 'creating-new-project.md'
-    - Add to existing project: 'adding-to-project.md'
-    - Next steps: 'next-steps.md'
-    - Updating BLT: 'updating-blt.md'
-  - Project documentation:
-    - Developer:
-          - Onboarding: 'onboarding.md'
-          - Required / Recommended Skills: 'skills.md'
-          - Repository architecture: 'repo-architecture.md'
-          - Running project tasks:
-            - Overview: 'project-tasks.md'
-            - Dependency management: 'dependency-management.md'
-            - Patches: 'patches.md'
-            - Drush: 'drush.md'
-            - Git hooks: 'git-hooks.md'
-          - Development Workflow: 'dev-workflow.md'
-          - PHPStorm setup: 'phpstorm.md'
-          - Configuration Management: 'configuration-management.md'
-          - Using Config Split: 'config-split.md'
-          - Frontend Management: 'frontend.md'
-          - Automated testing: 'testing.md'
-    - Technical Architect:
-        - Deploying to cloud: 'deploy.md'
-        - Release process: 'release-process.md'
-        - Acquia Cloud Site Factory support: 'acsf-setup.md'
-        - Setting up continuous integration: 'ci.md'
-        - Setting up SSO with SimpleSAMLphp: 'simplesamlphp-setup.md'
-        - Setting up multisite: 'multisite.md'
-        - Open source contribution: 'os-contribution.md'
-  - Extending / Overriding BLT: 'extending-blt.md'
-  - Contribution: 'CONTRIBUTING.md'
-  - Support & FAQ: 'FAQ.md'
+  - Home: 'rtd-deprecated.md'


### PR DESCRIPTION
Going forward, official compiled documentation will live on acquia.com: https://docs.acquia.com/blt/