### PR TITLE
Fixes #3436: Reduce verbosity of BLT internal test output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - COMPOSER_BIN=$TRAVIS_BUILD_DIR/vendor/bin
     - BLT_DIR=$TRAVIS_BUILD_DIR
     - DRUPAL_CORE_HEAD=^8.7.0-alpha1
+    - BLT_PRINT_COMMAND_OUTPUT=0
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Fixes #3436
--------

Should reduce output by an order of magnitude. Should still display errors.

If anyone needs to debug beyond what's shown in errors they can just re-enable this variable.