### PR TITLE
Fixes #3704: Pin Chromedriver to 74 on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ matrix:
     - env: ORCA_JOB=CORE_NEXT
     # Temporary allowances.
     - env: ORCA_JOB=DEPRECATED_CODE_SCAN_SUT
-    - env: DRUPAL_CORE_VERSION=default PHPUNIT_GROUP='drupal'
 
 before_install:
   # Exit build early if only documentation was changed in a Pull Request.

--- a/scripts/linux/install-chrome.sh
+++ b/scripts/linux/install-chrome.sh
@@ -14,7 +14,10 @@ if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 
   # Installs chromedriver for Linux 64 bit systems.
   LATEST_CHROMEDRIVER=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
-  wget -N http://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER/chromedriver_linux64.zip
+  # wget -N http://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER/chromedriver_linux64.zip
+  # Temporarily pin to Chromedriver 74.
+  # @see https://github.com/acquia/blt/issues/3704
+  wget -N https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
   unzip chromedriver_linux64.zip
   chmod +x chromedriver
   mv -f chromedriver $BIN_DIR

--- a/scripts/linux/install-chrome.sh
+++ b/scripts/linux/install-chrome.sh
@@ -13,11 +13,11 @@ if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   # apt-get -f install
 
   # Installs chromedriver for Linux 64 bit systems.
-  LATEST_CHROMEDRIVER=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
-  # wget -N http://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER/chromedriver_linux64.zip
   # Temporarily pin to Chromedriver 74.
   # @see https://github.com/acquia/blt/issues/3704
-  wget -N https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+  # CHROMEDRIVER_VERSION=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+  [ -z "$CHROMEDRIVER_VERSION" ] && CHROMEDRIVER_VERSION=74.0.3729.6
+  wget -N https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
   unzip chromedriver_linux64.zip
   chmod +x chromedriver
   mv -f chromedriver $BIN_DIR


### PR DESCRIPTION
Fixes #3704 
--------

Changes proposed
---------
- Chromedriver 75 introduces a breaking change that makes it impossible to run Drupal core tests, as well as many other Behat tests. Pin to 74 until that's resolved.

Steps to replicate the issue
----------
1. See that all of our tests (for PHPUNIT_GROUP=drupal) were previously failing, and now pass with this PR.