### PR TITLE
DT-654: Link to troubleshooting guide for errors.

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -45,7 +45,7 @@ In this case, BLT is simply executing the following drush command for you:
 ```
 /Users/me/Sites/mysite/vendor/bin/drush @blted10.local --site-name="BLTed 10" --site-mail="no-reply@acquia.com" --account-name="admin" --account-pass="admin" --account-mail="no-reply@acquia.com" --uri=default --yes --verbose site-install "lightning" "install_configure_form.update_status_module='array(FALSE,FALSE)'"
 ```
-To debug the problem, just run the drush command directly on the command line. It may be easier to navigate without BLT. Once the problem is resolved, go back to using BLT's automation layer.
+To debug the problem, run the drush command directly on the command line, as it will be easier to debug without involving BLT. If you still cannot diagnose the issue, contact Acquia Support. Do not open an issue in the BLT queue unless you’ve identified a specific bug or feature request for BLT itself.
 
 ## Common BLT Issues and Solutions
 

--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -93,6 +93,7 @@ class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerA
       // command. We must check the exit code and throw our own exception. This
       // obviates the need to check the exit code of every invoked command.
       if ($exit_code) {
+        $this->output->writeln("The command `$command_name` failed. This most likely indicates a problem with your configuration, and is NOT a BLT bug. Follow this troubleshooting guide to diagnose the issue: https://docs.acquia.com/blt/faq/");
         throw new BltException("Command `$command_name {$input->__toString()}` exited with code $exit_code.");
       }
     }


### PR DESCRIPTION
Changes proposed
---------
- Print a message anytime a BLT command fails that links to the troubleshooting guide and FAQ
- Add a note to the FAQ explicitly directing people to the appropriate support channel in this situation

Steps to replicate the issue
----------
1. Run an invalid BLT command such as `blt sync -D drush.aliases.remote=asdf` and observe the new error text.