### PR TITLE
DT-971: Fixes #3917: Deprecate run-tests.sh, support Chrome for Drupal core tests.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -217,8 +217,8 @@ tests:
     # May be phpunit or run-tests-script.
     test-runner: phpunit
     sudo-run-tests: true
-    # Only chromedriver is supported at this time.
-    web-driver: chromedriver
+    # Chrome or chromedriver.
+    web-driver: chrome
     sqlite: '${repo.root}/tmp/test.sqlite'
     browsertest-output-directory: 'browser_output'
     apache-run-group: 'www-data'

--- a/config/build.yml
+++ b/config/build.yml
@@ -215,7 +215,7 @@ tests:
     args: null
   drupal:
     # May be phpunit or run-tests-script.
-    test-runner: run-tests-script
+    test-runner: phpunit
     sudo-run-tests: true
     # Only chromedriver is supported at this time.
     web-driver: chromedriver

--- a/src/Robo/Commands/Tests/DrupalTestCommand.php
+++ b/src/Robo/Commands/Tests/DrupalTestCommand.php
@@ -161,6 +161,9 @@ class DrupalTestCommand extends TestsCommandBase {
       $this->launchSelenium();
       $this->launchChromeDriver();
     }
+    elseif ($this->getConfigValue('tests.drupal.web-driver') == 'chrome') {
+      $this->launchChrome();
+    }
   }
 
   /**
@@ -170,6 +173,9 @@ class DrupalTestCommand extends TestsCommandBase {
     if ($this->getConfigValue('tests.drupal.web-driver') == 'chromedriver') {
       $this->killSelenium();
       $this->killChromeDriver();
+    }
+    elseif ($this->getConfigValue('tests.drupal.web-driver') == 'chrome') {
+      $this->killChrome();
     }
   }
 

--- a/src/Robo/Commands/Tests/DrupalTestCommand.php
+++ b/src/Robo/Commands/Tests/DrupalTestCommand.php
@@ -114,6 +114,7 @@ class DrupalTestCommand extends TestsCommandBase {
       $this->invokeCommand('tests:drupal:phpunit:run');
     }
     elseif ($this->drupalTestRunner == 'run-tests-script') {
+      $this->logger->notice("The run-tests-script option and tests:drupal:phpunit:run command are deprecated in BLT 11 and will be removed in BLT 12. Use PHPUnit to run Drupal core tests instead.");
       $this->invokeCommand('tests:drupal:run-tests:run');
     }
     else {


### PR DESCRIPTION
Fixes #3917 
--------

Changes proposed
---------
- Deprecate the run-tests script support, since it's also being deprecated in Drupal core, and recommend PHPUnit instead.
- Support Google Chrome as an alternative to Chromedriver and use Chrome by default, since this is recommended by Drupal core.

I've tested this on an actual BLT project to ensure that these tests can be run in an OOTB Travis or Pipelines environment (previously they would fail because of the Selenium / Chromedriver dependency).