### PR TITLE
Add note about PHPCS filesets to build.yml

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -110,6 +110,7 @@ git:
 #  - default
 
 # @todo Move to subkey of validate.
+# Note that PHPCS filesets are not configured here, but via phpcs.xml.dist in the root directory.
 phpcs:
   standard: Drupal,DrupalPractice
 
@@ -236,6 +237,7 @@ tests:
     #   config: ${docroot}/core/phpunit.xml.dist
     #   directory: '${repo.root}/tests/phpunit'
 
+# Note that PHPCS filesets are not configured here, but via phpcs.xml.dist in the root directory.
 validate:
   # You can change this to true to have blt automatically validate acsf-init.
   acsf: false

--- a/config/build.yml
+++ b/config/build.yml
@@ -110,7 +110,7 @@ git:
 #  - default
 
 # @todo Move to subkey of validate.
-# Note that PHPCS filesets are not configured here, but via phpcs.xml.dist in the root directory.
+# Note that PHPCS filesets are not configured here, but via phpcs.xml.dist in the root directory. See "Extending BLT" in docs.
 phpcs:
   standard: Drupal,DrupalPractice
 
@@ -237,7 +237,7 @@ tests:
     #   config: ${docroot}/core/phpunit.xml.dist
     #   directory: '${repo.root}/tests/phpunit'
 
-# Note that PHPCS filesets are not configured here, but via phpcs.xml.dist in the root directory.
+# Note that PHPCS filesets are not configured here, but via phpcs.xml.dist in the root directory. See "Extending BLT" in docs.
 validate:
   # You can change this to true to have blt automatically validate acsf-init.
   acsf: false


### PR DESCRIPTION
We received a support request asking how to modify phpcs filesets. This is documented at https://docs.acquia.com/blt/extending-blt/#overriding-variables-at-runtime but people expect it to be configurable via blt.yml.