### PR TITLE
Skip drupal:update if Drupal is not installed

### DIFF
--- a/src/Robo/Commands/Deploy/DeployCommand.php
+++ b/src/Robo/Commands/Deploy/DeployCommand.php
@@ -739,12 +739,16 @@ class DeployCommand extends BltTasks {
    *   Multisite.
    */
   protected function updateSite($multisite) {
-    $this->say("Deploying updates to <comment>$multisite</comment>...");
     $this->switchSiteContext($multisite);
 
-    $this->invokeCommand('drupal:update');
-
-    $this->say("Finished deploying updates to $multisite.");
+    if ($this->getInspector()->isDrupalInstalled()) {
+      $this->say("Deploying updates to <comment>$multisite</comment>...");
+      $this->invokeCommand('drupal:update');
+      $this->say("Finished deploying updates to $multisite.");
+    }
+    else {
+      $this->logger->warning("Drupal is not installed for $multisite. Skipping updates.");
+    }
   }
 
   /**

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -221,7 +221,8 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    */
   public function isDrupalInstalled() {
     $this->logger->debug("Verifying that Drupal is installed...");
-    $result = $this->executor->drush("sqlq \"SHOW TABLES LIKE 'config'\"")->run();
+    $uri = $this->getConfigValue('drush.uri');
+    $result = $this->executor->drush("sqlq --uri=$uri \"SHOW TABLES LIKE 'config'\"")->run();
     $output = trim($result->getMessage());
     $installed = $result->wasSuccessful() && $output == 'config';
 


### PR DESCRIPTION
Fixes #3277 
--------

Changes proposed
---------
This change checks to see if a site can bootstrap via `Inspector::isDrupalInstalled` before invoking the `drupal:update` command. If the site cannot bootstrap, it logs a warning but continues to attempt database updates on other multisites.

Steps to replicate the issue
----------
The steps originally outlined in #3277 suffice but locally you can replicate this by:
- Creating two multisites locally
  - a.com
  - b.com
- Installing Drupal in b.com and not in a.com
- Run `blt auda`

Previous (bad) behavior, before applying PR
----------
The previous behavior would cause the `blt auda` command to fail on a.com. This actually has potentially negative consequences like leaving b.com or any number of other multisites in a wonky state during AC deployments.

Expected behavior, after applying PR and re-running test steps
-----------
The `blt auda` command logs a warning, skips running database updates on a.com and proceeds to b.com.
