### PR TITLE
Fixed config split template needs description field.

### DIFF
--- a/scripts/config-split/templates/config_split.config_split.env.yml.twig
+++ b/scripts/config-split/templates/config_split.config_split.env.yml.twig
@@ -4,6 +4,7 @@ status: true
 dependencies: {  }
 id: {{ id }}
 label: {{ name }}
+description: ''
 folder: ../config/envs/{{ id }}
 module: {  }
 theme: {  }


### PR DESCRIPTION
Changes proposed
---------
- Add a "description" field to our config_split template to account for https://www.drupal.org/node/2983364

Steps to replicate the issue
----------
1. Start with a new or existing BLT project without existing config splits
2. Run `blt recipes:config:init:splits`
3. Run `drush cim` or otherwise import the new config splits

Previous (bad) behavior, before applying PR
----------
Observe that the config split definitions are overridden, either via the config sync UI or by running `drush cim` or `cex` again. You should see the description key being perpetually overridden.

Expected behavior, after applying PR and re-running test steps
-----------
The config split definitions are no longer overridden.