### PR TITLE
DT-649: Update ORCA to alpha19.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     # ORCA configuration.
     - ORCA_SUT_NAME=acquia/blt
     - ORCA_SUT_BRANCH=10.x
-    - ORCA_VERSION=v1.0.0-alpha18
+    - ORCA_VERSION=v1.0.0-alpha19
     # Custom configuration.
     - COMPOSER_BIN=$TRAVIS_BUILD_DIR/vendor/bin
     - BLT_DIR=$TRAVIS_BUILD_DIR


### PR DESCRIPTION
We can switch to master and reduce the burden of these updates once the upstream patches are merged.