### PR TITLE
DT-605: Use account() to test cloud api auth.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/twig-bridge": "^3.3",
         "symfony/yaml": "^3.2.8",
         "tivie/php-os-detector": "^1.0",
-        "typhonius/acquia-php-sdk-v2": "^1.0.3",
+        "typhonius/acquia-php-sdk-v2": "^1.0.4",
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe908fd36bb56c6770b4cc324eba501f",
+    "content-hash": "2d930b94fffdec75382a45f068c7161a",
     "packages": [
         {
             "name": "acquia/http-hmac-php",
@@ -5844,7 +5844,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -6854,16 +6854,16 @@
         },
         {
             "name": "typhonius/acquia-php-sdk-v2",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/typhonius/acquia-php-sdk-v2.git",
-                "reference": "2e046528a1e85eda89cd40c0960cef0e006b84ff"
+                "reference": "c37dab976883d4200e5723b2e21dd5ff5e85d0d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/typhonius/acquia-php-sdk-v2/zipball/2e046528a1e85eda89cd40c0960cef0e006b84ff",
-                "reference": "2e046528a1e85eda89cd40c0960cef0e006b84ff",
+                "url": "https://api.github.com/repos/typhonius/acquia-php-sdk-v2/zipball/c37dab976883d4200e5723b2e21dd5ff5e85d0d7",
+                "reference": "c37dab976883d4200e5723b2e21dd5ff5e85d0d7",
                 "shasum": ""
             },
             "require": {
@@ -6894,7 +6894,7 @@
                 }
             ],
             "description": "A PHP SDK for Acquia CloudAPI v2",
-            "time": "2018-04-11T23:41:25+00:00"
+            "time": "2019-07-17T10:42:35+00:00"
         },
         {
             "name": "typo3/phar-stream-wrapper",
@@ -8235,7 +8235,7 @@
             "time": "2019-01-28T19:31:35+00:00"
         },
         {
-            "name": "mikey179/vfsStream",
+            "name": "mikey179/vfsstream",
             "version": "v1.6.6",
             "source": {
                 "type": "git",

--- a/src/Robo/Commands/Generate/AliasesCommand.php
+++ b/src/Robo/Commands/Generate/AliasesCommand.php
@@ -211,7 +211,7 @@ class AliasesCommand extends BltTasks {
       ]);
       $cloud_api = Client::factory($connector);
       // We must call some method on the client to test authentication.
-      $cloud_api->applications();
+      $cloud_api->account();
       $this->cloudApiClient = $cloud_api;
     }
     catch (MalformedResponseExceptionAlias $e) {


### PR DESCRIPTION
Fixes #3742 
--------

Changes proposed
---------
- Use the newly-available account() method to test api auth, since it's more performant than applications()

Steps to replicate the issue
----------
1. Ensure that `blt recipes:aliases:init:acquia` still runs as expected.
