### PR TITLE
Fixes #3643: Allow directory argument for Drupal phpunit tests.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -269,6 +269,7 @@ Each row under the `tests:drupal-tests` key should contain a combination of the 
  * `concurrency`
  * `dburl`
  * `die-on-fail`
+ * `directory`
  * `keep-results-table`
  * `keep-results`
  * `repeat`

--- a/src/Robo/Commands/Tests/RunTestsCommand.php
+++ b/src/Robo/Commands/Tests/RunTestsCommand.php
@@ -95,6 +95,7 @@ class RunTestsCommand extends DrupalTestCommand {
           $task->sudo();
         }
 
+        /* Boolean parameters. */
         if (isset($test['all']) && ($test['all'])) {
           $task->all();
         }
@@ -115,10 +116,6 @@ class RunTestsCommand extends DrupalTestCommand {
           $task->dieOnFail();
         }
 
-        if (isset($test['directory'])) {
-          $task->directory($test['directory']);
-        }
-
         if (isset($test['keep-results']) && ($test['keep-results'])) {
           $task->keepResults();
         }
@@ -131,6 +128,7 @@ class RunTestsCommand extends DrupalTestCommand {
           $task->suppressDeprecations();
         }
 
+        /* Integer parameters. */
         if (isset($test['concurrency']) && is_int($test['concurrency'])) {
           $task->concurrency($test['concurrency']);
         }
@@ -139,8 +137,13 @@ class RunTestsCommand extends DrupalTestCommand {
           $task->repeat($test['repeat']);
         }
 
+        /* String parameters. */
         if (isset($test['dburl'])) {
           $task->dbUrl($test['dburl']);
+        }
+
+        if (isset($test['directory'])) {
+          $task->directory($test['directory']);
         }
 
         if (isset($test['sqlite'])) {
@@ -160,6 +163,7 @@ class RunTestsCommand extends DrupalTestCommand {
           }
         }
 
+        /* Array parameters. */
         if (isset($test['tests']) && is_array($test['tests'])) {
           $task->tests($test['tests']);
         }

--- a/src/Robo/Commands/Tests/RunTestsCommand.php
+++ b/src/Robo/Commands/Tests/RunTestsCommand.php
@@ -115,6 +115,10 @@ class RunTestsCommand extends DrupalTestCommand {
           $task->dieOnFail();
         }
 
+        if (isset($test['directory'])) {
+          $task->directory($test['directory']);
+        }
+
         if (isset($test['keep-results']) && ($test['keep-results'])) {
           $task->keepResults();
         }

--- a/src/Robo/Tasks/RunTestsTask.php
+++ b/src/Robo/Tasks/RunTestsTask.php
@@ -135,16 +135,6 @@ class RunTestsTask extends BaseTask implements CommandInterface, PrintedInterfac
   }
 
   /**
-   * @param string $directory
-   *
-   * @return $this
-   */
-  public function directory($directory) {
-    $this->option("directory", $directory);
-    return $this;
-  }
-
-  /**
    * @return $this
    */
   public function keepResultsTable() {
@@ -211,6 +201,16 @@ class RunTestsTask extends BaseTask implements CommandInterface, PrintedInterfac
    */
   public function dbUrl($dbUrl) {
     $this->option("dburl", $dbUrl);
+    return $this;
+  }
+
+  /**
+   * @param string $directory
+   *
+   * @return $this
+   */
+  public function directory($directory) {
+    $this->option("directory", $directory);
     return $this;
   }
 

--- a/src/Robo/Tasks/RunTestsTask.php
+++ b/src/Robo/Tasks/RunTestsTask.php
@@ -135,6 +135,16 @@ class RunTestsTask extends BaseTask implements CommandInterface, PrintedInterfac
   }
 
   /**
+   * @param string $directory
+   *
+   * @return $this
+   */
+  public function directory($directory) {
+    $this->option("directory", $directory);
+    return $this;
+  }
+
+  /**
    * @return $this
    */
   public function keepResultsTable() {


### PR DESCRIPTION
Fixes #3643
--------

Changes proposed
---------
- Support the directory option for run-tests.sh

Additional details
-----------
@dpagini and @greylabel , would you mind reviewing?