### PR TITLE
DT-577: Ensure after_failure runs during Travis tests.

### DIFF
--- a/scripts/travis/run_tests
+++ b/scripts/travis/run_tests
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# Ordinarily we'd use set -e here but that breaks travis_wait, so we use exit
+# Ordinarily we'd use set -e here but that breaks travis_wait, so we use return
 # pattern below.
 
 set -v
 
-blt validate:all --no-interaction || exit 1
-travis_wait blt setup --define drush.alias='${drush.aliases.ci}' --environment=ci --no-interaction --verbose || exit 1
-blt tests:all --define drush.alias='${drush.aliases.ci}' --define tests.run-server=true --environment=ci --no-interaction --verbose || exit 1
+blt validate:all --no-interaction || { set +v && return 1; }
+travis_wait blt setup --define drush.alias='${drush.aliases.ci}' --environment=ci --no-interaction --verbose || { set +v && return 1; }
+blt tests:all --define drush.alias='${drush.aliases.ci}' --define tests.run-server=true --environment=ci --no-interaction --verbose || { set +v && return 1; }
 
 set +v


### PR DESCRIPTION
Fixes #3687 
--------

Note that the run_tests script is `source`d via .travis.yml. That means it operates in the same shell context as the master Travis script. So when it exits, the whole shell exits and that's why subsequent steps don't run.

To avoid that, let's return instead of exiting. This prevents subsequent test steps from running, but allows the master Travis build to continue. We also need to be good bash citizens and unset verbose mode before returning.
