### PR TITLE
DT-586: Fixes #3616: Support syncing of private files.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -138,6 +138,7 @@ sync:
   # Set this value to 'true' or pass -D sync.files=true
   # to override this behavior.
   files: false
+  private-files: false
   # Paths to exclude during file syncing operations.
   exclude-paths:
     - styles

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -37,17 +37,23 @@ class SyncCommand extends BltTasks {
    * Copies remote db to local db, re-imports config, and executes db updates
    * for each multisite.
    *
+   * @param array $options
+   *   Array of CLI options.
+   *
    * @command drupal:sync:default:site
    * @aliases ds drupal:sync drupal:sync:default sync sync:refresh
    * @executeInVm
    */
-  public function sync($options = [
+  public function sync(array $options = [
     'sync-files' => FALSE,
+    'sync-private-files' => FALSE,
   ]) {
-
     $commands = $this->getConfigValue('sync.commands');
     if ($options['sync-files'] || $this->getConfigValue('sync.files')) {
       $commands[] = 'drupal:sync:files';
+    }
+    if ($options['sync-private-files'] || $this->getConfigValue('sync.private-files')) {
+      $commands[] = 'drupal:sync:private-files';
     }
     $this->invokeCommands($commands);
   }
@@ -74,6 +80,37 @@ class SyncCommand extends BltTasks {
       ->drush('rsync')
       ->arg($remote_alias . ':%files/')
       ->arg($this->getConfigValue('docroot') . "/sites/$site_dir/files")
+      ->option('exclude-paths', implode(':', $this->getConfigValue('sync.exclude-paths')));
+
+    $result = $task->run();
+
+    return $result;
+  }
+
+  /**
+   * Copies private remote files to local machine.
+   *
+   * @command drupal:sync:private-files
+   *
+   * @aliases dspf
+   *
+   * @validateDrushConfig
+   * @executeInVm
+   */
+  public function syncPrivateFiles() {
+    $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
+    $site_dir = $this->getConfigValue('site');
+    $private_files_local_path = $this->getConfigValue('repo.root') . '/files-private';
+    if ($site_dir != 'default') {
+      $private_files_local_path .= "/$site_dir";
+    }
+
+    $task = $this->taskDrush()
+      ->alias('')
+      ->uri('')
+      ->drush('rsync')
+      ->arg($remote_alias . ':%private/')
+      ->arg($private_files_local_path)
       ->option('exclude-paths', implode(':', $this->getConfigValue('sync.exclude-paths')));
 
     $result = $task->run();

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -63,7 +63,7 @@ class SyncCommand extends BltTasks {
    *
    * @command drupal:sync:files
    *
-   * @aliases dsf sync:files
+   * @aliases dsf sync:files drupal:sync:public-files
    *
    * @validateDrushConfig
    * @executeInVm


### PR DESCRIPTION
Fixes #3616 
--------

Changes proposed
---------
- Add `drupal:sync:private-files` command
- Add `sync.private-files` config option
- Modify `blt sync` to call `drupal:sync:private-files` if `sync.private-files` is TRUE.

Steps to replicate the issue
----------
1. Have a BLT project with a remote alias (cloud environment) defined, which has private files
1. Run `blt sync -Dsync.private-files=true` and verify that private files are synced to `<repo-root>/files-private`.