### PR TITLE
DT-851: Fix local private files path.

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -158,7 +158,7 @@ $config['system.file']['path']['temporary'] = '/tmp';
 /**
  * Private file path.
  */
-$settings['file_private_path'] = $dir . '/files-private';
+$settings['file_private_path'] = $dir . '/files-private/default';
 if (isset($_acsf_site_name)) {
   $settings['file_public_path'] = "sites/default/files/$_acsf_site_name";
   // phpcs:ignore

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -59,18 +59,18 @@ class SyncCommand extends BltTasks {
   }
 
   /**
-   * Copies remote files to local machine.
+   * Copies public remote files to local machine.
    *
-   * @command drupal:sync:files
+   * @command drupal:sync:public-files
    *
-   * @aliases dsf sync:files drupal:sync:public-files
+   * @aliases dsf sync:files drupal:sync:files
    *
    * @validateDrushConfig
    * @executeInVm
    *
    * @todo Support multisite.
    */
-  public function syncFiles() {
+  public function syncPublicFiles() {
     $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
     $site_dir = $this->getConfigValue('site');
 
@@ -100,10 +100,7 @@ class SyncCommand extends BltTasks {
   public function syncPrivateFiles() {
     $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
     $site_dir = $this->getConfigValue('site');
-    $private_files_local_path = $this->getConfigValue('repo.root') . '/files-private';
-    if ($site_dir != 'default') {
-      $private_files_local_path .= "/$site_dir";
-    }
+    $private_files_local_path = $this->getConfigValue('repo.root') . '/files-private' . "/$site_dir";
 
     $task = $this->taskDrush()
       ->alias('')

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -100,7 +100,7 @@ class SyncCommand extends BltTasks {
   public function syncPrivateFiles() {
     $remote_alias = '@' . $this->getConfigValue('drush.aliases.remote');
     $site_dir = $this->getConfigValue('site');
-    $private_files_local_path = $this->getConfigValue('repo.root') . '/files-private' . "/$site_dir";
+    $private_files_local_path = $this->getConfigValue('repo.root') . "/files-private/$site_dir";
 
     $task = $this->taskDrush()
       ->alias('')


### PR DESCRIPTION
Fixes #3854 
--------

Changes proposed
---------
- For default single-site installs, change local private files path from `/files-private` to `/files-private/default`
- Rename commands and methods for consistency

Change record required because this requires folks to move or re-sync their local files (probably not many affected users).