### PR TITLE
Check if site can bootstrap before running updb in drupal:update

### DIFF
--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -34,7 +34,8 @@ class ConfigCommand extends BltTasks {
 
     if (empty($status->bootstrap) || $status->bootstrap != 'Successful') {
       $this->logger->warning('Site not bootstrapped. Cannot update database.');
-    } else {
+    }
+    else {
       $task = $this->taskDrush()
         ->stopOnFail()
         // Execute db updates.

--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -27,7 +27,7 @@ class ConfigCommand extends BltTasks {
       ->drush('status')
       ->option('fields', 'bootstrap')
       ->option('format', 'json')
-      ->silent(true)
+      ->silent(TRUE)
       ->run();
 
     $status = json_decode($result->getMessage());

--- a/src/Robo/Commands/Setup/ConfigCommand.php
+++ b/src/Robo/Commands/Setup/ConfigCommand.php
@@ -22,23 +22,37 @@ class ConfigCommand extends BltTasks {
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function update() {
-    $task = $this->taskDrush()
+    $result = $this->taskDrush()
       ->stopOnFail()
-      // Execute db updates.
-      // This must happen before features are imported or configuration is
-      // imported. For instance, if you add a dependency on a new extension to
-      // an existing configuration file, you must enable that extension via an
-      // update hook before attempting to import the configuration.
-      // If a db update relies on updated configuration, you should import the
-      // necessary configuration file(s) as part of the db update.
-      ->drush("updb");
+      ->drush('status')
+      ->option('fields', 'bootstrap')
+      ->option('format', 'json')
+      ->silent(true)
+      ->run();
 
-    $result = $task->run();
-    if (!$result->wasSuccessful()) {
-      throw new BltException("Failed to execute database updates!");
+    $status = json_decode($result->getMessage());
+
+    if (empty($status->bootstrap) || $status->bootstrap != 'Successful') {
+      $this->logger->warning('Site not bootstrapped. Cannot update database.');
+    } else {
+      $task = $this->taskDrush()
+        ->stopOnFail()
+        // Execute db updates.
+        // This must happen before features are imported or configuration is
+        // imported. For instance, if you add a dependency on a new extension to
+        // an existing configuration file, you must enable that extension via an
+        // update hook before attempting to import the configuration.
+        // If a db update relies on updated configuration, you should import the
+        // necessary configuration file(s) as part of the db update.
+        ->drush("updb");
+
+      $result = $task->run();
+      if (!$result->wasSuccessful()) {
+        throw new BltException("Failed to execute database updates!");
+      }
+
+      $this->invokeCommands(['drupal:config:import', 'drupal:toggle:modules']);
     }
-
-    $this->invokeCommands(['drupal:config:import', 'drupal:toggle:modules']);
   }
 
   /**


### PR DESCRIPTION
Fixes #3277 
--------

Changes proposed
---------
This change checks to see if the site can bootstrap via `drush status` (similarly to https://github.com/acquia/blt/blob/10.x/src/Robo/Commands/Doctor/DrupalCheck.php#L51) before running `drush updb` in the `drupal:update` BLT command. If the site cannot bootstrap, it logs a warning but continues to attempt database updates on other multisites.

Steps to replicate the issue
----------
The steps originally outlined in #3277 suffice but locally you can replicate this by:
- Creating two multisites locally
  - a.com
  - b.com
- Installing Drupal in b.com
- Run `blt auda`

Previous (bad) behavior, before applying PR
----------
The previous behavior would cause the `blt auda` command to fail on a.com. This actually has potentially serious consequences like leaving b.com or any number of other multisites in a wonky state during AC deployments.

Expected behavior, after applying PR and re-running test steps
-----------
The `blt auda` command logs a warning, skips running database updates on a.com and proceeds to b.com.

Additional details
-----------
Maybe this should be an opt-in feature via configuration? 

Any feedback would be greatly appreciated. Thanks.
