### PR TITLE
DT-657: Fixes #3785: Split up examples:init command, don't run automatically

### DIFF
--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -113,7 +113,6 @@ class UpdateCommand extends BltTasks {
     $this->getConfig()->replace($new_config->export());
 
     $this->invokeCommand('blt:init:settings');
-    $this->invokeCommand('recipes:blt:init:command');
     $this->invokeCommand('blt:init:shell-alias');
     if (DIRECTORY_SEPARATOR === '\\') {
       // On Windows, during composer create-project,

--- a/src/Robo/Commands/Recipes/BehatCommand.php
+++ b/src/Robo/Commands/Recipes/BehatCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Acquia\Blt\Robo\Commands\Recipes;
+
+use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Exceptions\BltException;
+use Robo\Contract\VerbosityThresholdInterface;
+
+/**
+ * Defines commands in the "recipes:behat:*" namespace.
+ */
+class BehatCommand extends BltTasks {
+
+  /**
+   * Generates example files for writing custom Behat tests.
+   *
+   * @command recipes:behat:init
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  public function init() {
+    $result = $this->taskFilesystemStack()
+      ->copy(
+        $this->getConfigValue('blt.root') . '/scripts/blt/examples/Test/Examples.feature',
+        $this->getConfigValue('repo.root') . '/tests/behat/features/Examples.feature', FALSE)
+      ->stopOnFail()
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+      ->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Could not copy example files into the repository root.");
+    }
+
+    $this->say("<info>Example Behat tests were copied into your application.</info>");
+  }
+
+}

--- a/src/Robo/Commands/Recipes/BltCommand.php
+++ b/src/Robo/Commands/Recipes/BltCommand.php
@@ -7,28 +7,46 @@ use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
 
 /**
- * Defines commands in the "examples:*" namespace.
+ * Defines commands in the "recipes:blt:*" namespace.
  */
-class ExamplesCommand extends BltTasks {
+class BltCommand extends BltTasks {
 
   /**
    * Generates example files for writing custom commands and hooks.
    *
-   * @command recipes:blt:init:command
+   * @command recipes:blt:command:init
    *
-   * @aliases rbic examples:init
+   * @aliases rbci rbic examples:init
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
-  public function init() {
+  public function commandInit() {
     $result = $this->taskFilesystemStack()
       ->copy(
         $this->getConfigValue('blt.root') . '/scripts/blt/examples/Commands/ExampleCommands.php',
         $this->getConfigValue('repo.root') . '/blt/src/Blt/Plugin/Commands/ExampleCommands.php', FALSE)
-      ->copy(
-        $this->getConfigValue('blt.root') . '/scripts/blt/examples/Test/ExampleTest.php',
-        $this->getConfigValue('repo.root') . '/tests/phpunit/ExampleTest.php', FALSE)
-      ->copy(
-        $this->getConfigValue('blt.root') . '/scripts/blt/examples/Test/Examples.feature',
-        $this->getConfigValue('repo.root') . '/tests/behat/features/Examples.feature', FALSE)
+      ->stopOnFail()
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+      ->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Could not copy example files into the repository root.");
+    }
+
+    $this->say("<info>Example commands and hooks were copied into your application.</info>");
+  }
+
+  /**
+   * Generates example files for writing custom filesets.
+   *
+   * @command recipes:blt:filesystem:init
+   *
+   * @aliases rbfi
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  public function filesetInit() {
+    $result = $this->taskFilesystemStack()
       ->copy(
         $this->getConfigValue('blt.root') . '/scripts/blt/examples/Filesets/ExampleFilesets.php',
         $this->getConfigValue('repo.root') . '/blt/src/Blt/Plugin/Filesets/ExampleFilesets.php', FALSE)
@@ -40,7 +58,7 @@ class ExamplesCommand extends BltTasks {
       throw new BltException("Could not copy example files into the repository root.");
     }
 
-    $this->say("<info>Example commands and hooks were copied to your repository root.</info>");
+    $this->say("<info>Example filesets were copied into your application.</info>");
   }
 
 }

--- a/src/Robo/Commands/Recipes/PhpUnitCommand.php
+++ b/src/Robo/Commands/Recipes/PhpUnitCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Acquia\Blt\Robo\Commands\Recipes;
+
+use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Exceptions\BltException;
+use Robo\Contract\VerbosityThresholdInterface;
+
+/**
+ * Defines commands in the "recipes:phpunit:*" namespace.
+ */
+class PhpUnitCommand extends BltTasks {
+
+  /**
+   * Generates example files for writing PHPUnit tests.
+   *
+   * @command recipes:phpunit:init
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  public function init() {
+    $result = $this->taskFilesystemStack()
+      ->copy(
+        $this->getConfigValue('blt.root') . '/scripts/blt/examples/Test/ExampleTest.php',
+        $this->getConfigValue('repo.root') . '/tests/phpunit/ExampleTest.php', FALSE)
+      ->stopOnFail()
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+      ->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Could not copy example files into the repository root.");
+    }
+
+    $this->say("<info>Example PHPUnit files were copied to your application.</info>");
+  }
+
+}

--- a/subtree-splits/blt-project/phpcs.xml.dist
+++ b/subtree-splits/blt-project/phpcs.xml.dist
@@ -26,7 +26,6 @@
     <exclude name="DrupalPractice.InfoFiles.NamespacedDependency"/>
   </rule>
 
-  <file>blt/src</file>
   <file>docroot/modules/custom</file>
   <file>docroot/themes/custom</file>
   <file>tests</file>

--- a/tests/phpunit/src/CustomCommandTest.php
+++ b/tests/phpunit/src/CustomCommandTest.php
@@ -12,7 +12,7 @@ use Acquia\Blt\Tests\BltProjectTestBase;
 class CustomCommandTest extends BltProjectTestBase {
 
   public function testExampleCustomCommand() {
-    $this->blt("recipes:blt:init:command");
+    $this->blt("recipes:blt:command:init");
     // For some reason, using $this->blt does not work. Guessing related to
     // symlinking blt.
     $process = $this->execute("./vendor/bin/blt custom:hello");

--- a/tests/phpunit/src/TestBehatCommandTest.php
+++ b/tests/phpunit/src/TestBehatCommandTest.php
@@ -15,6 +15,7 @@ class TestBehatCommandTest extends BltProjectTestBase {
    * Tests tests:behat:init:config command.
    */
   public function testSetupBehat() {
+    $this->blt("recipes:behat:init");
     $this->blt("tests:behat:init:config");
     // Assert that a local.yml file was created in the new project.
     $this->assertFileExists($this->sandboxInstance . '/tests/behat/local.yml');
@@ -28,6 +29,7 @@ class TestBehatCommandTest extends BltProjectTestBase {
    * @group requires-db
    */
   public function testBehatCommand() {
+    $this->blt("recipes:behat:init");
     $this->installDrupalMinimal();
     list($status_code) = $this->blt("tests:behat:run");
     $this->assertEquals(0, $status_code);

--- a/tests/phpunit/src/TestPhpUnitCommandTest.php
+++ b/tests/phpunit/src/TestPhpUnitCommandTest.php
@@ -26,7 +26,7 @@ class TestPhpUnitCommandTest extends BltProjectTestBase {
    */
   public function setUp() {
     parent::setUp();
-    $this->blt('recipes:blt:init:command');
+    $this->blt('recipes:phpunit:init');
     $this->docroot = $this->config->get("docroot");
     $this->reporoot = $this->config->get("repo.root");
   }


### PR DESCRIPTION
Fixes #3785 
--------

Changes proposed
---------
- Don't initialize these files automatically for new BLT projects, since they are just templates and not useful for all users.
- Split examples:init into more granular commands for each type of file.

Steps to replicate the issue
----------
1. In a normal BLT application, remove `blt/src`, `tests/phpunit`, and `tests/behat/features/Examples.feature`, then run these commands and ensure the files are recreated exactly as before. 