### PR TITLE
Preserve comments in blt.yml on project creation.

### DIFF
--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -3,7 +3,6 @@
 namespace Acquia\Blt\Robo\Commands\Blt;
 
 use Acquia\Blt\Robo\BltTasks;
-use Acquia\Blt\Robo\Common\YamlMunge;
 use Acquia\Blt\Robo\Common\YamlWriter;
 use Acquia\Blt\Robo\Config\ConfigInitializer;
 use Acquia\Blt\Robo\Exceptions\BltException;

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -4,6 +4,7 @@ namespace Acquia\Blt\Robo\Commands\Blt;
 
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\YamlMunge;
+use Acquia\Blt\Robo\Common\YamlWriter;
 use Acquia\Blt\Robo\Config\ConfigInitializer;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Acquia\Blt\Update\Updater;
@@ -369,16 +370,15 @@ class UpdateCommand extends BltTasks {
   }
 
   /**
-   * Sets project.name using the directory name of repot.root.
-   *
-   * @return \Robo\Result
+   * Sets project.name using the directory name of repo.root.
    */
   protected function setProjectName() {
     $project_name = basename($this->getConfigValue('repo.root'));
     $project_yml = $this->getConfigValue('blt.config-files.project');
-    $project_config = YamlMunge::parseFile($project_yml);
+    $yamlWriter = new YamlWriter($project_yml);
+    $project_config = $yamlWriter->getContents();
     $project_config['project']['machine_name'] = $project_name;
-    YamlMunge::writeFile($project_yml, $project_config);
+    $yamlWriter->write($project_config);
   }
 
 }

--- a/src/Robo/Common/YamlWriter.php
+++ b/src/Robo/Common/YamlWriter.php
@@ -45,6 +45,7 @@ class YamlWriter {
     $commentManager->collect(explode("\n", $this->contents));
     $alteredWithComments = $commentManager->inject(explode("\n", $alteredContents));
     $result = implode("\n", $alteredWithComments);
+    $result .= "\n";
     file_put_contents($this->filepath, $result);
   }
 

--- a/subtree-splits/blt-project/blt/blt.yml
+++ b/subtree-splits/blt-project/blt/blt.yml
@@ -1,49 +1,37 @@
 # This file contains your BLT configuration. For a list of all available
 # properties with current values run `blt config:dump`. Default values come
 # from vendor/acquia/blt/config/build.yml.
-
 project:
   # Everyone: This will determine the the directory name of the new repository.
   # Dev Desktop users: this should match your local site name.
-  machine_name: 'blted10'
+  machine_name: blted10
   # Used for enforcing correct git commit msg syntax.
-  prefix: 'BLT'
+  prefix: BLT
   human_name: 'BLTed 10'
   profile:
-    name: 'lightning'
+    name: lightning
   # This will be used as the local uri for all developers.
   local:
     protocol: http
-    hostname: local.${project.machine_name}.com
-
+    hostname: 'local.${project.machine_name}.com'
 # Configuration settings for new git repository.
 git:
   default_branch: master
-  remotes: []
-
+  remotes: {  }
 deploy:
   # When manually deploying a tag, also tag the source repository.
-  tag_source: TRUE
-
+  tag_source: true
 drush:
   # You can set custom project aliases in drush/sites/*.site.yml.
   aliases:
     # The remote environment from which the database will be pulled.
-    remote: ${project.machine_name}.test
+    remote: '${project.machine_name}.test'
     # The local environment against which all local drush commands are run.
-    local: 'self'
+    local: self
     # The drush alias against which all ci commands are run.
-    ci: 'self'
+    ci: self
     # The default drush alias to be used when no environment is specified.
-  default_alias: ${drush.aliases.local}
-
-# Configuration management options, such as core CM or features.
-# cm:
-#   features:
-#     bundle:
-#       - blted8
-#     no-overrides: 'true'
-
+  default_alias: '${drush.aliases.local}'
 # An array of modules to be enabled or uninstalled automatically in local, ci,
 # and deploy contexts.
 modules:
@@ -57,7 +45,7 @@ modules:
       - acquia_connector
       - shield
   ci:
-    enable: []
+    enable: {  }
     uninstall:
       - acquia_connector
       - shield
@@ -65,7 +53,7 @@ modules:
     enable:
       - acquia_connector
       - shield
-    uninstall: []
+    uninstall: {  }
   test:
     enable:
       - acquia_connector


### PR DESCRIPTION
We have all of these lovely and helpful comments in our template blt.yml file, but it's likely that almost no one sees them because they get stripped when a new BLT project is created. This preserves them.

To test this, start with a BLT-based project. Copy the default blt.yml from subtree-splits/blt-project/blt/blt.yml into your project. Finally run `blt internal:create-project --no-interaction` to simulate what would happen if you were creating a new project from scratch.

Without this PR, you should see that comments are lost, and additionally a lot of reformatting takes place since the template blt.yml doesn't match the Yaml formatter style. If you link the dev version of BLT from this PR, or apply it as a patch, and re-run those steps, you'll see that comments are preserved.