### PR TITLE
pipelines-deploy should fail gracefully.

### DIFF
--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -45,14 +45,14 @@ events:
     steps:
       - deploy:
           script:
-            - pipelines-deploy
+            - source ${BLT_DIR}/scripts/pipelines/pipelines_deploy_safe
   pr-merged:
     steps:
       - deploy:
           script:
-            - pipelines-deploy
+            - source ${BLT_DIR}/scripts/pipelines/pipelines_deploy_safe
   pr-closed:
     steps:
       - deploy:
           script:
-            - pipelines-deploy
+            - source ${BLT_DIR}/scripts/pipelines/pipelines_deploy_safe

--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -50,9 +50,11 @@ events:
     steps:
       - deploy:
           script:
+            - composer install --ansi
             - source ${BLT_DIR}/scripts/pipelines/pipelines_deploy_safe
   pr-closed:
     steps:
       - deploy:
           script:
+            - composer install --ansi
             - source ${BLT_DIR}/scripts/pipelines/pipelines_deploy_safe

--- a/scripts/pipelines/pipelines_deploy_safe
+++ b/scripts/pipelines/pipelines_deploy_safe
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -v
+set +e
+
+pipelines-deploy
+
+set +v


### PR DESCRIPTION
The `pipelines-deploy` command (own by Cloud / Pipelines, not BLT) can fail for a variety of benign reasons, for instance due to transient issues with AWS (500 / 504 errors). It will also fail for any customer using Pipelines but not CDEs, or when they run out of CDEs (403 errors).

In these situations, the entire Pipelines job is marked as failure, and that's a bad customer experience as it renders the automated tests basically worthless (especially if every job starts failing).

Since spinning up a CDE is a "nice to have" but not nearly as important as the outcome of Pipelines automated tests, which are rendered useless by these failures, I think we should just swallow any such errors.