### PR TITLE
DT-633: blt:dev:link-composer lando support

### DIFF
--- a/src/Robo/Commands/Blt/DevCommand.php
+++ b/src/Robo/Commands/Blt/DevCommand.php
@@ -82,7 +82,7 @@ class DevCommand extends BltTasks {
 
     // Mount local BLT in Lando.
     if ($this->getInspector()->isLandoConfigPresent()) {
-      if (!isset(self::VM_DIRECTORY_MAPPING[$options['blt-path']])) {
+      if (!isset(self::LANDO_DIRECTORY_MAPPING[$options['blt-path']])) {
         $this->logger->info('BLT path is not valid for usage with Lando.');
         return;
       }

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -356,6 +356,16 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
   }
 
   /**
+   * Determines if Lando configuration exists in the project.
+   *
+   * @return bool
+   *   TRUE if Lando configuration exists.
+   */
+  public function isLandoConfigPresent() {
+    return file_exists($this->getConfigValue('repo.root') . '/.lando.yml');
+  }
+
+  /**
    * Determines if Drupal VM is initialized for the local machine.
    *
    * I.E., whether Drupal VM is the default LAMP stack for BLT on local machine.


### PR DESCRIPTION
Might be a touch tricky to test. Start by checking out this branch in your local BLT repo. Set up a test site as a supported sibling directory (i.e. either `~/blt`+`~/my-blt-project` or `~/packages/blt`+`~/sites/my-blt-project`). Make sure the new site has Lando initialized.

Run `blt blt:dev:link-composer` once, which will run using the old version of this command and link BLT, but fail during the VM setup. That's expected.

Run it a second time and it should configure your Lando file without error to mount your local version of BLT. Now you can confirm that BLT commands still run inside Lando.

Long-term, I think we need to find a home for this command outside of BLT since it's such a chicken-and-egg problem to test.