### PR TITLE
DT-950: Update node version in Pipelines.

### DIFF
--- a/scripts/pipelines/acquia-pipelines.yml
+++ b/scripts/pipelines/acquia-pipelines.yml
@@ -18,7 +18,7 @@ events:
               - composer validate --no-check-all --ansi
               - composer install --ansi
               - source ${BLT_DIR}/scripts/pipelines/setup_env
-              # - nvm install v6.9.1
+              # - nvm install v6.9.1 --latest-npm
               # - npm install --global yarn
         - validate:
             type: script

--- a/scripts/pipelines/build_artifact
+++ b/scripts/pipelines/build_artifact
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Composer and should not be modified by end users. To
+# override its default behavior, copy it into your project and modify
+# acquia-pipelines.yml to call your custom version.
 
 set -ev
 

--- a/scripts/pipelines/setup_app
+++ b/scripts/pipelines/setup_app
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Composer and should not be modified by end users. To
+# override its default behavior, copy it into your project and modify
+# acquia-pipelines.yml to call your custom version.
 
 set -ev
 

--- a/scripts/pipelines/setup_env
+++ b/scripts/pipelines/setup_env
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Composer and should not be modified by end users. To
+# override its default behavior, copy it into your project and modify
+# acquia-pipelines.yml to call your custom version.
 
 set -ev
 
@@ -12,7 +15,6 @@ git config --global user.email "noreply@acquia.com"
 mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS drupal"
 
 # Setup NVM.
-nvm install v8.1.4
-npm install -g npm
+nvm install stable --latest-npm
 
 set +v

--- a/scripts/pipelines/setup_env
+++ b/scripts/pipelines/setup_env
@@ -14,7 +14,7 @@ git config --global user.email "noreply@acquia.com"
 # Create MySQL DB.
 mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS drupal"
 
-# Setup NVM.
+# Setup NVM and install latest node/npm versions. This is necessary to avoid a common Pipelines support request related to resource exhaustion on older versions of NPM.
 nvm install stable --latest-npm
 
 set +v

--- a/scripts/pipelines/setup_env
+++ b/scripts/pipelines/setup_env
@@ -14,7 +14,4 @@ git config --global user.email "noreply@acquia.com"
 # Create MySQL DB.
 mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS drupal"
 
-# Setup NVM and install latest node/npm versions. This is necessary to avoid a common Pipelines support request related to resource exhaustion on older versions of NPM.
-nvm install stable --latest-npm
-
 set +v

--- a/scripts/pipelines/tests
+++ b/scripts/pipelines/tests
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Composer and should not be modified by end users. To
+# override its default behavior, copy it into your project and modify
+# acquia-pipelines.yml to call your custom version.
 
 set -ev
 

--- a/scripts/pipelines/validate
+++ b/scripts/pipelines/validate
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# This file is managed by Composer and should not be modified by end users. To
+# override its default behavior, copy it into your project and modify
+# acquia-pipelines.yml to call your custom version.
 
 set -ev
 


### PR DESCRIPTION
Fixes #3900 
--------

Changes proposed
---------
- Stop automatically updating Node in Pipelines. We already provide guidance on how end users can manage this themselves.
- Add notes clarifying intended usage of Pipelines scripts

Requires change record since users relying on BLT's node version might be surprised when it goes away.