### PR TITLE
Cleaned up test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,8 @@ matrix:
     - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
     - { name: "Integrated test w/ dev package versions & next minor dev version of Drupal core", env: ORCA_JOB=CORE_NEXT }
     # Custom jobs.
-    - { env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal,long,requires-vm' }
-    - { env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='long' PHPUNIT_EXCLUDE_GROUP='drupal,requires-vm' }
-    - { env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal' PHPUNIT_EXCLUDE_GROUP='long,requires-vm' }
+    - { env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal'}
+    - { env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'}
     - { env: DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD }
   allow_failures:
     - env: ORCA_JOB=ISOLATED_DEV

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
     - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
     - { name: "Integrated test w/ dev package versions & next minor dev version of Drupal core", env: ORCA_JOB=CORE_NEXT }
     # Custom jobs.
-    - env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal'
+    - env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal,requires-vm'
   allow_failures:
     - env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'
     - env: DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ matrix:
     - { name: "Integrated test w/ dev package versions & next minor dev version of Drupal core", env: ORCA_JOB=CORE_NEXT }
     # Custom jobs.
     - env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal'
-    - env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'
   allow_failures:
+    - env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'
     - env: DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
     - env: ORCA_JOB=ISOLATED_DEV
     - env: ORCA_JOB=INTEGRATED_DEV

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,14 +47,16 @@ matrix:
     - { name: "Integrated test w/ dev package versions & next minor dev version of Drupal core", env: ORCA_JOB=CORE_NEXT }
     # Custom jobs.
     - env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal,requires-vm'
-  allow_failures:
     - env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'
+    - env: DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
+  allow_failures:
     - env: DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
     - env: ORCA_JOB=ISOLATED_DEV
     - env: ORCA_JOB=INTEGRATED_DEV
     - env: ORCA_JOB=CORE_NEXT
     # Temporary allowances.
     - env: ORCA_JOB=DEPRECATED_CODE_SCAN_SUT
+    - env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'
 
 before_install:
   # Exit build early if only documentation was changed in a Pull Request.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     # Custom configuration.
     - COMPOSER_BIN=$TRAVIS_BUILD_DIR/vendor/bin
     - BLT_DIR=$TRAVIS_BUILD_DIR
-    - DRUPAL_CORE_HEAD=^8.7.0-alpha1
+    - DRUPAL_CORE_HEAD=8.8.x-dev
     - BLT_PRINT_COMMAND_OUTPUT=0
 
 matrix:
@@ -46,10 +46,10 @@ matrix:
     - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
     - { name: "Integrated test w/ dev package versions & next minor dev version of Drupal core", env: ORCA_JOB=CORE_NEXT }
     # Custom jobs.
-    - { env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal'}
-    - { env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'}
-    - { env: DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD }
+    - env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal'
+    - env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'
   allow_failures:
+    - env: DRUPAL_CORE_VERSION=$DRUPAL_CORE_HEAD
     - env: ORCA_JOB=ISOLATED_DEV
     - env: ORCA_JOB=INTEGRATED_DEV
     - env: ORCA_JOB=CORE_NEXT


### PR DESCRIPTION
I found the way we'd defined the test matrix to be really hard to reason through, and predict what's going to run. It also contains a lot of cruft, plus now Drupal tests are completely broken due to #3704. So here are a few changes:

- Remove all references to the 'long' group since we don't define any tests in that group
- Remove all references to the 'requires-vm' group since that's already excluded by default in phpunit.xml, except when we're resetting PHPUNIT_EXCLUDE_GROUP
- Allow Drupal tests to fail because there's no way we can fix them for now
- Change the Drupal core HEAD version of 8.8.x and allow it to fail since that's very bleeding-edge and not supported by BLT 10.