### PR TITLE
TwigCommand should use configured project docroot.

### DIFF
--- a/src/Robo/Commands/Validate/TwigCommand.php
+++ b/src/Robo/Commands/Validate/TwigCommand.php
@@ -107,8 +107,8 @@ class TwigCommand extends BltTasks {
   protected function createTwigLintCommand() {
     $twig = new Environment(new FilesystemLoader());
 
-    $repo_root = $this->getConfigValue('repo.root');
-    $extension_file_contents = file_get_contents($repo_root . '/docroot/core/lib/Drupal/Core/Template/TwigExtension.php');
+    $docroot = $this->getConfigValue('docroot');
+    $extension_file_contents = file_get_contents($docroot . '/core/lib/Drupal/Core/Template/TwigExtension.php');
 
     // Get any custom defined Twig filters to be ignored by linter.
     $twig_filters = (array) $this->getConfigValue('validate.twig.filters');
@@ -149,7 +149,7 @@ class TwigCommand extends BltTasks {
     }
 
     // Add Drupal Twig parser to include trans tag.
-    $token_parser_filename = $repo_root . '/docroot/core/lib/Drupal/Core/Template/TwigTransTokenParser.php';
+    $token_parser_filename = $docroot . '/core/lib/Drupal/Core/Template/TwigTransTokenParser.php';
     if (file_exists($token_parser_filename)) {
       // phpcs:ignore
       require_once $token_parser_filename;


### PR DESCRIPTION
Fixes #3863
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- Use BLT configuration for Drupal docroot instead of hardcoded `docroot` relative to repo root during Twig linting
-

Steps to replicate the issue
----------
1. 
2. 

Previous (bad) behavior, before applying PR
----------
> tests:twig:lint:files
Linting twig files...
PHP Warning:  file_get_contents(/path/to/project/docroot/core/lib/Drupal/Core/Template

Expected behavior, after applying PR and re-running test steps
-----------
No path errors during Twig lint command.

Additional details
-----------
