### PR TITLE
Fixes #3761 - Set Composer PHP Platform to 7.2.

### DIFF
--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -24,7 +24,10 @@
         "acquia/blt-require-dev": "^10.0.0-alpha1"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "7.2"
+        }
     },
     "extra": {
         "composer-exit-on-patch-failure": true,

--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -24,10 +24,10 @@
         "acquia/blt-require-dev": "^10.0.0-alpha1"
     },
     "config": {
-        "sort-packages": true,
         "platform": {
             "php": "7.2"
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "composer-exit-on-patch-failure": true,


### PR DESCRIPTION
Fixes #3761
--------

Changes proposed
---------
- Sets composer php version to 7.2

Steps to replicate the issue
----------
1. If Local environment is PHP 7.3 and running composer update would install php 7.3 based libraries.

Previous (bad) behavior, before applying PR
----------
composer update installed library with stable version of php 7.3 version.

Expected behavior, after applying PR and re-running test steps
-----------
Any BLT project would be in 7.2 version.
