### PR TITLE
Remove Drupal Spec Tool version constraint

### DIFF
--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=7.1",
         "acquia/blt": "10.x-dev",
-        "acquia/drupal-spec-tool": ">=2.0.0",
+        "acquia/drupal-spec-tool": "*",
         "acquia/lightning": "^4.0.0",
         "drupal/acquia_connector": "^1.5.0",
         "drupal/acquia_purge": "^1.0-beta3",


### PR DESCRIPTION
@danepowell any chance we could remove the version constraint on the Drupal Spec Tool altogether? It's preventing ORCA from requiring the latest dev version under certain circumstances.