### PR TITLE
Remove stale composer files.

### DIFF
--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -151,6 +151,8 @@ class UpdateCommand extends BltTasks {
     $this->say("Removing deprecated files and directories...");
     $this->taskFilesystemStack()
       ->remove([
+        "blt/composer.required.json",
+        "blt/composer.suggested.json",
         "build",
         "docroot/sites/default/settings/apcu_fix.yml",
         "docroot/sites/default/settings/base.settings.php",


### PR DESCRIPTION
We explicitly remove composer.required.json and composer.suggested.json in the 10.0 update step, but somehow they can persist on some projects (probably due to oddities in the way that Composer runs updates).

This will ensure that they get killed. To reproduce, create such a file if it doesn't exist (`touch blt/composer.required.json`) and then run `blt blt:update` to ensure it gets deleted.