### PR TITLE
DT-880: Fixes #3869: duplicate .htaccess in composer.json with acsf:init

### DIFF
--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -75,7 +75,7 @@ class AcsfCommand extends BltTasks {
     // .htaccess was patched, excluding from further updates.
     $composer_filepath = $this->getConfigValue('repo.root') . '/composer.json';
     $composer_contents = json_decode(file_get_contents($composer_filepath));
-    if (!isset($composer_contents->extra->{'drupal-scaffold'}->excludes['.htaccess'])) {
+    if (!property_exists($composer_contents->extra->{'drupal-scaffold'}, 'excludes') || !in_array('.htaccess', $composer_contents->extra->{'drupal-scaffold'}->excludes)) {
       $composer_contents->extra->{'drupal-scaffold'}->excludes[] = '.htaccess';
     }
     file_put_contents($composer_filepath, json_encode($composer_contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));

--- a/src/Robo/Commands/Acsf/AcsfCommand.php
+++ b/src/Robo/Commands/Acsf/AcsfCommand.php
@@ -75,7 +75,9 @@ class AcsfCommand extends BltTasks {
     // .htaccess was patched, excluding from further updates.
     $composer_filepath = $this->getConfigValue('repo.root') . '/composer.json';
     $composer_contents = json_decode(file_get_contents($composer_filepath));
-    $composer_contents->extra->{'drupal-scaffold'}->excludes[] = '.htaccess';
+    if (!isset($composer_contents->extra->{'drupal-scaffold'}->excludes['.htaccess'])) {
+      $composer_contents->extra->{'drupal-scaffold'}->excludes[] = '.htaccess';
+    }
     file_put_contents($composer_filepath, json_encode($composer_contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   }
 


### PR DESCRIPTION
Fixes #3869 
--------

Changes proposed
---------
- Only add `.htaccess` to the drupal scaffold excludes list if it doesn't already exist.

Steps to replicate the issue
----------
1. Start with a new non-ACSF BLT project.
2. Run `blt acsf:init` once and verify `.htaccess` is added to drupal-scaffold excludes array.
3. Run `blt acsf:init` a second time.

Previous (bad) behavior, before applying PR
----------
`.htaccess` is added a second time.

Expected behavior, after applying PR and re-running test steps
-----------
`.htaccess` only exists once.
