### PR TITLE
Correct extra.patches data type in blt-project/composer.json

### DIFF
--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -76,7 +76,7 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
-        "patches": []
+        "patches": {}
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The `extra.patches` element in `composer.json` is supposed to be an object, not an array. I doubt anyone will make me defend a fix to something that technically wrong, but I'll just mention without going into details that this makes it much more difficult than it needs to be to safely modify the value from the command-line (i.e., to insert a member rather than clobbering the whole value).