### PR TITLE
Standardize on \Drupal instead of Drupal.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -66,7 +66,7 @@ if ($ip) {
 $repo_root = dirname(DRUPAL_ROOT);
 
 if (!isset($site_path)) {
-  $site_path = Drupal::service('site.path');
+  $site_path = \Drupal::service('site.path');
 }
 $site_dir = str_replace('sites/', '', $site_path);
 

--- a/settings/misc.settings.php
+++ b/settings/misc.settings.php
@@ -32,7 +32,7 @@ $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
  * custom code that changes the container, changing this identifier will also
  * allow the container to be invalidated as soon as code is deployed.
  */
-$settings['deployment_identifier'] = Drupal::VERSION;
+$settings['deployment_identifier'] = \Drupal::VERSION;
 $deploy_id_file = DRUPAL_ROOT . '/../deployment_identifier';
 if (file_exists($deploy_id_file)) {
   $settings['deployment_identifier'] = file_get_contents($deploy_id_file);


### PR DESCRIPTION
Looks like core has decided to standardize on `\Drupal` instead of `Drupal` even when referencing in a procedural context. This should have no functional change but just aligns with core standards. This might require an upstream change to Coder standards since I'm not sure if they are in line with this standard.