### PR TITLE
Correcting hosting type check, to generate aliases.

### DIFF
--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -266,7 +266,7 @@ class AliasesCommand extends BltTasks {
       $remoteHost = $ssh_split[1];
       $remoteUser = $ssh_split[0];
 
-      if ($hosting == 'ace') {
+      if (in_array($hosting, ['ace', 'acp'])) {
 
         $siteID = $site_split[1];
         $uri = $env->domains[0];


### PR DESCRIPTION
Fixes #3727  
--------

Changes proposed
---------
When reading hosting type, include `acp`

Steps to replicate the issue
----------
1. Be on a `ACP` hosting type.
2. Generate aliases by using command `blt recipes:aliases:init:acquia`

Previous (bad) behavior, before applying PR
----------
The aliases wont generate

Expected behavior, after applying PR and re-running test steps
-----------
The aliases are generated for `acp` hosting type

Additional details
-----------
None.