### PR TITLE
Fix typo.

### DIFF
--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -74,7 +74,7 @@ class UpdateCommand extends BltTasks {
     $this->displayArt();
     $this->yell("Your new BLT-based project has been created in {$this->getConfigValue('repo.root')}.");
     $this->say("Please continue by following the \"Creating a new project with BLT\" instructions:");
-    $this->say("<comment>https://docs.acquia.com/blt/install/creating-new-project//</comment>");
+    $this->say("<comment>https://docs.acquia.com/blt/install/creating-new-project/</comment>");
   }
 
   /**


### PR DESCRIPTION
Fixes # 
--------

Changes proposed
---------
 
When you run the documented command to create a new project, e.g.
`composer create-project --no-interaction acquia/blt-project my-project` 

The very last line says to: 
`Please continue by following the "Creating a new project with BLT" instructions:`

But the provided url has a typo.


Steps to replicate the issue
----------
1. `composer create-project --no-interaction acquia/blt-project my-project` 
2. When it completes, CMD + click on the url provided (macOS Terminal.app)

 
