### PR TITLE
Clear cache before sql-sanitise on sync

### DIFF
--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -135,6 +135,7 @@ class SyncCommand extends BltTasks {
       ->option('create-db');
 
     if ($this->getConfigValue('drush.sanitize')) {
+      $task->drush('cr');
       $task->drush('sql-sanitize');
     }
 

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -139,7 +139,6 @@ class SyncCommand extends BltTasks {
       $task->drush('sql-sanitize');
     }
 
-    $task->drush('cr');
     $task->drush('sqlq "TRUNCATE cache_entity"');
 
     $result = $task->run();


### PR DESCRIPTION
Fixes # 3791
--------

Changes proposed
---------
Clear drupal cache before sql-sanitise is run, to ensure plugins are registered.
