### PR TITLE
DT-485: Don't optimize Composer autoloader locally.

### DIFF
--- a/src/Robo/Commands/Setup/BuildCommand.php
+++ b/src/Robo/Commands/Setup/BuildCommand.php
@@ -102,7 +102,7 @@ class BuildCommand extends BltTasks {
   public function composerInstall() {
     $result = $this->taskExec(
       (DIRECTORY_SEPARATOR == "\\") ? 'set' : 'export' .
-        " COMPOSER_EXIT_ON_PATCH_FAILURE=1 && composer install --ansi --no-interaction --optimize-autoloader --apcu-autoloader"
+        " COMPOSER_EXIT_ON_PATCH_FAILURE=1 && composer install --ansi --no-interaction"
     )
       ->dir($this->getConfigValue('repo.root'))
       ->interactive($this->input()->isInteractive())

--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -24,8 +24,6 @@
         "acquia/blt-require-dev": "^10.0.0-alpha1"
     },
     "config": {
-        "apcu-autoloader": true,
-        "optimize-autoloader": true,
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
Fixes #3591 
--------

Changes proposed
---------
- Don't optimize the autoloader locally since the Composer documentation expressly forbids doing so

To test, run `blt setup` locally and ensure that it doesn't behave any differently than before.

I also verified that this in no way interacts with https://github.com/composer/composer/pull/8085