### PR TITLE
DT-679: Update post-code-update to work on ODEs on manual pushes.

### DIFF
--- a/src/Robo/Commands/Artifact/AcHooksCommand.php
+++ b/src/Robo/Commands/Artifact/AcHooksCommand.php
@@ -171,7 +171,8 @@ class AcHooksCommand extends BltTasks {
   public function updateOdeSites($target_env) {
     if ($this->getInspector()->isDrupalInstalled()) {
       $this->updateCloudSites($target_env);
-    } else {
+    }
+    else {
       $this->invokeCommand('artifact:install:drupal');
     }
   }

--- a/src/Robo/Commands/Artifact/AcHooksCommand.php
+++ b/src/Robo/Commands/Artifact/AcHooksCommand.php
@@ -164,23 +164,27 @@ class AcHooksCommand extends BltTasks {
   }
 
   /**
-   * Reinstall Drupal in an ODE.
+   * Install or sync Drupal in an ODE.
    *
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  public function updateOdeSites() {
-    $this->invokeCommand('artifact:install:drupal');
+  public function updateOdeSites($target_env) {
+    if ($this->getInspector()->isDrupalInstalled()) {
+      $this->updateCloudSites($target_env);
+    } else {
+      $this->invokeCommand('artifact:install:drupal');
+    }
   }
 
   /**
-   * Executes updates against all ACE sites in the target environment.
+   * Executes updates against all sites in the target environment.
    *
    * @param string $target_env
    *   Target env.
    *
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  public function updateAceSites($target_env) {
+  public function updateCloudSites($target_env) {
     $this->say("Running updates for environment: $target_env");
     $this->invokeCommand('artifact:update:drupal:all-sites');
     $this->say("Finished updates for environment: $target_env");
@@ -287,10 +291,10 @@ class AcHooksCommand extends BltTasks {
    */
   protected function updateSites($site, $target_env) {
     if (EnvironmentDetector::isAhOdeEnv($target_env)) {
-      $this->updateOdeSites();
+      $this->updateOdeSites($target_env);
     }
     else {
-      $this->updateAceSites($target_env);
+      $this->updateCloudSites($target_env);
     }
   }
 


### PR DESCRIPTION
Fixes #3798 
--------

Changes proposed
---------
- Don't run a Drupal install if Drupal is already installed when using Acquia CDEs

Steps to replicate the issue
----------
1. Create a CDE by hand, and push code to it

Previous (bad) behavior, before applying PR
----------
If you create a CDE by hand, and push code to it, it would attempt to install Drupal if already installed, causing the error described in #3798 

Expected behavior, after applying PR and re-running test steps
-----------
In Acquia CDE's, It would install Drupal if needed the first time, or skip the install if needed.

Additional details
-----------
