### PR TITLE
DT-483: Disable interactive input on vm command.

### DIFF
--- a/src/Robo/Commands/Composer/ComposerCommand.php
+++ b/src/Robo/Commands/Composer/ComposerCommand.php
@@ -26,8 +26,12 @@ class ComposerCommand extends BltTasks {
       ->printOutput(TRUE)
       ->printMetadata(TRUE)
       ->dir($this->getConfigValue('repo.root'))
-      ->interactive($this->input()->isInteractive())
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE);
+
+    if ('\\' !== DIRECTORY_SEPARATOR) {
+      $task->interactive($this->input()->isInteractive());
+    }
+
     if ($options['dev']) {
       $task->dev(TRUE);
     }

--- a/src/Robo/Commands/Composer/ComposerCommand.php
+++ b/src/Robo/Commands/Composer/ComposerCommand.php
@@ -27,7 +27,6 @@ class ComposerCommand extends BltTasks {
       ->printMetadata(TRUE)
       ->dir($this->getConfigValue('repo.root'))
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE);
-
     if ($options['dev']) {
       $task->dev(TRUE);
     }

--- a/src/Robo/Commands/Composer/ComposerCommand.php
+++ b/src/Robo/Commands/Composer/ComposerCommand.php
@@ -28,10 +28,6 @@ class ComposerCommand extends BltTasks {
       ->dir($this->getConfigValue('repo.root'))
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE);
 
-    if ('\\' !== DIRECTORY_SEPARATOR) {
-      $task->interactive($this->input()->isInteractive());
-    }
-
     if ($options['dev']) {
       $task->dev(TRUE);
     }

--- a/src/Robo/Commands/Vm/VmCommand.php
+++ b/src/Robo/Commands/Vm/VmCommand.php
@@ -34,7 +34,8 @@ class VmCommand extends BltTasks {
    */
   public function initialize() {
     $this->drupalVmAlias = $this->getConfigValue('project.machine_name') . '.local';
-    $this->drupalVmVersionConstraint = '^5.0';
+    // Use tilde instead of more traditional caret version to avoid Windows bug.
+    $this->drupalVmVersionConstraint = '~5.0';
     $this->defaultDrupalVmDrushAliasesFile = $this->getConfigValue('blt.root') . '/scripts/drupal-vm/drupal-vm.site.yml';
     $this->defaultDrupalVmConfigFile = $this->getConfigValue('blt.root') . '/scripts/drupal-vm/config.yml';
     $this->defaultDrupalVmVagrantfile = $this->getConfigValue('blt.root') . '/scripts/drupal-vm/Vagrantfile';


### PR DESCRIPTION
Fixes #3637
--------

Changes proposed
---------
- Don't explicitly set interactivity when running Composer commands. Rely on Robo's built-in interactivity detection instead.

Steps to replicate the issue
----------
1. Start with a project without a VM or drupal-vm dependency installed, using Windows.
2. Run `blt vm`

Previous (bad) behavior, before applying PR
----------
Process crashes with error `TTY mode is not supported on Windows platform.`

Expected behavior, after applying PR and re-running test steps
-----------
Process completes

Additional details
-----------
I don't know why we explicitly set interaction in the first place. It doesn't seem like it should be necessary, and I could find no comments in issues or code as to why we do it. Removing it seems to have no ill effect, I tested by running commands with and without `--no-interaction` and ensuring they still behave as expected.