### PR TITLE
Bump PHP version in use on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: php
 
-php: "7.1"
+php: "7.2"
 
 addons:
   chrome: stable


### PR DESCRIPTION
In light of the fact that Acquia will be retiring support for PHP 7.1 on October 1, the ORCA product team has decided to increase the PHP version in use on ORCA tests to 7.2 today. If you wish to run non-default jobs on another version of PHP, you can do so via matrix settings, e.g.:

```yaml
matrix:
  include:
    - { name: "PHP 7.1 job", env: SOME_VARIABLE=1, php: "7.1" }
```