### PR TITLE
Allow blt:init:shell-alias install confirmation to be configurable when run with --no-interaction

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -24,6 +24,8 @@ blt:
     example-local: ${repo.root}/blt/example.local.blt.yml
     schema-version: ${repo.root}/blt/.schema_version
   command-cache-dir: ${blt.root}/cache/commands
+  alias:
+    auto-install: false
 
 composer:
   bin: ${repo.root}/${bin.path}

--- a/src/Robo/Commands/Blt/AliasCommand.php
+++ b/src/Robo/Commands/Blt/AliasCommand.php
@@ -40,14 +40,14 @@ class AliasCommand extends BltTasks {
       }
       $this->say("BLT can automatically create a Bash alias to make it easier to run BLT tasks.");
       $this->say("This alias will be created in <comment>$config_file</comment>.");
-      $confirm = $this->confirm("Install alias?", true);
+      $confirm = $this->confirm("Install alias?", $this->getConfigValue('blt.alias.auto-install'));
       if ($confirm) {
         $this->createNewAlias();
       }
     }
     elseif (!$this->isBltAliasUpToDate()) {
       $this->logger->warning("Your BLT alias is out of date.");
-      $confirm = $this->confirm("Would you like to update it?", true);
+      $confirm = $this->confirm("Would you like to update it?", $this->getConfigValue('blt.alias.auto-install'));
       if ($confirm) {
         $this->updateAlias();
       }
@@ -180,7 +180,7 @@ class AliasCommand extends BltTasks {
    */
   protected function createBashProfile() {
     if (EnvironmentDetector::isDarwin() || EnvironmentDetector::isAhEnv()) {
-      $continue = $this->confirm("Would you like to create ~/.bash_profile?", true);
+      $continue = $this->confirm("Would you like to create ~/.bash_profile?", $this->getConfigValue('blt.alias.auto-install'));
       if ($continue) {
         $home_dir = getenv('HOME');
         $bash_profile = $home_dir . '/.bash_profile';

--- a/src/Robo/Commands/Blt/AliasCommand.php
+++ b/src/Robo/Commands/Blt/AliasCommand.php
@@ -40,14 +40,14 @@ class AliasCommand extends BltTasks {
       }
       $this->say("BLT can automatically create a Bash alias to make it easier to run BLT tasks.");
       $this->say("This alias will be created in <comment>$config_file</comment>.");
-      $confirm = $this->confirm("Install alias?");
+      $confirm = $this->confirm("Install alias?", true);
       if ($confirm) {
         $this->createNewAlias();
       }
     }
     elseif (!$this->isBltAliasUpToDate()) {
       $this->logger->warning("Your BLT alias is out of date.");
-      $confirm = $this->confirm("Would you like to update it?");
+      $confirm = $this->confirm("Would you like to update it?", true);
       if ($confirm) {
         $this->updateAlias();
       }
@@ -180,7 +180,7 @@ class AliasCommand extends BltTasks {
    */
   protected function createBashProfile() {
     if (EnvironmentDetector::isDarwin() || EnvironmentDetector::isAhEnv()) {
-      $continue = $this->confirm("Would you like to create ~/.bash_profile?");
+      $continue = $this->confirm("Would you like to create ~/.bash_profile?", true);
       if ($continue) {
         $home_dir = getenv('HOME');
         $bash_profile = $home_dir . '/.bash_profile';


### PR DESCRIPTION
Changes proposed
---------
When issuing `blt blt:init:shell-alias --no-interaction`, the shell alias should be installed rather than not installed (by default). This could be a configurable value for BC purposes. For automated project setups that run with `--no-interaction`, this just results in the alias not ever being setup properly.

Steps to replicate the issue
----------
1. Without the shell alias installed, run `blt blt:init:shell-alias --no-interaction`.
2. Run `blt --version` and note that `blt` cannot be found.

Previous (bad) behavior, before applying PR
----------
Running `blt blt:init:shell-alias --no-interaction` does not setup the shell alias.

Expected behavior, after applying PR and re-running test steps
-----------
Running `blt blt:init:shell-alias --no-interaction` sets up the shell alias after setting in blt.yml:
```
blt:
  alias:
    auto-install: true
```

Additional details
-----------
Previous to BLT 10.x you could run `composer run-script blt-alias` and this would install the alias for you, which is what our automated setup scripts have used. However on 10.x it's no longer possible to get this behavior since the composer script was removed and the dedicated BLT command does not work in the same manner.