### PR TITLE
DT-948: Improve ACSF detection logic.

### DIFF
--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Blt\Robo\Common;
 
-use Acquia\Blt\Robo\Exceptions\BltException;
 use drupol\phposinfo\OsInfo;
 
 /**

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -22,7 +22,9 @@ class EnvironmentDetector {
   }
 
   /**
-   * Is ACSF env.
+   * Check if this is an ACSF env.
+   *
+   * Roughly duplicates the detection logic implemented by the ACSF module.
    *
    * @param mixed $ah_group
    *   The Acquia Hosting site / group name (e.g. my_subscription).
@@ -30,9 +32,9 @@ class EnvironmentDetector {
    *   The Acquia Hosting environment name (e.g. 01dev).
    *
    * @return bool
-   *   Bool.
+   *   TRUE if this is an ACSF environment, FALSE otherwise.
    *
-   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   * @see https://git.drupalcode.org/project/acsf/blob/8.x-2.62/acsf_init/lib/sites/default/acsf.settings.php#L14
    */
   public static function isAcsfEnv($ah_group = NULL, $ah_env = NULL) {
     if (is_null($ah_group)) {
@@ -47,14 +49,7 @@ class EnvironmentDetector {
       return FALSE;
     }
 
-    $is_acsf_json = file_exists("/mnt/files/$ah_group.$ah_env/files-private/sites.json");
-    $is_acsf_env_name = preg_match('/\d+(dev|test|live|update)(up)?/', $ah_env);
-
-    if ($is_acsf_json != $is_acsf_env_name) {
-      throw new BltException("Cannot determine if this is an ACSF environment or not.");
-    }
-
-    return ($is_acsf_env_name && $is_acsf_json);
+    return file_exists("/mnt/files/$ah_group.$ah_env/files-private/sites.json");
   }
 
   /**


### PR DESCRIPTION
Changes proposed
---------
- Fix ACSF detection logic in unorthodox environments / realms (other than dev/test/live)

Steps to replicate the issue
----------
1. Deploy to an ACSF environment named something like `01train1`

Previous (bad) behavior, before applying PR
----------
Observe a BLT exception.

Expected behavior, after applying PR and re-running test steps
-----------
No exception, BLT correctly detects the presence of ACSF hosting

Additional details
-----------
The ACSF module itself just checks for the existence of the sites.json module, we should follow its lead (if that fails, BLT will be the least of the problem). Doing an additional regex is overkill and fails in some environments.

We considered alternatives such as checking the AH_REALM env var, but this is also not consistent between subscriptions (usually enterprise-g1, but sometimes other values). And again... let's just follow in the ACSF module's footsteps.