### PR TITLE
DT-628: Update default Lightning version to 4.x.

### DIFF
--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.1",
         "acquia/blt": "10.x-dev",
         "acquia/drupal-spec-tool": ">=2.0.0",
-        "acquia/lightning": "^3.1.0",
+        "acquia/lightning": "^4.0.0",
         "drupal/acquia_connector": "^1.5.0",
         "drupal/acquia_purge": "^1.0-beta3",
         "drupal/cog": "^1.0.0",


### PR DESCRIPTION
Fixes #3753 
--------

Changes proposed
---------
- Update the default version of Lightning installed on new projects to 4.x. Doesn't affect existing projects, which can update in their own time by modifying their composer.json.