### PR TITLE
DT-593: Codesniffing via pre-commit hook doesn't respect filesets.

### DIFF
--- a/src/Robo/Commands/Git/GitCommand.php
+++ b/src/Robo/Commands/Git/GitCommand.php
@@ -62,7 +62,7 @@ class GitCommand extends BltTasks {
     $collection->addCode(
       function () use ($changed_files) {
         return $this->invokeCommands([
-          'tests:phpcs:sniff:files' => ['file_list' => $changed_files],
+          'tests:phpcs:sniff:modified',
           'tests:twig:lint:files' => ['file_list' => $changed_files],
           'tests:yaml:lint:files' => ['file_list' => $changed_files],
         ]);

--- a/src/Robo/Commands/Validate/PhpcsCommand.php
+++ b/src/Robo/Commands/Validate/PhpcsCommand.php
@@ -11,21 +11,17 @@ use Acquia\Blt\Robo\Exceptions\BltException;
 class PhpcsCommand extends BltTasks {
 
   /**
-   * Executes PHP Code Sniffer against all phpcs.filesets files.
+   * Executes PHP Code Sniffer against configured files.
    *
-   * By default, these include custom themes, modules, and tests.
+   * By default, these include custom themes, modules, and tests. This is
+   * configured via phpcs.xml in the project root directory.
    *
    * @command tests:phpcs:sniff:all
    *
    * @aliases tpsa phpcs tests:phpcs:sniff validate:phpcs
    */
   public function sniffFileSets() {
-    $bin = $this->getConfigValue('composer.bin');
-    $result = $this->taskExecStack()
-      ->dir($this->getConfigValue('repo.root'))
-      ->exec("$bin/phpcs")
-      ->run();
-    $exit_code = $result->getExitCode();
+    $exit_code = $this->doSniff();
     if ($exit_code) {
       if ($this->input()->isInteractive()) {
         $this->fixViolationsInteractively();
@@ -50,10 +46,12 @@ class PhpcsCommand extends BltTasks {
   }
 
   /**
-   * Executes PHP Code Sniffer against a list of files, if in phpcs.filesets.
+   * Executes PHP Code Sniffer against a list of files.
    *
-   * This command will execute PHP Codesniffer against a list of files if those
-   * files are a subset of the phpcs.filesets filesets.
+   * This command will execute PHP Codesniffer against a list of files. Note
+   * that files excluded by phpcs.xml will not be sniffed, even if specifically
+   * included here. However, files passed as arguments and not specifically
+   * included or excluded by phpcs.xml _will_ be sniffed.
    *
    * @param string $file_list
    *   A list of files to scan, separated by \n.
@@ -97,7 +95,7 @@ class PhpcsCommand extends BltTasks {
    */
   public function sniffModified() {
     $this->say("Sniffing modified and untracked files in repo...");
-    $arguments = "--filter=gitmodified " . $this->getConfigValue('repo.root');
+    $arguments = "--filter=GitModified";
     $exit_code = $this->doSniff($arguments);
 
     return $exit_code;
@@ -112,7 +110,7 @@ class PhpcsCommand extends BltTasks {
    * @return int
    *   Exit code.
    */
-  protected function doSniff($arguments) {
+  protected function doSniff($arguments = '') {
     $bin = $this->getConfigValue('composer.bin') . '/phpcs';
     $command = "'$bin' $arguments";
     if ($this->output()->isVerbose()) {
@@ -122,6 +120,7 @@ class PhpcsCommand extends BltTasks {
       $command .= ' -vv';
     }
     $result = $this->taskExecStack()
+      ->dir($this->getConfigValue('repo.root'))
       ->exec($command)
       ->printMetadata(FALSE)
       ->run();

--- a/src/Robo/Commands/Validate/PhpcsCommand.php
+++ b/src/Robo/Commands/Validate/PhpcsCommand.php
@@ -50,8 +50,8 @@ class PhpcsCommand extends BltTasks {
    *
    * This command will execute PHP Codesniffer against a list of files. Note
    * that files excluded by phpcs.xml will not be sniffed, even if specifically
-   * included here. However, files passed as arguments and not specifically
-   * included or excluded by phpcs.xml _will_ be sniffed.
+   * included here. However, files passed as arguments will be sniffed even if
+   * they are _not_ specifically included/whitelisted in phpcs.xml.
    *
    * @param string $file_list
    *   A list of files to scan, separated by \n.

--- a/subtree-splits/blt-project/phpcs.xml.dist
+++ b/subtree-splits/blt-project/phpcs.xml.dist
@@ -34,9 +34,5 @@
   <exclude-pattern>*/behat</exclude-pattern>
   <exclude-pattern>*/node_modules</exclude-pattern>
   <exclude-pattern>*/vendor</exclude-pattern>
-  <!-- Exclude files provided by ACSF that fail code sniffing. -->
-  <exclude-pattern>factory-hooks</exclude-pattern>
-  <exclude-pattern>hooks</exclude-pattern>
-  <exclude-pattern>docroot/sites/g</exclude-pattern>
 
 </ruleset>

--- a/tests/phpunit/src/SetupGitHooksTest.php
+++ b/tests/phpunit/src/SetupGitHooksTest.php
@@ -106,7 +106,7 @@ class SetupGitHooksTest extends BltProjectTestBase {
     $process->run();
     $output = $process->getOutput();
     // @todo Assert only changed files are validated.
-    $this->assertContains('tests:phpcs:sniff:files', $output);
+    $this->assertContains('tests:phpcs:sniff:modified', $output);
     $this->assertContains('tests:yaml:lint:files', $output);
     $this->assertContains('tests:twig:lint:files', $output);
   }


### PR DESCRIPTION
Fixes #3448 
--------

Changes proposed
---------
- For git pre-commit hook, stop sniffing an explicit list of modified files (which can result in files getting sniffed that otherwise wouldn't, according to filesets defined in phpcs.xml), and instead use PHPCS' built-in GitModified filter (which does respect phpcs.xml)
- Clarify comments / documentation about interaction between BLT's functions, phpcs.xml, and filesets.
- Fix the wrongly-named gitmodified filter
- Stop passing the current directory as an argument to phpcs, which will also cause it to include files not defined in phpcs.xml.

Steps to replicate the issue
----------
0. Ensure git hooks are installed in your project (you'll see validation running on commits).
1. Create a file with code style errors, such as `new-dir/test.php`.
2. Run `blt phpcs`, observe output.
3. `git add` the new file and attempt `git commit`.

Previous (bad) behavior, before applying PR
----------
`blt phcs` passes without errors as expected, since `new-dir` is not configured to be sniffed via phpcs.xml. But the Git commit fails unexpectedly.

Expected behavior, after applying PR and re-running test steps
-----------
Both `blt phpcs` and `git commit` pass without errors. Other files with errors (in directories such as `docroot/modules/custom`) still cause `blt phpcs` and `git commit` to fail.
