### PR TITLE
DT-587: Fixes #3564: Simulate deploys on TravisCI.

### DIFF
--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -11,6 +11,7 @@ local.blt.yml
 # Ignore build artifacts.
 /tmp/
 /reports/
+/travis_wait*
 
 # Node.js package manager.
 npm-debug.log

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -48,6 +48,7 @@ script:
   # Uncomment these lines to test database updates using live content.
   # - blt drupal:sync:default:site
   - source ${BLT_DIR}/scripts/travis/run_tests
+  - source ${BLT_DIR}/scripts/travis/simulate_deploy
 
 deploy:
    - provider: script

--- a/scripts/travis/deploy_branch
+++ b/scripts/travis/deploy_branch
@@ -2,6 +2,6 @@
 
 set -ev
 
-blt artifact:deploy --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" --branch "${TRAVIS_BRANCH}-build" --ignore-dirty --no-interaction --verbose
+blt artifact:deploy --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" --branch "${TRAVIS_BRANCH}-build" --no-interaction --verbose
 
 set +v

--- a/scripts/travis/deploy_tag
+++ b/scripts/travis/deploy_tag
@@ -2,6 +2,6 @@
 
 set -ev
 
-blt artifact:deploy --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_TAG}" --tag "${TRAVIS_TAG}-build" --ignore-dirty --no-interaction --verbose
+blt artifact:deploy --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_TAG}" --tag "${TRAVIS_TAG}-build" --no-interaction --verbose
 
 set +v

--- a/scripts/travis/simulate_deploy
+++ b/scripts/travis/simulate_deploy
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ev
+
+blt artifact:deploy --dry-run --commit-msg "Automated commit by Travis CI for Build ${TRAVIS_BUILD_ID}" --no-interaction --verbose
+
+set +v

--- a/src/Robo/Commands/Artifact/DeployCommand.php
+++ b/src/Robo/Commands/Artifact/DeployCommand.php
@@ -171,7 +171,7 @@ class DeployCommand extends BltTasks {
             ->interactive(FALSE)
             ->run();
         }
-        throw new BltException("There are uncommitted changes, commit or stash these changes before deploying.");
+        throw new BltException("There are uncommitted changes on the source repository (listed above). Commit, stash, or remove these changes before deploying, or use the --ignore-dirty flag. Additional guidance is available at https://support.acquia.com/hc/en-us/articles/360035204013-Dirty-BLT-source-directory-prevents-deploys.");
       }
     }
   }

--- a/subtree-splits/blt-project/.gitignore
+++ b/subtree-splits/blt-project/.gitignore
@@ -34,6 +34,7 @@ deployment_identifier
 bin/*
 tmp
 reports
+/travis_wait*
 
 # OS X
 .DS_Store


### PR DESCRIPTION
Fixes #3564 
--------

Changes proposed
---------
- Stop ignoring dirty build directories during deploys on Travis
- Since ^ will likely generate subtle failures for some customers, simulate deploys during the test process to make any errors obvious.

Additional details
-----------
I've verified that the new .travis.yml file works great on a BLTed project, and only adds a few seconds to the build process.