### PR TITLE
DT-676: Fixes #3807: Fix composer warnings for Composer 1.9.0.

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -107,6 +107,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    */
   public static function onPostAutoloadDump(Event $event) {
     $composer = $event->getComposer();
+    // This workaround is only necessary for Composer versions before 1.9.0.
+    if (version_compare($composer::VERSION, '1.9.0', '>=')) {
+      return;
+    }
     $vendor_dir = $composer->getConfig()->get('vendor-dir');
     $installed_json = realpath($vendor_dir) . "/composer/installed.json";
     $installed = json_decode(file_get_contents($installed_json));


### PR DESCRIPTION
Fixes #3807 
--------

Changes proposed
---------
The workaround we implemented for these Composer warnings ironically conflicts with Composer's upstream fix in 1.9.0 and causes them to reappear. So only apply the workaround to older Composer versions.

Steps to replicate the issue
----------
1. Use a local dev version of BLT on your project: `blt blt:dev:link-composer`
2. Ensure you are using Composer 1.9.0: `composer --version`
3. Run any Composer command (`composer --version`).

Previous (bad) behavior, before applying PR
----------
You get the warnings

Expected behavior, after applying PR and re-running test steps
-----------
No warnings