### PR TITLE
DT-663: Ensure deploy.dir config is set before running deploys.

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -73,10 +73,15 @@ class DeployCommand extends BltTasks {
    * This hook will fire for all commands in this command file.
    *
    * @hook init
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function initialize() {
     $this->excludeFileTemp = $this->getConfigValue('deploy.exclude_file') . '.tmp';
     $this->deployDir = $this->getConfigValue('deploy.dir');
+    if (!$this->deployDir) {
+      throw new BltException('Configuration deploy.dir must be set to run this command');
+    }
     $this->tagSource = $this->getConfigValue('deploy.tag_source', TRUE);
   }
 


### PR DESCRIPTION
Fixes #3784 
--------

Changes proposed
---------
- Ensure deploy.dir is set before running deploys

Steps to replicate the issue
----------
1. `rm -rf vendor/acquia/blt/config`
2. `blt deploy -vvv` (DANGER: only do this in an isolated VM, not on any machine of value)

Previous (bad) behavior, before applying PR
----------
The generated rsync command uses '/' as a destination.

Expected behavior, after applying PR and re-running test steps
-----------
The deploy aborts before running any rsync commands.
