### PR TITLE
DT-679: Fixes #3798: Treat CDE and Cloud sites identically.

### DIFF
--- a/src/Robo/Commands/Artifact/AcHooksCommand.php
+++ b/src/Robo/Commands/Artifact/AcHooksCommand.php
@@ -67,7 +67,7 @@ class AcHooksCommand extends BltTasks {
   public function postCodeUpdate($site, $target_env, $source_branch, $deployed_tag, $repo_url, $repo_type) {
     if (!EnvironmentDetector::isAcsfEnv($site, $target_env)) {
       try {
-        $this->updateSites($site, $target_env);
+        $this->updateCloudSites($target_env);
         $success = TRUE;
         $this->sendPostCodeUpdateNotifications($site, $target_env, $source_branch, $deployed_tag, $success);
       }
@@ -164,15 +164,6 @@ class AcHooksCommand extends BltTasks {
   }
 
   /**
-   * Reinstall Drupal in an ODE.
-   *
-   * @throws \Acquia\Blt\Robo\Exceptions\BltException
-   */
-  public function updateOdeSites() {
-    $this->invokeCommand('artifact:install:drupal');
-  }
-
-  /**
    * Executes updates against all ACE sites in the target environment.
    *
    * @param string $target_env
@@ -180,7 +171,7 @@ class AcHooksCommand extends BltTasks {
    *
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  public function updateAceSites($target_env) {
+  public function updateCloudSites($target_env) {
     $this->say("Running updates for environment: $target_env");
     $this->invokeCommand('artifact:update:drupal:all-sites');
     $this->say("Finished updates for environment: $target_env");
@@ -273,25 +264,6 @@ class AcHooksCommand extends BltTasks {
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
     curl_exec($ch);
     curl_close($ch);
-  }
-
-  /**
-   * Executes updates against all sites.
-   *
-   * @param string $site
-   *   Site.
-   * @param string $target_env
-   *   Target env.
-   *
-   * @throws \Acquia\Blt\Robo\Exceptions\BltException
-   */
-  protected function updateSites($site, $target_env) {
-    if (EnvironmentDetector::isAhOdeEnv($target_env)) {
-      $this->updateOdeSites();
-    }
-    else {
-      $this->updateAceSites($target_env);
-    }
   }
 
 }


### PR DESCRIPTION
Fixes #3798 
--------

Changes proposed
---------
- Instead of trying to install Drupal on CDEs when code is manually deployed, which will fail more often than not, just treat CDEs like any other Cloud environment and attempt to run the standard updates. These will fail gracefully if Drupal is not installed following https://github.com/acquia/blt/pull/3831

Note that this only changes the behavior for customers who _manually_ deploy code to their CDEs _and_ automatically install/sync the Drupal DB, which is a pretty tiny subset of users. Most just rely on Pipelines to manage the deploys (which doesn't run these hooks, it just syncs the DB).

Steps to replicate the issue
----------
1. Spin up a CDE.
2. Install Drupal or copy a DB from another env.
3. Deploy this code to the CDE.

Previous (bad) behavior, before applying PR
----------
Error in task log because Drupal is already installed, and BLT attempts to reinstall it:
```
 [Drupal\Core\Entity\EntityStorageException]              
  'date_format' entity with ID 'fallback' already exists.  
```

Expected behavior, after applying PR and re-running test steps
-----------
(also requires #3831)
No error, BLT doesn't attempt to reinstall, it just applies updates.
Note: you may see other errors in the CDE if you are using Solr, these seem to be related to Acquia Connector not finding the search server. These are unrelated to BLT, as evidenced by the fact that they occur before BLT is invoked.