### PR TITLE
Adds the --copy-links flag to copy symlinks as files.

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -365,7 +365,7 @@ class DeployCommand extends BltTasks {
 
     $this->setMultisiteFilePermissions(0777);
     $this->say("Rsyncing files from source repo into the build artifact...");
-    $this->taskExecStack()->exec("rsync -a --no-g --delete --delete-excluded --exclude-from='$exclude_list_file' '$source/' '$dest/' --filter 'protect /.git/'")
+    $this->taskExecStack()->exec("rsync -a --no-g --copy-links --delete --delete-excluded --exclude-from='$exclude_list_file' '$source/' '$dest/' --filter 'protect /.git/'")
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->stopOnFail()
       ->dir($this->getConfigValue('repo.root'))


### PR DESCRIPTION
Fixes #3635  
--------

I am integrating BLT into a project that utilizes symlinks of custom code into `docroot`. Adding this flag allows the `deploy` command to still work as expected since it treats those symlinks as files and correctly copies them into the artifact.

