### PR TITLE
Minor settings cleanup: removed unnecessary logic.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -64,7 +64,9 @@ if ($ip) {
 }
 
 $repo_root = dirname(DRUPAL_ROOT);
-/** @var $site_path **/
+if (!isset($site_path)) {
+  $site_path = 'default';
+}
 $site_dir = str_replace('sites/', '', $site_path);
 
 // Special site name detection for ACSF sites being developed locally.

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -64,7 +64,10 @@ if ($ip) {
 }
 
 $repo_root = dirname(DRUPAL_ROOT);
-/** @var $site_path **/
+/**
+ * @var $site_path
+ * This is always set and exposed by the Drupal Kernel.
+ */
 $site_dir = str_replace('sites/', '', $site_path);
 
 // Special site name detection for ACSF sites being developed locally.

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -64,10 +64,7 @@ if ($ip) {
 }
 
 $repo_root = dirname(DRUPAL_ROOT);
-
-if (!isset($site_path)) {
-  $site_path = \Drupal::service('site.path');
-}
+/** @var $site_path **/
 $site_dir = str_replace('sites/', '', $site_path);
 
 // Special site name detection for ACSF sites being developed locally.

--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -64,9 +64,7 @@ if ($ip) {
 }
 
 $repo_root = dirname(DRUPAL_ROOT);
-if (!isset($site_path)) {
-  $site_path = 'default';
-}
+/** @var $site_path **/
 $site_dir = str_replace('sites/', '', $site_path);
 
 // Special site name detection for ACSF sites being developed locally.


### PR DESCRIPTION
This conditional seems unnecessary and in fact risky. Drupal hasn't generally bootstrapped far enough at this point to allow access to the service container, so if the logic in this conditional ever actually got called it would throw an exception:
> \Drupal::$container is not initialized yet. \Drupal::setContainer() must be called with a real container.

Test this for yourself by simply setting `$site_path = null` prior to that line. Fortunately as far as I know it's not possible for `$site_path` to be undefined so this logic is never called.

Even Drupal's [default.settings.php](https://git.drupalcode.org/project/drupal/blob/8.8.x/sites/default/default.settings.php#L675) uses `$site_path` without making any such check.

If there is some kind of edge case were are trying to support here, we need clear testing steps for it, a comment in the code, and some guard code such as `if (\Drupal::hasService('kernel'))...`

Hold to verify on ACSF.