### PR TITLE
Remove acsf-tools from being required by default for acsf projects.

### DIFF
--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -48,14 +48,6 @@ class AcsfCommand extends BltTasks {
     $this->invokeCommand('internal:composer:require', $package_options);
     $this->say("In the future, you may pass in a custom value for acsf-version to override the default version, e.g., blt recipes:acsf:init:all --acsf-version='8.1.x-dev'");
     $this->acsfDrushInitialize();
-    $this->say('Adding acsf-tools drush module as a dependency...');
-    $package_options = [
-      'package_name' => 'acquia/acsf-tools',
-      'package_version' => 'dev-9.x-dev',
-    ];
-    $this->invokeCommand('internal:composer:require', $package_options);
-    $this->say('<comment>ACSF Tools has been added. Some post-install configuration is necessary.</comment>');
-    $this->say('<comment>See /drush/Commands/acsf_tools/README.md. </comment>');
     $this->say('<info>ACSF was successfully initialized.</info>');
     $this->say('Adding nedsbeds/profile_split_enable module as a dependency...');
     $package_options = [


### PR DESCRIPTION
Changes proposed
---------
ACSF tools is not an official Acquia project and neither support nor the ACSF engineering team are able to assist customers when they run into issues, nor is it recommended by the ACSF team. As it has caused significant issues in support, BLT should not include acsf-tools by default when running the `blt acsf` command.

The PR removes the package, so once merged the BLT release notes should likely call out that customers who wish to continue using the toolset should `composer require acquia/acsf-tools` in their root project composer.json. 

