### PR TITLE
DT-597: Run updates after CDE DB copies.

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -38,6 +38,8 @@ To initialize Pipelines support for your BLT project:
         blt recipes:ci:pipelines:init
 
     This will generate an [acquia-pipelines.yml file](https://docs.acquia.com/acquia-cloud/develop/pipelines/yaml/) in your project root based on [BLT's default acquia-pipelines.yml file](https://github.com/acquia/blt/blob/10.x/scripts/pipelines/acquia-pipelines.yml).
+    
+1. Modify `acquia-pipelines.yml` to [specify which DBs you would like to copy](https://docs.acquia.com/acquia-cloud/develop/pipelines/databases/) into your CDEs on deploys. 
 
 1. Commit the new file and push it to your Acquia git remote. Example commands:
 

--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -48,7 +48,7 @@ events:
             - pipelines-deploy
             # Uncomment this line and replace DB_NAME to sync a db on deploys.
             # @see https://docs.acquia.com/acquia-cloud/develop/pipelines/databases/
-            # - pipelines-sync-db DB_NAME
+            # - pipelines-sync-dbs DB_NAME
   pr-merged:
     steps:
       - deploy:

--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -1,4 +1,4 @@
-version: 1.1.0
+version: 1.2.0
 services:
   - mysql
   - php:
@@ -46,6 +46,9 @@ events:
       - deploy:
           script:
             - pipelines-deploy
+            # Uncomment this line and replace DB_NAME to sync a db on deploys.
+            # @see https://docs.acquia.com/acquia-cloud/develop/pipelines/databases/
+            # - pipelines-sync-db DB_NAME
   pr-merged:
     steps:
       - deploy:

--- a/src/Robo/Commands/Artifact/AcHooksCommand.php
+++ b/src/Robo/Commands/Artifact/AcHooksCommand.php
@@ -94,9 +94,16 @@ class AcHooksCommand extends BltTasks {
    *   The source environment. E.g., dev.
    *
    * @command artifact:ac-hooks:post-db-copy
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function postDbCopy($site, $target_env, $db_name, $source_env) {
-    // Do nothing for now. Allow extension of this call.
+    // Only run updates for ODEs, where DBs are copied automatically after new
+    // code has been deployed. In other environments, DBs are usually copied
+    // manually prior to initiating a code deploy, so an update is redundant.
+    if (EnvironmentDetector::isAhOdeEnv($target_env)) {
+      $this->invokeCommand('artifact:update:drupal:all-sites');
+    }
   }
 
   /**

--- a/src/Robo/Commands/Ci/CiCommand.php
+++ b/src/Robo/Commands/Ci/CiCommand.php
@@ -30,6 +30,8 @@ class CiCommand extends BltTasks {
     }
 
     $this->say("<info>A pre-configured acquia-pipelines.yml file was copied to your repository root.</info>");
+    $this->say("<info>To support copying DBs into newly-deployed CDEs, follow these instructions:</info>");
+    $this->say("<info>https://docs.acquia.com/acquia-cloud/develop/pipelines/cli/install</info>");
   }
 
   /**

--- a/src/Update/Updater.php
+++ b/src/Update/Updater.php
@@ -613,4 +613,14 @@ class Updater {
     return FALSE;
   }
 
+  /**
+   * Regenerate Pipelines config if it exists.
+   */
+  public function regeneratePipelines() {
+    if (file_exists($this->getRepoRoot() . '/acquia-pipelines.yml')) {
+      self::executeCommand("./vendor/bin/blt recipes:ci:pipelines:init", NULL, FALSE);
+      $this->getOutput()->writeln("acquia-pipelines.yml has been regenerated. Review the resulting file and re-add any customizations.");
+    }
+  }
+
 }

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -815,4 +815,16 @@ class Updates {
     $this->updater->writeComposerJson($composer_json);
   }
 
+  /**
+   * Version 10.3.0.
+   *
+   * @Update(
+   *   version = "10003000",
+   *   description = "Regenerate acquia-pipelines.yml."
+   * )
+   */
+  public function update_10003000() {
+    $this->updater->regeneratePipelines();
+  }
+
 }


### PR DESCRIPTION
Fixes #3022
--------

Changes proposed
---------
- Update pipelines schema version to support copying of dbs into containers
- Add notes about how customers can enable this functionality
- Automatically run updates after dbs are copied

Steps to replicate the issue
----------
1. Configure a subscription with CDEs to copy dbs into new CDEs according to [these instructions](https://docs.acquia.com/acquia-cloud/develop/pipelines/databases/) and start a deploy.

Previous (bad) behavior, before applying PR
----------
1. DB is copied into the container, but config imports and db updates are not run.

Expected behavior, after applying PR and re-running test steps
-----------
1. DB is copied and config imports / db updates are run.

