### PR TITLE
Adds documentation for the Docksal environment

### DIFF
--- a/docs/alternative-environment-tips/docksal.md
+++ b/docs/alternative-environment-tips/docksal.md
@@ -1,0 +1,15 @@
+# Setting up BLT with Docksal
+
+By default, BLT is set to work with Drupal VM. It is easy to set up to use with Docksal, and there are two easy ways
+to set this up.
+
+## Setting Your Existing Project to Use Docksal
+
+You can install the [Docksal BLT plugin](../plugins) and run the commands to setup your BLT site to use Docksal.
+
+## Creating a New BLT Project Using Docksal
+
+If you have [Docksal](https://docksal.io) installed and want to create a new BLT project, use `fin project create`
+wizard and select Drupal 8 (BLT Version) from the list. This will download the BLT Boilerplate Project and run the 
+included `fin init` command. This will download all composer require dependencies, set proper database settings for BLT, 
+include the BLT addon command, and install the Drupal site.


### PR DESCRIPTION
Referencing #3828 

Although there is a plugin now listed on the plugins documentation page, I still believe that there needs to be "some" documentation of Docksal as an alternative environment. Included in this PR is documentation on the two methods to setting up Docksal with BLT. One uses the plugin for existing systems, one uses Docksal to create the BLT site - pre-configured for running BLT and Docksal.

Removing it altogether makes it look like Docksal isn't a candidate for an alternative development environment.