### PR TITLE
Fixes #3647: Removed stale references to failOnDirty option.

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -600,9 +600,7 @@ class RoboFile extends Tasks implements LoggerAwareInterface {
   /**
    * Checks to see if current git branch has uncommitted changes.
    *
-   * @throws \Exception
-   *   Thrown if deploy.git.failOnDirty is TRUE and there are uncommitted
-   *   changes.
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   protected function checkDirty() {
     $result = $this->taskExec('git status --porcelain')

--- a/config/build.yml
+++ b/config/build.yml
@@ -54,9 +54,6 @@ deploy:
   exclude_file: ${blt.root}/scripts/blt/deploy/deploy-exclude.txt
   exclude_additions_file: ${repo.root}/blt/deploy-exclude-additions.txt
   gitignore_file: ${blt.root}/scripts/blt/deploy/.gitignore
-  git:
-    # If true, deploys will fail if there are uncommitted changes.
-    failOnDirty: true
 
 # File and Directory locations.
 docroot: ${repo.root}/docroot

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -88,8 +88,7 @@ class DeployCommand extends BltTasks {
    * @param array $options
    *   Set ignore-dirty to false to disable checks for dirty Git directory.
    *
-   * @throws BltException Thrown if deploy.git.failOnDirty is TRUE and there are uncommitted
-   *   changes.
+   * @throws BltException Thrown if there are uncommitted changes.
    */
   public function checkDirty($options = ['ignore-dirty' => FALSE]) {
     $result = $this->taskExec('git status --porcelain')


### PR DESCRIPTION
Fixes #3647
--------

This option existed back in the Phing days, but was replaced by the `--ignore-dirty` param when we moved to Robo, and the original docs / references were never updated.