### PR TITLE
Fixes #3684 BLT docs to add KB article

### DIFF
--- a/docs/config-split.md
+++ b/docs/config-split.md
@@ -1,15 +1,10 @@
 # Config Split
 
-This covers common use cases for using configuration splits as a strategy for configuration management in Drupal 8. Specifically, it covers:
+Config Split is the "standard" Configuration Management Strategy provided by BLT. BLT does support other options for configuration management (or none at all). See [Configuration Management](configuration-management.md)).
 
-- Default application configuration
-- Environment specific configuration (e.g., local, data, test, prod, etc.)
-- Site-specific configuration (when multisite is used)
-- Profile-specific split (when multisite and multiple profiles are used)
-- "Feature" specific configuration (e.g., a distinct blog feature that is shared across multiple sites). Not to be confused with the features module.
-- Miscellaneous troubleshooting information
+For additional details, please review the [Managing Configuration with Config Split](https://support.acquia.com/hc/en-us/articles/360024009393) article on the Acquia Knowledge Base.
 
-# Scenario Background
+# Example Scenarios
 
 For the sake of this tutorial, let's assume that we have a "kitchen sink" site that requires all of these types of splits. It is a multisite application and it will be hosted in multiple environments, which must share some default configuration between all sites. It also must allow some features (like a blog) to be enabled on some sites and not others.
 
@@ -245,10 +240,9 @@ To disable the plug-in discovery cache, add the following to your local.settings
 
 This will obviate the need to clear caches in order to register a status change in a configuration split.
 
-
 # Resources
 
 * [blog post by Jeff Geerling](https://www.jeffgeerling.com/blog/2017/adding-configuration-split-drupal-site-using-blt-and-acquia-cloud)
-* [BLT multisite documentation](http://blt.readthedocs.io/en/latest/readme/multisite/)
+* [BLT Multisite Documentation](multisite.md)
 * [Configuration split](https://www.drupal.org/project/config_split)
 * [Configuration ignore](https://www.drupal.org/project/config_ignore)

--- a/docs/configuration-management.md
+++ b/docs/configuration-management.md
@@ -3,7 +3,7 @@
 
 BLT supports several methods of configuration management (CM) in Drupal 8. All of these rely to varying degrees on Drupal core's configuration entities, which can be "imported" into a database or "exported" to disk as yml files.
 
-BLT _strongly recommends_ a CM workflow based on the [Configuration Split](https://www.drupal.org/project/config_split) module, as described below. For most projects, this strikes the best balance of flexibility, reliability, and ease of maintenance and development. This document will also describe a Features-based workflow (analogous to most CM workflows in Drupal 7) that can better accomodate certain multisite architectures, but generally has a much higher development and maintenance overhead.
+BLT _strongly recommends_ a CM workflow based on the [Configuration Split](https://www.drupal.org/project/config_split) module, as described on the [Acquia Knowledge Base](https://support.acquia.com/hc/en-us/articles/360024009393). For most projects, this strikes the best balance of flexibility, reliability, and ease of maintenance and development. This document will also describe a Features-based workflow (analogous to most CM workflows in Drupal 7) that can better accommodate certain multisite architectures, but generally has a much higher development and maintenance overhead.
 
 ## General principles
 
@@ -13,7 +13,7 @@ This section describes aspects of BLT's development and deployment process that 
 
 The primary goal of configuration management is to ensure that all configuration changes can be reviewed, tested, and predictably deployed to production environments. Some simple changes, such as changing a site's name or slogan, might have limited, atomic, and predictable effects, and therefore not require strict change management. Other types of changes, such as modifying field storage schemas, _always_ need to go through a review process. Additionally, different projects might have different degrees of risk tolerance. For instance, some might prefer that configuration be strictly read-only in production, prohibiting even the simple site name change above.
 
-A good CM workflow should be flexible enough to accomodate either of these use cases, and make it easy for developers to make and capture configuration changes, review and test these changes, and reliably deploy these changes to a remote environment.
+A good CM workflow should be flexible enough to accommodate either of these use cases, and make it easy for developers to make and capture configuration changes, review and test these changes, and reliably deploy these changes to a remote environment.
 
 Generally speaking, a configuration change follows this lifecycle:
 
@@ -78,28 +78,15 @@ Finally, you should enable protected branches in GitHub to ensure that pull requ
 
 For an ongoing discussion of how to ensure configuration integrity, see https://www.drupal.org/node/2869910
 
-## Configuration Split workflow
+## Configuration Split Workflow
 
-### Overview
-
-BLT recommends using the Config Split module to manage configuration on most projects. It will allow you to split your application configuration into different groups according to:
-
-* Default (always on) application configuration
-* Environment specific configuration (e.g., local, data, test, prod, etc.)
-* Site-specific configuration (when multisite is used)
-* Feature (e.g., a distinct blog feature that is shared across multiple sites). Not to be confused with the features module.
-
-### Using Config Split
-
-BLT uses Config Split for configuration management by default.
-
-Basic environment splits are defined by default. However, we advise reading about [managing configuration splits](config-split.md).
+More information can be found in the article [Managing Configuration with Config Split](https://support.acquia.com/hc/en-us/articles/360024009393) on the Acquia Knowledge Base.
 
 #### Troubleshooting
 
 If for some reason BLT is not working with Config Split, ensure that you are using Drush version 8.1.10 or higher, Config Split version 8.1.0-beta4 or higher, and that `cm.strategy` is set to `config-split` in `blt/blt.yml`.
 
-### Using update hooks to importing individual config files
+## Using update hooks to importing individual config files
 
 BLT runs module update hooks before importing configuration changes. For use cases where it is necessary for a configuration change to be imported before the update hook runs, in your hook, you'll need to import the needed configuration from files first. (An example of this would be adding a new taxonomy vocabulary via config, and populating that vocabulary with terms in an update hook.)
 


### PR DESCRIPTION
Fixes #3684 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- removes "some" config split documentation from BLT docs
- links to https://support.acquia.com/hc/en-us/articles/360024009393
- some cleanup for spelling, links, etc.
