### PR TITLE
Work around Drush 9.5 bug with path based domains

### DIFF
--- a/scripts/factory-hooks/db-update/db-update.sh
+++ b/scripts/factory-hooks/db-update/db-update.sh
@@ -18,7 +18,8 @@ site="$1"
 env="$2"
 # database role. (Not expected to be needed in most hook scripts.)
 db_role="$3"
-# The public domain name of the website.
+# The public domain name of the website. If the site uses a path based domain,
+# the path is appended (without trailing slash), e.g. "domain.com/subpath".
 domain="$4"
 
 # BLT executable:
@@ -44,6 +45,9 @@ echo "Generated temporary drush cache directory: $cacheDir."
 # Print to cloud task log.
 echo "Running BLT deploy tasks on $uri domain in $env environment on the $site subscription."
 
-DRUSH_PATHS_CACHE_DIRECTORY=$cacheDir $blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain --verbose --no-interaction
+# Update Drupal. The trailing slash behind the domain works around a bug in
+# Drush < 9.6 for path based domains: "domain.com/subpath/" is considered a
+# valid URI but "domain.com/subpath" is not.
+DRUSH_PATHS_CACHE_DIRECTORY=$cacheDir $blt drupal:update --environment=$env --site=${name[0]} --define drush.uri=$domain/ --verbose --no-interaction
 
 set +v


### PR DESCRIPTION
Fixes # (Acquia internally reported issues, possibly)
--------

Changes proposed
---------
Add slash to ACSF db-update.sh hook so that path domains should be able to work with Drush 9.3 / 4 / 5 (I believe Drush 9.2 and older will never work. Not sure anymore. Drush8 works fine.)

Steps to replicate the issue
----------
1. Have codebase with Drush 9.5; have ACSF site with path based domain
2. Update code.

Previous (bad) behavior, before applying PR
----------
Likely: error related to database "default" not being found?

Expected behavior, after applying PR and re-running test steps
-----------
Normal update.

Additional details
-----------
I filled in the template but actually details were discussed with @danepowell in internal tickets.