### PR TITLE
9.x Fixes #3796: Deploy command continues despite composer failure

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -406,10 +406,13 @@ class DeployCommand extends BltTasks {
       ->copy($this->getConfigValue('repo.root') . '/composer.lock', $this->deployDir . '/composer.lock', TRUE)
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
-    $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader")
+    $execution_result = $this->taskExecStack()->exec("composer install --no-dev --no-interaction --optimize-autoloader")
       ->stopOnFail()
       ->dir($this->deployDir)
       ->run();
+    if (!$execution_result->wasSuccessful()) {
+      throw new BltException("Composer install failed, please check the output for details.");
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #3796 for 9.x Branch
--------

Changes proposed
---------
Added logic check to see if the `composer install` command was successful, and if not interrupt the deployment to prevent corrupt environment code

Steps to replicate the issue
----------
1. Create a semi-corrupt compsoer.json
2. Example, apply incorrect patch to module
```
"patches": {
    "drupal/svg_image_field": {
      "This doesn't apply": "https://www.drupal.org/files/issues/entity-browser-view-context-2865928-14.patch"
    },
```
3. Run `blt artifact:deploy`
4. The deployment will display the error `[Exception] Cannot apply patch This doesn't apply (https://www.drupal.org/files/issues/entity-browser-view-context-2865928-14.patch)!`
5. The error will be ignored and cause a broken artifact to be pushed to the environment. 

Previous (bad) behavior, before applying PR
----------
Corrupt environment code on deployment and ignored the composer error

Expected behavior, after applying PR and re-running test steps
-----------
An exception is now thrown and the process is stopped, preventing a corrupted artifact deployment
