### PR TITLE
Fixes #3815: SQL sanitization fails when using memcache.

### DIFF
--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -139,8 +139,6 @@ class SyncCommand extends BltTasks {
       $task->drush('sql-sanitize');
     }
 
-    $task->drush('sqlq "TRUNCATE cache_entity"');
-
     $result = $task->run();
 
     return $result;

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -133,9 +133,9 @@ class SyncCommand extends BltTasks {
       ->option('--target-dump', sys_get_temp_dir() . '/tmp.target.sql.gz')
       ->option('structure-tables-key', 'lightweight')
       ->option('create-db');
+    $task->drush('cr');
 
     if ($this->getConfigValue('drush.sanitize')) {
-      $task->drush('cr');
       $task->drush('sql-sanitize');
     }
 


### PR DESCRIPTION
Fixes #3815 
--------
Alternative to #3816 

Changes proposed
---------
- Remove redundant cache clear which can fail in some circumstances (i.e. if using memcache instead of db caching). We already do a full `cr` a few lines above this, no reason to manually truncate tables here.*

Additional details
-----------
*in fact, we might not need a cache clear at all since Drush [now resets](https://github.com/drush-ops/drush/commit/fd5b5d68661588f3af5c5fdecc24812191208c93) the [user entity cache](https://github.com/drush-ops/drush/blob/master/src/Drupal/Commands/sql/SanitizeUserTableCommands.php) during sanitization. But there might be other good reasons to clear cache, and I'd prefer a minimally invasive approach.