### PR TITLE
DT-1016: BLT 10.x tests broken.

### DIFF
--- a/tests/phpunit/src/SandboxManager.php
+++ b/tests/phpunit/src/SandboxManager.php
@@ -193,7 +193,7 @@ class SandboxManager {
         'symlink' => TRUE,
       ],
     ];
-    $composer_json_contents->{'require-dev'}->{'acquia/blt-require-dev'} = '*@dev';
+    $composer_json_contents->{'require-dev'}->{'acquia/blt-require-dev'} = 'dev-master';
     $this->fs->dumpFile($composer_json_path,
       json_encode($composer_json_contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   }


### PR DESCRIPTION
BLT's internal tests mirror `subtree-splits/blt-require-dev` to `/tmp/blt-require-dev` and then add it as a Composer local path repository.

The problem is that `/tmp/blt-require-dev` has no specific version or Git history, so Composer interprets its version as `dev-master`. When you have a newer or more stable version (such as the recently-released 11.0.0-alpha1) Composer might use that instead of the local version, breaking tests.

Incidentally, it's pretty frustrating and confusing how Composer handles this. I don't know why it suddenly decided to use the new release instead of the local version. `composer why-not acquia/blt-require-dev:dev-master` reveals `There is no installed package depending on "acquia/blt-require-dev" in versions not matching dev-master`, which I think is Composer's way of saying "Oh yeah I'd be happy to install the local version for you", and yet... it doesn't. :man_shrugging: 

Additionally, it appears to be "sticky"... if you do install the local version using `dev-master` as the version constraint, and then change the constraint back to `*@dev` and run `composer update`, Composer will keep the local version... even though it would get the remote package in a fresh-install scenario with the same composer.json.