### PR TITLE
Fixes #3722 to add a config-status command.

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -203,6 +203,13 @@ class ConfigCommand extends BltTasks {
    */
   protected function checkConfigOverrides() {
     if (!$this->getConfigValue('cm.allow-overrides') && !$this->getInspector()->isActiveConfigIdentical()) {
+      $task = $this->taskDrush()
+        ->stopOnFail()
+        ->drush("config-status");
+      $result = $task->run();
+      if (!$result->wasSuccessful()) {
+        throw new BltException("Unable to determine configuration status.");
+      }
       throw new BltException("Configuration in the database does not match configuration on disk. This indicates that your configuration on disk needs attention. Please read https://github.com/acquia/blt/wiki/Configuration-override-test-and-errors");
     }
   }


### PR DESCRIPTION
Fixes #3722 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- adds `drush config-status` to checkConfigOverrides

Steps to replicate the issue
----------
1. run `blt setup` on a site that has config out of sync
2. confirm that when checkConfigOverrides it tells you "what" fails and not just the current messaging that `Configuration in the database does not match configuration on disk. BLT has attempted to automatically fix this by re-exporting configuration to disk. Please read https://github.com/acquia/blt/wiki/Configuration-override-test-and-errors 
`

Most Straight Forward way to test this is to edit an entity display config file (after `blt setup`) and delete out the "hidden" fields. For some reason, these refuse to import properly during `blt drupal:update`