### PR TITLE
Use Latest Stable Chromedriver on TravisCI

### DIFF
--- a/scripts/linux/install-chrome.sh
+++ b/scripts/linux/install-chrome.sh
@@ -13,10 +13,7 @@ if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   # apt-get -f install
 
   # Installs chromedriver for Linux 64 bit systems.
-  # Temporarily pin to Chromedriver 74.
-  # @see https://github.com/acquia/blt/issues/3704
-  # CHROMEDRIVER_VERSION=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
-  [ -z "$CHROMEDRIVER_VERSION" ] && CHROMEDRIVER_VERSION=74.0.3729.6
+  [ -z "$CHROMEDRIVER_VERSION" ] && CHROMEDRIVER_VERSION=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
   wget -N https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
   unzip chromedriver_linux64.zip
   chmod +x chromedriver


### PR DESCRIPTION
Fixes https://github.com/acquia/blt/issues/3817
--------

Changes proposed
---------
- Set by default `CHROMEDIVER_VERSION` to the latest stable released version while keeping in place the option for the variable to be overridden by a `.tarvis.yml` configuration file. 
This applies the change that was commented out. Indicating this was the intended eventual behavior once the upstream issue outlined in https://github.com/acquia/blt/issues/3704 was resolved. Now that the original issue seem to have been resolved with the latest stable version of `chromedriver` we should install the latest version by default.

Previous (bad) behavior
----------
See [BLT Internal builds](https://travis-ci.com/acquia/blt/jobs/226152012#L1508) for example.


Expected behavior
-----------
The `chromedriver` functional tests should successfully pass without being skipped by default on TravisCI. Without having to configure the `CHROMEDRIVER_VERSION` manually in the travis config file.