### PR TITLE
Add isset check on $_SERVER['PWD'] in find_repo_root()

### DIFF
--- a/bin/blt-robo.php
+++ b/bin/blt-robo.php
@@ -20,11 +20,14 @@ require_once __DIR__ . '/blt-robo-run.php';
  */
 function find_repo_root() {
   $possible_repo_roots = [
-    $_SERVER['PWD'],
     getcwd(),
     realpath(__DIR__ . '/../'),
     realpath(__DIR__ . '/../../../'),
   ];
+      // Check for PWD - some local environments will not have this key.
+    if (isset($_SERVER['PWD'])) {
+        array_unshift($possible_repo_roots, $_SERVER['PWD']);
+    }
   foreach ($possible_repo_roots as $possible_repo_root) {
     if ($repo_root = find_directory_containing_files($possible_repo_root, ['vendor/bin/blt', 'vendor/autoload.php'])) {
       return $repo_root;


### PR DESCRIPTION
This addresses https://github.com/acquia/blt/issues/3715

Not all local environments declare a $_SERVER['PWD'] superglobal and this results in a PHP Notice that wrecks numerous BLT commands. This fails, for instance, in Lando environments. This should be made agnostic so that $_SERVER['PWD'] is only included as a possible_repo_root if declared.

Fixes # .

Changes proposed:

Remove $_SERVER['PWD'] from $possible_repo_roots
Add an isset check to $_SERVER['PWD']
if set, add $_SERVER['PWD'] to $possible_repo_roots via array_unshift to maintain the original array order.