### PR TITLE
DT-598: Fixes #2722: ci.blt.yml not consistently applied.

### DIFF
--- a/scripts/pipelines/build_artifact
+++ b/scripts/pipelines/build_artifact
@@ -7,7 +7,7 @@ export PATH=${COMPOSER_BIN}:${PATH}
 # Generate artifact in a separate directory.
 export NEW_BUILD_DIR=/tmp/artifact
 blt deploy:check-dirty --ansi --verbose
-blt artifact:build -D deploy.dir=${NEW_BUILD_DIR} --ansi --verbose
+blt artifact:build -D deploy.dir=${NEW_BUILD_DIR} --environment=ci --ansi --verbose
 # Move git history to artifact directory. Required for pipelines to commit and push.
 mv ${SOURCE_DIR}/.git ${NEW_BUILD_DIR}/
 # Allow dotfiles (hidden) to be globbed (via *).

--- a/subtree-splits/blt-project/blt/blt.yml
+++ b/subtree-splits/blt-project/blt/blt.yml
@@ -1,6 +1,14 @@
 # This file contains your BLT configuration. For a list of all available
 # properties with current values run `blt config:dump`. Default values come
 # from vendor/acquia/blt/config/build.yml.
+#
+# These values can be overridden at the command line using `--define`, i.e.:
+# blt setup --define project.profile.name=minimal
+#
+# However, when tokens in this file are expanded, they will not use any such
+# command-line overrides. For instance, `blt sync --define drush.aliases.local`
+# will not modify `drush.default_alias`, even though `drush.default_alias` is
+# set to `drush.aliases.local` by default.
 project:
   # Everyone: This will determine the the directory name of the new repository.
   # Dev Desktop users: this should match your local site name.


### PR DESCRIPTION
Fixes #2722 
--------

Changes proposed
---------
- Add documentation about how yml properties are expanded
- Fix ci environment not being detected when building artifact on Pipelines

Steps to replicate the issue
----------
1. Add a `post-deploy-build` command to `ci.blt.yml`, i.e.:
```
command-hooks:
  post-deploy-build:
    dir: /tmp/artifact
    command: 'npm install'
```
2. Commit and start a pipelines job.

Previous (bad) behavior, before applying PR
----------
The post-deploy-build command is not run

Expected behavior, after applying PR and re-running test steps
-----------
The post-deploy-build command is run
