### PR TITLE
Include adminer hostname for drupal-vm dashboard.

### DIFF
--- a/scripts/drupal-vm/config.yml
+++ b/scripts/drupal-vm/config.yml
@@ -42,6 +42,11 @@ apache_vhosts:
     serveralias: "www.dashboard.{{ drupal_domain }}"
     documentroot: "/var/www/dashboard"
     extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"
+  - servername: 'adminer.{{ drupal_domain }}'
+    serveralias: 'www.adminer.{{ drupal_domain }}'
+    documentroot: '{{ adminer_install_dir }}'
+    extra_parameters: '{{ apache_vhost_php_fpm_parameters }}'
+
 #  - servername: "local.second-drupal-site.com"
 #    documentroot: "{{ drupal_core_path }}"
 #    extra_parameters: "{{ apache_vhost_php_fpm_parameters }}"


### PR DESCRIPTION
Fixes # 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- When I create a new project, the Drupal VM dashboard `dashboard.local.[sitename].com` includes a link for Adminer but it does not work

Expected behavior, after applying PR and re-running test steps
-----------

Additional details
-----------
