### PR TITLE
DT-795: Fixes #3847: Add support link to BltException.

### DIFF
--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -93,8 +93,7 @@ class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerA
       // command. We must check the exit code and throw our own exception. This
       // obviates the need to check the exit code of every invoked command.
       if ($exit_code) {
-        $this->output->writeln("The command `$command_name` failed. This most likely indicates a problem with your configuration, and is NOT a BLT bug. Follow this troubleshooting guide to diagnose the issue: https://docs.acquia.com/blt/faq/");
-        throw new BltException("Command `$command_name {$input->__toString()}` exited with code $exit_code.");
+        throw new BltException("Command `$command_name {$input->__toString()}` exited with code $exit_code. This most likely indicates a problem with your configuration, and is not a BLT bug.");
       }
     }
   }

--- a/src/Robo/Exceptions/BltException.php
+++ b/src/Robo/Exceptions/BltException.php
@@ -18,8 +18,7 @@ class BltException extends \Exception {
     \Throwable $previous = NULL
   ) {
 
-    // @todo Check verbosity level. If not verbose, append "Re-run the command
-    // with -v to see more verbose output."
+    $message .= "\nFor troubleshooting guidance and support, see https://docs.acquia.com/blt/faq/";
     parent::__construct($message, $code, $previous);
 
     $this->transmitAnalytics();


### PR DESCRIPTION
Fixes #3847 
--------

Changes proposed
---------
- Whenever a BltException is thrown, add a link to troubleshooting docs so people know where to go for support.

Steps to replicate the issue
----------
1. Run any command that generates an exception. `blt doctor` will usually do it.

Expected behavior, after applying PR and re-running test steps
-----------
1. Get a link to support docs.

Note that the FAQ on docs.acquia.com is a bit anemic at the moment, it will be improved with this updated version after the next docs sync: https://github.com/acquia/blt/blob/10.x/docs/SUPPORT.md