### PR TITLE
DT-485: Update hook for composer autoload change.

### DIFF
--- a/src/Update/Updater.php
+++ b/src/Update/Updater.php
@@ -444,7 +444,7 @@ class Updater {
       ksort($contents['require-dev']);
       $contents['require-dev'] = (object) $contents['require-dev'];
     }
-    file_put_contents($this->composerJsonFilepath, json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    file_put_contents($this->composerJsonFilepath, json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
   }
 
   /**

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -789,4 +789,19 @@ class Updates {
     }
   }
 
+  /**
+   * 10.1.0.
+   *
+   * @Update(
+   *    version = "10001000",
+   *    description = "Remove composer autoload optimizations."
+   * )
+   */
+  public function update_10001000() {
+    $composer_json = $this->updater->getComposerJson();
+    unset($composer_json['config']['apcu-autoloader']);
+    unset($composer_json['config']['optimize-autoloader']);
+    $this->updater->writeComposerJson($composer_json);
+  }
+
 }


### PR DESCRIPTION
Follow-up to #3692
--------

Changes proposed
---------
- Automatically update existing users' composer.json to incorporate change from #3692
- Add a newline when writing composer.json files (they have a newline by default, and all files should have a newline per code standards)

Steps to replicate the issue
----------
1. Start with a project generated by BLT version 10.0 or earlier, which has the old config keys.
2. Run `blt blt:update` and see that the keys are removed.

Requires a change record because people might not understand why these keys are getting removed and get alarmed that we are removing "optimizations".