### PR TITLE
Added some clarifying language to Install.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -86,9 +86,13 @@ Linux is fully supported by BLT and DrupalVM and shares many of the same depende
 
 # Installing BLT
 
-Choose your own adventure:
+After you have successfully installed the prerequisites, you can now proceed with installing BLT.
 
 * [Creating a new project with BLT](creating-new-project.md)
-* [Cloning an existing BLT project](onboarding.md)
 * [Adding BLT to an existing project](adding-to-project.md)
+
+If BLT is already setup for a project and you need instructions on how to get started please see:
+* [Cloning an existing BLT project](onboarding.md)
+
+If you are trying to update Acquia BLT please see:
 * [Upgrading BLT](updating-blt.md)


### PR DESCRIPTION
Changes proposed
---------
The documentation for BLT on [Acquia Docs](https://docs.acquia.com/blt/install/) has slightly diverged from the docs in this repo. Some wording has been changed there and implies that the user has installed BLT when they have actually just installed the prerequisites. In an effort to clarify this documentation I've open a ticket and PR for the Docs team and now doing the same here.

In this PR, the changes made are after the System Requirements and are to help a user more clearly understand what the next steps are with installing BLT.

Additional details
-----------
- https://docs.acquia.com/blt/install/
- https://backlog.acquia.com/browse/DOC-19034