### PR TITLE
Fixes #3674 to repair site splits in 9.2.x

### DIFF
--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -99,6 +99,7 @@ if ($split != 'none') {
 $config["$split_filename_prefix.$site_dir"]['status'] = TRUE;
 
 // Set acsf site split if explicit global exists.
+global $_acsf_site_name;
 if (isset($_acsf_site_name)) {
   $config["$split_filename_prefix.$_acsf_site_name"]['status'] = TRUE;
 }


### PR DESCRIPTION
Fixes #3674
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- added a global prior to checking for the existence of the site name variable
