### PR TITLE
DT-850: Renamed sync.files config to sync.public-files.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -135,9 +135,9 @@ setup:
 
 sync:
   # By default, files are not synced during sync:refresh.
-  # Set this value to 'true' or pass -D sync.files=true
+  # Set this value to 'true' or pass -D sync.public-files=true
   # to override this behavior.
-  files: false
+  public-files: false
   private-files: false
   # Paths to exclude during file syncing operations.
   exclude-paths:

--- a/docs/project-tasks.md
+++ b/docs/project-tasks.md
@@ -44,7 +44,7 @@ This all in one command will make sure your local is in sync with the remote sit
 
 This will sync your site and execute all necessary updates afterwards (cache clears, database updates, config imports).
 
-By default, BLT will not sync your public and private files directories. However, you may set `sync.files` to `true` in your `blt.yml` file to perform a file sync during `sync:refresh` tasks by default
+By default, BLT will not sync your public and private files directories. However, you may set `sync.public-files` and `sync.private-files` to `true` in your `blt.yml` file to perform a file sync during `sync:refresh` tasks by default
 within your project.
 
 ### Multisite
@@ -57,7 +57,7 @@ If you are using multisite, you may refresh every single multisite on your local
 
     blt drupal:sync:db
 
-This will copy the database (and files if sync.files is set to true) but will not execute any updates afterwards.
+This will copy the database (and files if sync.public-files is set to true) but will not execute any updates afterwards.
 
 ### Update: Run update tasks locally
 

--- a/src/Robo/Commands/Sync/SyncCommand.php
+++ b/src/Robo/Commands/Sync/SyncCommand.php
@@ -45,12 +45,12 @@ class SyncCommand extends BltTasks {
    * @executeInVm
    */
   public function sync(array $options = [
-    'sync-files' => FALSE,
+    'sync-public-files' => FALSE,
     'sync-private-files' => FALSE,
   ]) {
     $commands = $this->getConfigValue('sync.commands');
-    if ($options['sync-files'] || $this->getConfigValue('sync.files')) {
-      $commands[] = 'drupal:sync:files';
+    if ($options['sync-public-files'] || $this->getConfigValue('sync.public-files')) {
+      $commands[] = 'drupal:sync:public-files';
     }
     if ($options['sync-private-files'] || $this->getConfigValue('sync.private-files')) {
       $commands[] = 'drupal:sync:private-files';


### PR DESCRIPTION
Fixes #3860 
--------

Changes proposed
---------
- Rename config options from `sync.files` to `sync.public-files`, etc...

Requires change record since users will need to use the new config value and parameter names.