### PR TITLE
Fixes #3849: Drush alias check fails on Windows.

### DIFF
--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -79,7 +79,7 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
     $bin = $this->getConfigValue('composer.bin');
     /** @var \Robo\Common\ProcessExecutor $process_executor */
     $drush_alias = $this->getConfigValue('drush.alias');
-    $command_string = "\"$bin/drush\" @$drush_alias $command";
+    $command_string = $bin . DIRECTORY_SEPARATOR . "drush @$drush_alias $command";
 
     // URIs do not work on remote drush aliases in Drush 9. Instead, it is
     // expected that the alias define the uri in its configuration.

--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -79,7 +79,7 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
     $bin = $this->getConfigValue('composer.bin');
     /** @var \Robo\Common\ProcessExecutor $process_executor */
     $drush_alias = $this->getConfigValue('drush.alias');
-    $command_string = "'$bin/drush' @$drush_alias $command";
+    $command_string = "\"$bin/drush\" @$drush_alias $command";
 
     // URIs do not work on remote drush aliases in Drush 9. Instead, it is
     // expected that the alias define the uri in its configuration.

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -275,8 +275,9 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
   /**
    * Validates a drush alias.
    *
-   * Note that this runs in the context of the _configured_ Drush alias, but validates the _passed_ Drush alias. So the
-   * generated command might be `drush @self site:alias @self --format=json`
+   * Note that this runs in the context of the _configured_ Drush alias, but
+   * validates the _passed_ Drush alias. So the generated command might be:
+   * `drush @self site:alias @self --format=json`
    *
    * @param string $alias
    *   Drush alias.

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -275,6 +275,9 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
   /**
    * Validates a drush alias.
    *
+   * Note that this runs in the context of the _configured_ Drush alias, but validates the _passed_ Drush alias. So the
+   * generated command might be `drush @self site:alias @self --format=json`
+   *
    * @param string $alias
    *   Drush alias.
    *
@@ -282,10 +285,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    *   TRUE if alias is valid.
    */
   public function isDrushAliasValid($alias) {
-    $bin = $this->getConfigValue('composer.bin');
-    $command = "'$bin/drush' site:alias @$alias --format=json";
-    return $this->executor->execute($command)
-      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERY_VERBOSE)
+    return $this->executor->drush("site:alias @$alias --format=json")
       ->run()
       ->wasSuccessful();
   }


### PR DESCRIPTION
Fixes #3849 
--------

Changes proposed
---------
- Use the built-in `drush()` executor instead of the one-off Drush call (not sure why it was written this way)
- Change the Drush executor to play nicely on Windows by wrapping the command in double quotes instead of single quotes

Steps to replicate the issue
----------
1. Create a new BLT project on Windows
2. Attempt to install the site via Git Bash (I think it would fail in other shells as well): `blt setup`

Previous (bad) behavior, before applying PR
----------
Error that Drush alias is not valid

Expected behavior, after applying PR and re-running test steps
-----------
Install proceeds without error
