### PR TITLE
Remove RTD references from README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 BLT (Build and Launch Tool) provides an automation layer for testing, building, and launching Drupal 8 applications.
 
-You can find compiled BLT documentation on [docs.acquia.com](https://docs.acquia.com/blt):
+You can find compiled BLT documentation on [docs.acquia.com](https://docs.acquia.com/blt).
 
 ## Getting started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,14 +2,11 @@
 
 ![BLT logo of stylized sandwich](https://github.com/acquia/blt/raw/10.x/docs/blt-logo.png)
 
-[![Build Status](https://travis-ci.com/acquia/blt.svg?branch=10.x)](https://travis-ci.com/acquia/blt) [![Documentation Status](https://readthedocs.org/projects/blt/badge/?version=10.x)](http://blt.readthedocs.io/en/10.x/?badge=10.x) [![Packagist](https://img.shields.io/packagist/v/acquia/blt.svg)](https://packagist.org/packages/acquia/blt) [![Stories in Ready](https://badge.waffle.io/acquia/blt.png?label=ready&title=Ready)](http://waffle.io/acquia/blt)
+[![Build Status](https://travis-ci.com/acquia/blt.svg?branch=10.x)](https://travis-ci.com/acquia/blt) [![Packagist](https://img.shields.io/packagist/v/acquia/blt.svg)](https://packagist.org/packages/acquia/blt) 
 
 BLT (Build and Launch Tool) provides an automation layer for testing, building, and launching Drupal 8 applications.
 
-You can find all BLT documentation on [Read the Docs](http://blt.readthedocs.io):
-
-* [Latest release documentation (10.x)](http://blt.readthedocs.io/en/latest/) (best for guidance on general issues and best practices)
-* [Previous release documentation (9.2.x)](http://blt.readthedocs.io/en/stable/) (best for features specific to 9.2.x)
+You can find compiled BLT documentation on [docs.acquia.com](https://docs.acquia.com/blt):
 
 ## Getting started
 


### PR DESCRIPTION
We were going to wait to remove references from docs files, but I guess we should at least fix this since it's on the front page.