### PR TITLE
DT-747: Removing dependency on webflo.

### DIFF
--- a/src/Robo/Commands/Tests/DrupalTestCommand.php
+++ b/src/Robo/Commands/Tests/DrupalTestCommand.php
@@ -105,6 +105,7 @@ class DrupalTestCommand extends TestsCommandBase {
    *   Throws an exception if any Drupal test fails.
    */
   public function executeTests() {
+    $this->logger->notice("Ensure that you have installed Drupal Core's dev dependencies (such as via https://github.com/webflo/drupal-core-require-dev) prior to running this command.");
     if (empty(shell_exec('which java'))) {
       $this->logger->warning("Cannot find Java. Drupal tests require Selenium, which requires Java. Drupal tests will be skipped.");
       return;

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -848,4 +848,22 @@ class Updates {
     }
   }
 
+  /**
+   * Version 11.0.0.
+   *
+   * @Update(
+   *   version = "11000000",
+   *   description = "Updates for BLT 11."
+   * )
+   */
+  public function update_11000000() {
+    $composer_json = $this->updater->getComposerJson();
+    $template_composer_json = $this->updater->getTemplateComposerJson();
+    // Update blt-require-dev to 11.x.
+    if (array_key_exists('acquia/blt-require-dev', $composer_json['require-dev'])) {
+      $composer_json['require-dev']['acquia/blt-require-dev'] = $template_composer_json['require-dev']['acquia/blt-require-dev'];
+      $this->updater->writeComposerJson($composer_json);
+    }
+  }
+
 }

--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -21,7 +21,7 @@
         "drupal/shield": "^1.2.0"
     },
     "require-dev": {
-        "acquia/blt-require-dev": "^10.0.0-alpha1"
+        "acquia/blt-require-dev": "^11.0.0-alpha1"
     },
     "config": {
         "platform": {

--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -21,7 +21,7 @@
         "drupal/shield": "^1.2.0"
     },
     "require-dev": {
-        "acquia/blt-require-dev": "^11.0.0-alpha1"
+        "acquia/blt-require-dev": "11.x-dev"
     },
     "config": {
         "platform": {

--- a/subtree-splits/blt-require-dev/composer.json
+++ b/subtree-splits/blt-require-dev/composer.json
@@ -10,12 +10,11 @@
         "drupal/drupal-extension": "~3.2",
         "jarnaiz/behat-junit-formatter": "^1.3.2",
         "phpunit/phpunit": "^4.8 || ^6.5",
-        "squizlabs/php_codesniffer": "^3.0.1",
-        "webflo/drupal-core-require-dev": "^8.6.1"
+        "squizlabs/php_codesniffer": "^3.0.1"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "10.x-dev"
+            "dev-master": "11.x-dev"
         }
     },
     "minimum-stability": "dev"

--- a/tests/phpunit/src/TestDrupalTestCommandTest.php
+++ b/tests/phpunit/src/TestDrupalTestCommandTest.php
@@ -44,6 +44,7 @@ class TestDrupalTestCommandTest extends BltProjectTestBase {
     $this->sqlite = $this->config->get("tests.drupal.sqlite");
     $this->url = $this->config->get("tests.drupal.simpletest-base-url");
     $this->execute('composer require se/selenium-server-standalone');
+    $this->execute('composer require webflo/drupal-core-require-dev');
   }
 
   /**

--- a/tests/phpunit/src/TestDrupalTestCommandTest.php
+++ b/tests/phpunit/src/TestDrupalTestCommandTest.php
@@ -44,7 +44,9 @@ class TestDrupalTestCommandTest extends BltProjectTestBase {
     $this->sqlite = $this->config->get("tests.drupal.sqlite");
     $this->url = $this->config->get("tests.drupal.simpletest-base-url");
     $this->execute('composer require se/selenium-server-standalone');
-    $this->execute('composer require webflo/drupal-core-require-dev');
+    // drupal-core-require-dev has some nasty dependency conflicts.
+    $this->execute('composer require webflo/drupal-core-require-dev --no-update');
+    $this->execute('composer update');
   }
 
   /**


### PR DESCRIPTION
Fixes #3838  
--------

Changes proposed
---------
- Remove dependency on webflo/drupal-core-require-dev

Additional details
-----------
Users that wish to run Drupal core tests going forward will need to ensure they have Drupal core dev dependencies installed, i.e. by installing webflo/drupal-core-require-dev.

We can't easily test for the presence of these dependencies. We could test for webflo/drupal-core-require-dev but that's just a heuristic and would generate false positives for a lot of customers. I think it's better to not automate this.