### PR TITLE
Fixes #3617: Run cache clears for config strategy 'none'.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -200,11 +200,9 @@ class ConfigCommand extends BltTasks {
   /**
    * Checks whether core config is overridden.
    *
-   * @param string $cm_core_key
-   *
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  protected function checkConfigOverrides($cm_core_key) {
+  protected function checkConfigOverrides() {
     if (!$this->getConfigValue('cm.allow-overrides') && !$this->getInspector()->isActiveConfigIdentical()) {
       throw new BltException("Configuration in the database does not match configuration on disk. This indicates that your configuration on disk needs attention. Please read https://github.com/acquia/blt/wiki/Configuration-override-test-and-errors");
     }

--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -17,6 +17,8 @@ class ConfigCommand extends BltTasks {
    * @command drupal:update
    * @aliases du setup:update
    * @executeInVm
+   * @throws \Robo\Exception\TaskException
+   * @throws BltException
    */
   public function update() {
     $task = $this->taskDrush()
@@ -36,6 +38,9 @@ class ConfigCommand extends BltTasks {
     }
 
     $this->invokeCommands(['drupal:config:import', 'drupal:toggle:modules']);
+
+    // Clear caches to regenerate frontend assets, pick up config changes, etc.
+    $this->taskDrush()->drush("cache-rebuild")->run();
   }
 
   /**
@@ -96,7 +101,6 @@ class ConfigCommand extends BltTasks {
           break;
       }
 
-      $task->drush("cache-rebuild");
       $result = $task->run();
       if (!$result->wasSuccessful()) {
         throw new BltException("Failed to import configuration!");


### PR DESCRIPTION
Fixes #3617
--------

Changes proposed
---------
Run cache clear even if config strategy is none.
If config strategy is anything other than 'none', the only functional change is that the cache clear now happens after the post-config-import step. I doubt this will be breaking change for anyone.