### PR TITLE
Don't run pipelines-deploy on ACSF.

### DIFF
--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -45,14 +45,14 @@ events:
     steps:
       - deploy:
           script:
-            - if [ PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi
+            - if [ $PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi
   pr-merged:
     steps:
       - deploy:
           script:
-            - if [ PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi
+            - if [ $PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi
   pr-closed:
     steps:
       - deploy:
           script:
-            - if [ PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi
+            - if [ $PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi

--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -45,14 +45,14 @@ events:
     steps:
       - deploy:
           script:
-            - pipelines-deploy
+            - if [ PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi
   pr-merged:
     steps:
       - deploy:
           script:
-            - pipelines-deploy
+            - if [ PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi
   pr-closed:
     steps:
       - deploy:
           script:
-            - pipelines-deploy
+            - if [ PIPELINE_CLOUD_REALM != "enterprise-g1" ]; then pipelines-deploy; fi


### PR DESCRIPTION
Changes proposed
---------
- When Pipelines is run in an ACSF subscription, don't run `pipelines-deploy` because CD environments cannot exist on ACSF, and this command will always fail.
