### PR TITLE
Fix Issue-3767 Git commit fails due to yaml linting.

### DIFF
--- a/src/Robo/Commands/Validate/YamlCommand.php
+++ b/src/Robo/Commands/Validate/YamlCommand.php
@@ -53,7 +53,7 @@ class YamlCommand extends BltTasks {
       $filesets[$fileset_id] = $fileset_manager->filterFilesByFileset($files, $fileset);
     }
 
-    $this->executeCommandAgainstFilesets($filesets, $command);
+    $this->executeCommandAgainstFilesets($filesets, $command, TRUE);
   }
 
 }


### PR DESCRIPTION
Pre-commit yaml linting command runs sequentially which can create very long linting command for large file sets. Switched command to run in parallel.

Fixes #3767 
--------

Changes proposed
---------
Change the yaml linting command to run in parallel which allows the validation to pass.
[/vendor/blt/src/Robo/Commands/Validate/YamlCommand.php:56](https://github.com/acquia/blt/blob/46203b6c9c55ef142c9bd9150c7e6d2a14bfd5a0/src/Robo/Commands/Validate/YamlCommand.php#L56)
`$this->executeCommandAgainstFilesets($filesets, $command, TRUE);`


Steps to replicate the issue
----------

1. Add a bunch of yaml files to a commit (like 1300) 
`git add config/directory`
2. Try to commit the yaml files 
`git commit -m 'Commit message'`
3. Receive error

> [error]  Executing `'.../vendor/bin/yaml-cli' lint '%s'` against fileset(s) files.yaml returned a non-zero exit code.` 
> [CompletionWrapper]  Command `tests:yaml:lint:files 'config/directory/'
> 

Previous (bad) behavior, before applying PR
----------
Commit fails. Error message does not identity the problem yaml file. 

Expected behavior, after applying PR and re-running test steps
-----------
If linting is successful, commit proceeds. 
If error found, error message states the offending file.
`Iterating over fileset files.yaml...
''/home/phill/vhosts/drupal/vendor/bin/yaml-cli' lint '/home/phill/vhosts/drupal/config/site/block.block.bootstrap_barrio_local_actions.yml'' exited with code 1 
` 

Additional details
-----------
