### PR TITLE
Fixes #3796: Deploy command continues despite composer failure

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -493,7 +493,7 @@ class DeployCommand extends BltTasks {
       ->dir($this->deployDir)
       ->run();
     if (!$execution_result->wasSuccessful()) {
-      throw new BltException("Composer Install failed, please review and check your composer.json file.");
+      throw new BltException("Composer install failed, please check the output for details.");
     }
   }
 

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -488,7 +488,7 @@ class DeployCommand extends BltTasks {
     if ($this->ignorePlatformReqs) {
       $command .= ' --ignore-platform-reqs';
     }
-    $execution_result = $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader --ignore-platform-reqs")
+    $execution_result = $this->taskExecStack()->exec($command)
       ->stopOnFail()
       ->dir($this->deployDir)
       ->run();

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -492,7 +492,7 @@ class DeployCommand extends BltTasks {
       ->stopOnFail()
       ->dir($this->deployDir)
       ->run();
-    if(!$execution_result->wasSuccessful()) {
+    if (!$execution_result->wasSuccessful()) {
       throw new BltException("Composer Install failed, please review and check your composer.json file.");
     }
   }

--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -488,10 +488,13 @@ class DeployCommand extends BltTasks {
     if ($this->ignorePlatformReqs) {
       $command .= ' --ignore-platform-reqs';
     }
-    $this->taskExecStack()->exec($command)
+    $execution_result = $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader --ignore-platform-reqs")
       ->stopOnFail()
       ->dir($this->deployDir)
       ->run();
+    if(!$execution_result->wasSuccessful()) {
+      throw new BltException("Composer Install failed, please review and check your composer.json file.");
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #3796 
--------

Changes proposed
---------
Added logic check to see if the `composer install` command was successful, and if not interrupt the deployment to prevent corrupt environment code

Steps to replicate the issue
----------
1. Create a semi-corrupt compsoer.json
2. Example, apply incorrect patch to module
```
"patches": {
    "drupal/svg_image_field": {
      "This doesn't apply": "https://www.drupal.org/files/issues/entity-browser-view-context-2865928-14.patch"
    },
```
3. Run `blt artifact:deploy`
4. The deployment will display the error `[Exception] Cannot apply patch This doesn't apply (https://www.drupal.org/files/issues/entity-browser-view-context-2865928-14.patch)!`
5. The error will be ignored and cause a broken artifact to be pushed to the environment. 

Previous (bad) behavior, before applying PR
----------
Corrupt environment code on deployment and ignored the composer error

Expected behavior, after applying PR and re-running test steps
-----------
An exception is now thrown and the process is stopped, preventing a corrupted artifact deployment
