### PR TITLE
WIP: DT-682: Fixes #3811: Failing commands throw exception by default.

### DIFF
--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -10,6 +10,8 @@ use Acquia\Blt\Robo\Exceptions\BltException;
 use Acquia\Blt\Robo\Inspector\InspectorAwareInterface;
 use Acquia\Blt\Robo\Inspector\InspectorAwareTrait;
 use Acquia\Blt\Robo\Tasks\LoadTasks;
+use Acquia\Blt\Robo\Tasks\BltExecStack;
+use Acquia\Blt\Robo\Tasks\BltExec;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
@@ -166,6 +168,24 @@ class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerA
 
       return 0;
     }
+  }
+
+  /**
+   * Use BLT's implementation of the Robo ExecStack.
+   *
+   * @inheritDoc
+   */
+  protected function taskExecStack() {
+    return $this->task(BltExecStack::class);
+  }
+
+  /**
+   * Use BLT's implementation of the Robo Exec.
+   *
+   * @inheritDoc
+   */
+  protected function taskExec($command) {
+    return $this->task(BltExec::class, $command);
   }
 
   /**

--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -10,8 +10,6 @@ use Acquia\Blt\Robo\Exceptions\BltException;
 use Acquia\Blt\Robo\Inspector\InspectorAwareInterface;
 use Acquia\Blt\Robo\Inspector\InspectorAwareTrait;
 use Acquia\Blt\Robo\Tasks\LoadTasks;
-use Acquia\Blt\Robo\Tasks\BltExecStack;
-use Acquia\Blt\Robo\Tasks\BltExec;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
@@ -20,7 +18,6 @@ use Robo\Contract\BuilderAwareInterface;
 use Robo\Contract\ConfigAwareInterface;
 use Robo\Contract\IOAwareInterface;
 use Robo\Contract\VerbosityThresholdInterface;
-use Robo\LoadAllTasks;
 use Symfony\Component\Console\Input\ArrayInput;
 
 /**
@@ -29,7 +26,6 @@ use Symfony\Component\Console\Input\ArrayInput;
 class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerAwareInterface, BuilderAwareInterface, IOAwareInterface, ContainerAwareInterface {
 
   use ContainerAwareTrait;
-  use LoadAllTasks;
   use ConfigAwareTrait;
   use InspectorAwareTrait;
   use IO;
@@ -168,24 +164,6 @@ class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerA
 
       return 0;
     }
-  }
-
-  /**
-   * Use BLT's implementation of the Robo ExecStack.
-   *
-   * @inheritDoc
-   */
-  protected function taskExecStack() {
-    return $this->task(BltExecStack::class);
-  }
-
-  /**
-   * Use BLT's implementation of the Robo Exec.
-   *
-   * @inheritDoc
-   */
-  protected function taskExec($command) {
-    return $this->task(BltExec::class, $command);
   }
 
   /**

--- a/src/Robo/Commands/Setup/ImportCommand.php
+++ b/src/Robo/Commands/Setup/ImportCommand.php
@@ -3,7 +3,6 @@
 namespace Acquia\Blt\Robo\Commands\Setup;
 
 use Acquia\Blt\Robo\BltTasks;
-use Acquia\Blt\Robo\Exceptions\BltException;
 
 /**
  * Defines commands in the "drupal:sql:import" namespace.
@@ -19,17 +18,14 @@ class ImportCommand extends BltTasks {
    *
    * @validateDrushConfig
    * @executeInVm
+   *
+   * @throws \Robo\Exception\TaskException
    */
   public function import() {
     $task = $this->taskDrush()
       ->drush('sql-drop')
       ->drush('sql-cli < ' . $this->getConfigValue('setup.dump-file'));
-    $result = $task->run();
-    $exit_code = $result->getExitCode();
-
-    if ($exit_code) {
-      throw new BltException("Unable to import setup.dump-file.");
-    }
+    $task->run();
   }
 
 }

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -306,30 +306,17 @@ WARNING;
    *
    * @command drupal:hash-salt:init
    * @aliases dhsi setup:hash-salt
-   *
-   * @return int
-   *   A CLI exit code.
-   *
-   * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function hashSalt() {
     $hash_salt_file = $this->getConfigValue('repo.root') . '/salt.txt';
     if (!file_exists($hash_salt_file)) {
       $this->say("Generating hash salt...");
-      $result = $this->taskWriteToFile($hash_salt_file)
+      $this->taskWriteToFile($hash_salt_file)
         ->line(RandomString::string(55))
         ->run();
-
-      if (!$result->wasSuccessful()) {
-        $filepath = $this->getInspector()->getFs()->makePathRelative($hash_salt_file, $this->getConfigValue('repo.root'));
-        throw new BltException("Unable to write hash salt to $filepath.");
-      }
-
-      return $result->getExitCode();
     }
     else {
       $this->say("Hash salt already exists.");
-      return 0;
     }
   }
 

--- a/src/Robo/Commands/Setup/SettingsCommand.php
+++ b/src/Robo/Commands/Setup/SettingsCommand.php
@@ -334,15 +334,17 @@ WARNING;
     }
     $deployment_identifier_file = $this->getConfigValue('repo.root') . '/deployment_identifier';
     $this->say("Generating deployment identifier...");
-    $result = $this->taskWriteToFile($deployment_identifier_file)
-      ->line($options['id'])
-      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-      ->run();
-
-    if (!$result->wasSuccessful()) {
+    try {
+      $this->taskWriteToFile($deployment_identifier_file)
+        ->line($options['id'])
+        ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+        ->run();
+    }
+    catch (\Exception $exception) {
       $filepath = $this->getInspector()->getFs()->makePathRelative($deployment_identifier_file, $this->getConfigValue('repo.root'));
       throw new BltException("Unable to write deployment identifier to $filepath.");
     }
+
   }
 
 }

--- a/src/Robo/Commands/Setup/ToggleModulesCommand.php
+++ b/src/Robo/Commands/Setup/ToggleModulesCommand.php
@@ -58,25 +58,19 @@ class ToggleModulesCommand extends BltTasks {
    * @param string $config_key
    *   The config key containing the array of modules.
    *
-   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   * @throws \Robo\Exception\TaskException
    */
   protected function doToggleModules($command, $config_key) {
     if ($this->getConfig()->has($config_key)) {
       $this->say("Executing <comment>drush $command</comment> for modules defined in <comment>$config_key</comment>...");
       $modules = (array) $this->getConfigValue($config_key);
       $modules_list = implode(' ', $modules);
-      $result = $this->taskDrush()
+      $this->taskDrush()
         ->drush("$command $modules_list")
         ->run();
-      $exit_code = $result->getExitCode();
     }
     else {
-      $exit_code = 0;
       $this->logger->info("$config_key is not set.");
-    }
-
-    if ($exit_code) {
-      throw new BltException("Could not toggle modules listed in $config_key.");
     }
   }
 

--- a/src/Robo/Commands/Tests/SecurityUpdatesCommand.php
+++ b/src/Robo/Commands/Tests/SecurityUpdatesCommand.php
@@ -15,20 +15,21 @@ class SecurityUpdatesCommand extends BltTasks {
    * @command tests:security:check:updates
    * @aliases tscu security tests:security-updates
    * @executeInVm
+   *
+   * @throws \Exception
    */
   public function testsSecurityUpdates() {
-    $result = $this->taskDrush()
-      ->drush("pm:security")
-      ->run();
-
-    if ($result->getExitCode()) {
+    try {
+      $this->taskDrush()
+        ->drush("pm:security")
+        ->run();
+    }
+    catch (\Exception $exception) {
       $this->logger->notice('To disable security checks, set disable-targets.tests.security.check.updates to true in blt.yml.');
-      return 1;
+      throw $exception;
     }
-    else {
-      $this->writeln("<info>There are no outstanding security updates for Drupal projects.</info>");
-      return 0;
-    }
+
+    $this->writeln("<info>There are no outstanding security updates for Drupal projects.</info>");
   }
 
   /**
@@ -37,22 +38,23 @@ class SecurityUpdatesCommand extends BltTasks {
    * @command tests:security:check:composer
    * @aliases tscom security tests:composer
    * @executeInVm
+   *
+   * @throws \Exception
    */
   public function testsSecurityComposer() {
     $bin = $this->getConfigValue('composer.bin');
-    $result = $this->taskExecStack()
-      ->dir($this->getConfigValue('repo.root'))
-      ->exec("$bin/security-checker security:check composer.lock")
-      ->run();
-
-    if ($result->getExitCode()) {
+    try {
+      $this->taskExecStack()
+        ->dir($this->getConfigValue('repo.root'))
+        ->exec("$bin/security-checker security:check composer.lock")
+        ->run();
+    }
+    catch (\Exception $exception) {
       $this->logger->notice('To disable security checks, set disable-targets.tests.security.check.composer to true in blt.yml.');
-      return 1;
+      throw $exception;
     }
-    else {
-      $this->writeln("<info>There are no outstanding security updates for your composer packages.</info>");
-      return 0;
-    }
+
+    $this->writeln("<info>There are no outstanding security updates for your composer packages.</info>");
   }
 
 }

--- a/src/Robo/Tasks/BltExec.php
+++ b/src/Robo/Tasks/BltExec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Acquia\Blt\Robo\Tasks;
+
+use Acquia\Blt\Robo\Exceptions\BltException;
+use Robo\Task\Base\Exec;
+
+/**
+ * Overrides Robo's ExecStack to throw errors on failure.
+ */
+class BltExec extends Exec {
+
+  /**
+   * Throw errors on task failure.
+   *
+   * @inheritDoc
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  public function run() {
+    $result = parent::run();
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Task failed with exit code {$result->getExitCode()}. See log output above for details.", $result->getExitCode());
+    }
+    return $result;
+  }
+
+}

--- a/src/Robo/Tasks/BltExecStack.php
+++ b/src/Robo/Tasks/BltExecStack.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Acquia\Blt\Robo\Tasks;
+
+use Acquia\Blt\Robo\Exceptions\BltException;
+use Robo\Task\Base\ExecStack;
+
+/**
+ * Overrides Robo's ExecStack to throw errors on failure.
+ */
+class BltExecStack extends ExecStack {
+
+  /**
+   * Throw errors on task failure.
+   *
+   * @inheritDoc
+   *
+   * @throws \Robo\Exception\TaskException
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  public function run() {
+    $result = parent::run();
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Task failed with exit code {$result->getExitCode()}. See log output above for details.", $result->getExitCode());
+    }
+    return $result;
+  }
+
+}

--- a/src/Robo/Tasks/BltWrite.php
+++ b/src/Robo/Tasks/BltWrite.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Acquia\Blt\Robo\Tasks;
+
+use Acquia\Blt\Robo\Exceptions\BltException;
+use Robo\Task\File\Write;
+
+/**
+ * Overrides Robo's Write to throw errors on failure.
+ */
+class BltWrite extends Write {
+
+  /**
+   * Throw errors on task failure.
+   *
+   * @inheritDoc
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  public function run() {
+    $result = parent::run();
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Task failed with exit code {$result->getExitCode()}. See log output above for details.", $result->getExitCode());
+    }
+    return $result;
+  }
+
+}

--- a/src/Robo/Tasks/DrushTask.php
+++ b/src/Robo/Tasks/DrushTask.php
@@ -2,6 +2,7 @@
 
 namespace Acquia\Blt\Robo\Tasks;
 
+use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Exception\TaskException;
 use Robo\Task\CommandStack;
 use Robo\Common\CommandArguments;
@@ -370,6 +371,8 @@ class DrushTask extends CommandStack {
    *
    * Make note that if stopOnFail() is TRUE, then result data isn't returned!
    * Maybe this should be changed.
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function run() {
     $this->setupExecution();
@@ -383,7 +386,11 @@ class DrushTask extends CommandStack {
     // If 'stopOnFail' is not set, or if there is only one command to run,
     // then execute the single command to run.
     if (!$this->stopOnFail || (count($this->exec) == 1)) {
-      return $this->executeCommand($this->getCommand());
+      $result = $this->executeCommand($this->getCommand());
+      if (!$result->wasSuccessful()) {
+        throw new BltException("Task failed with exit code {$result->getExitCode()}. See log output above for details.", $result->getExitCode());
+      }
+      return $result;
     }
 
     // When executing multiple commands in 'stopOnFail' mode, run them
@@ -401,6 +408,10 @@ class DrushTask extends CommandStack {
       if (!$result->wasSuccessful()) {
         return $result;
       }
+    }
+
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Task failed with exit code {$result->getExitCode()}. See log output above for details.", $result->getExitCode());
     }
 
     return $result;

--- a/src/Robo/Tasks/LoadTasks.php
+++ b/src/Robo/Tasks/LoadTasks.php
@@ -2,10 +2,14 @@
 
 namespace Acquia\Blt\Robo\Tasks;
 
+use Robo\LoadAllTasks;
+
 /**
  * Load BLT's custom Robo tasks.
  */
 trait LoadTasks {
+
+  use LoadAllTasks;
 
   /**
    * Task drush.
@@ -30,7 +34,7 @@ trait LoadTasks {
    * @param null|string $pathToGit
    *   Path to git.
    *
-   * @return \Acquia\Blt\Robo\Tasks\GitTask
+   * @return \Acquia\Blt\Robo\Tasks\GitTask|\Robo\Collection\CollectionBuilder
    *   Git task.
    */
   protected function taskGit($pathToGit = 'git') {
@@ -43,7 +47,7 @@ trait LoadTasks {
    * @param null|string $pathToPhpUnit
    *   Path to phpunit.
    *
-   * @return \Acquia\Blt\Robo\Tasks\PhpUnitTask
+   * @return \Acquia\Blt\Robo\Tasks\PhpUnitTask|\Robo\Collection\CollectionBuilder
    *   Phpunit task.
    */
   protected function taskPhpUnitTask($pathToPhpUnit = NULL) {
@@ -53,11 +57,38 @@ trait LoadTasks {
   /**
    * Task run tests.
    *
-   * @return \Acquia\Blt\Robo\Tasks\RunTestsTask
+   * @return \Acquia\Blt\Robo\Tasks\RunTestsTask|\Robo\Collection\CollectionBuilder
    *   run tests task.
    */
   protected function taskRunTestsTask($runTestsScriptCommand = NULL) {
     return $this->task(RunTestsTask::class, $runTestsScriptCommand);
+  }
+
+  /**
+   * Use BLT's implementation of the Robo ExecStack.
+   *
+   * @inheritDoc
+   */
+  protected function taskExecStack() {
+    return $this->task(BltExecStack::class);
+  }
+
+  /**
+   * Use BLT's implementation of the Robo Exec.
+   *
+   * @inheritDoc
+   */
+  protected function taskExec($command) {
+    return $this->task(BltExec::class, $command);
+  }
+
+  /**
+   * Use BLT's implementation of the Robo Write.
+   *
+   * @inheritDoc
+   */
+  protected function taskWriteToFile($file) {
+    return $this->task(BltWrite::class, $file);
   }
 
 }


### PR DESCRIPTION
Fixes #3811 
--------

I'm not sure about this approach as it requires a lot of refactoring, and will almost certainly cause at least minor regressions.

To recap the problem, Robo's CommandStack doesn't throw any exceptions if a command (drush, composer, etc...) returns a non-zero exit code. It just captures and returns the error code. So every time BLT calls a command, it has to manually check and handle the exit code. This has led to many bugs in the past where exit codes are _not_ checked and BLT doesn't throw an error as expected.

This "fixes" that by overriding all of Robo's built-in tasks to throw an exception if the task fails.

In terms of regressions, the biggest risk with this change comes from the fact that commands will now throw an exception and stop the process by default when they fail, unless you specifically wrap them in a try/catch (duh, this is the whole point). I know that there are some commands that we run (such as `drush cr`) that we don't really mind if they fail, now they are going to start halting unexpectedly. Plus, it's just a _big_ change with lots of unknown side effects.

In terms of refactoring/code complexity, this requires that we override every Robo task individually. It generally just goes against the way Robo is architected. And because of this, it won't help if in the future someone uses a Robo task that we _haven't_ yet overridden. The whole point of this user story is to make commands strictly handle errors _universally_, so in that regard this approach still falls short.

Ideally Robo would fix this upstream and save us all this trouble: https://github.com/consolidation/Robo/issues/891. Maybe I'll ping the maintainer. As a short-term solution that's much less effort, we could just perform a code audit to try to catch any other instances where we aren't checking exit codes, and perform spot-fixes instead of changing the entire architecture.