### PR TITLE
Fixes #3650: Squelch Drush runserver output.

### DIFF
--- a/src/Robo/Commands/Tests/ServerCommand.php
+++ b/src/Robo/Commands/Tests/ServerCommand.php
@@ -35,7 +35,7 @@ class ServerCommand extends TestsCommandBase {
     /** @var \Acquia\Blt\Robo\Common\Executor $executor */
     $executor = $this->getContainer()->get('executor');
     $result = $executor
-      ->drush("runserver $this->serverUrl > $log_file 2>&1")
+      ->drush("runserver --quiet $this->serverUrl > $log_file 2>&1")
       ->background(TRUE)
       ->run();
 


### PR DESCRIPTION
Fixes #3650
--------

Changes proposed
---------
- Squelch output from drush runserver, which we used to do by redirecting output but need to adjust for Drush 9.6 since it no longer writes to stdout

I confirmed that this works with Drush 9.5 as well, and that it still properly captures error output with 9.6, since that still gets written to stderr.

To test, apply this patch to BLT via composer, then run `blt tests:server:run` and verify that you don't get output like `[200] /`.