### PR TITLE
DT-596: Fixes #3052: Add Git pre-push validation.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -86,6 +86,7 @@ git:
   # You should execute `blt blt:init:git-hooks` after modifying these values.
   hooks:
     pre-commit: ${blt.root}/scripts/git-hooks
+    pre-push: ${blt.root}/scripts/git-hooks
     commit-msg: ${blt.root}/scripts/git-hooks
   commit-msg:
     # Commit messages must conform to this pattern.

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
 ROOT_DIR="$(pwd)/"
-LIST=$( git diff --name-only --cached --diff-filter=ACM )
-PHPCS_BIN=vendor/bin/phpcs
 
 echo "Executing .git/hooks/pre-push..."
-"${ROOT_DIR}"/vendor/bin/blt internal:git-hook:execute:pre-push "${LIST}"
+"${ROOT_DIR}"/vendor/bin/blt internal:git-hook:execute:pre-push
 
 # Return the status of the last run command.
 exit $?

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="$(pwd)/"
+LIST=$( git diff --name-only --cached --diff-filter=ACM )
+PHPCS_BIN=vendor/bin/phpcs
+
+echo "Executing .git/hooks/pre-push..."
+"${ROOT_DIR}"/vendor/bin/blt internal:git-hook:execute:pre-push "${LIST}"
+
+# Return the status of the last run command.
+exit $?

--- a/src/Robo/Commands/Internal/GitCommand.php
+++ b/src/Robo/Commands/Internal/GitCommand.php
@@ -25,7 +25,7 @@ class GitCommand extends BltTasks {
     $pattern = $this->getConfigValue('git.commit-msg.pattern');
     $help_description = $this->getConfigValue('git.commit-msg.help_description');
     $example = $this->getConfigValue('git.commit-msg.example');
-    $this->logger->debug("Validing commit message with regex <comment>$pattern</comment>.");
+    $this->logger->debug("Validating commit message with regex <comment>$pattern</comment>.");
     if (!preg_match($pattern, $message)) {
       $this->logger->error("Invalid commit message!");
       $this->say("Commit messages must conform to the regex $pattern");
@@ -57,6 +57,47 @@ class GitCommand extends BltTasks {
    *   Result.
    */
   public function preCommitHook($changed_files) {
+    $result = $this->validateFiles($changed_files);
+
+    if ($result->wasSuccessful()) {
+      $this->say("<info>Your local code has passed git pre-commit validation.</info>");
+    }
+
+    return $result;
+  }
+
+  /**
+   * Validates staged files.
+   *
+   * @param string $changed_files
+   *   A list of staged files, separated by \n.
+   *
+   * @command internal:git-hook:execute:pre-push
+   * @hidden
+   *
+   * @return \Robo\Result
+   *   Result.
+   */
+  public function prePushHook($changed_files) {
+    $result = $this->validateFiles($changed_files);
+
+    if ($result->wasSuccessful()) {
+      $this->say("<info>Your local code has passed git pre-push validation.</info>");
+    }
+
+    return $result;
+  }
+
+  /**
+   * Validates staged files.
+   *
+   * @param string $changed_files
+   *   A list of staged files, separated by \n.
+   *
+   * @return \Robo\Result
+   *   Result.
+   */
+  public function validateFiles($changed_files) {
     $collection = $this->collectionBuilder();
     $collection->setProgressIndicator(NULL);
     $collection->addCode(
@@ -82,10 +123,6 @@ class GitCommand extends BltTasks {
     $result = $collection
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();
-
-    if ($result->wasSuccessful()) {
-      $this->say("<info>Your local code has passed git pre-commit validation.</info>");
-    }
 
     return $result;
   }

--- a/subtree-splits/blt-require-dev/composer.json
+++ b/subtree-splits/blt-require-dev/composer.json
@@ -10,7 +10,8 @@
         "drupal/drupal-extension": "~3.2",
         "jarnaiz/behat-junit-formatter": "^1.3.2",
         "phpunit/phpunit": "^4.8 || ^6.5",
-        "squizlabs/php_codesniffer": "^3.0.1"
+        "squizlabs/php_codesniffer": "^3.0.1",
+        "sirbrillig/phpcs-variable-analysis": "dev-master"
     },
     "extra": {
         "branch-alias": {

--- a/subtree-splits/blt-require-dev/composer.json
+++ b/subtree-splits/blt-require-dev/composer.json
@@ -10,8 +10,7 @@
         "drupal/drupal-extension": "~3.2",
         "jarnaiz/behat-junit-formatter": "^1.3.2",
         "phpunit/phpunit": "^4.8 || ^6.5",
-        "squizlabs/php_codesniffer": "^3.0.1",
-        "sirbrillig/phpcs-variable-analysis": "dev-master"
+        "squizlabs/php_codesniffer": "^3.0.1"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Fixes #3052 
--------

Changes proposed
---------
- Add a new pre-push git hook that runs the full validation suite

Steps to replicate the issue
----------
1. Run `blt blt:init:git-hooks` to install the new hook.
2. Create a custom file that fails validation (maybe a custom module, or modify composer.json without updating composer.lock)
3. Create a new commit and try to push it. Ensure that validation runs both during commits and pushes and catches the failure.
4. Follow instructions in the linked docs to optionally disable either the commit or push validation.

Additional details
-----------
Note that the Git hooks can be modified or disabled entirely using the process described here: https://github.com/acquia/blt/blob/11.x/docs/extending-blt.md#git-hooks

So @TravisCarden would probably want to disable pre-commit and just use pre-push, while @wu-edward might want the opposite. Let me know if this satisfies your use cases.