### PR TITLE
DT-981: Fixes #3921: Enabled D9 deprecated code scanning by default.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -246,10 +246,10 @@ tests:
 validate:
   # You can change this to true to have blt automatically validate acsf-init.
   acsf: false
-  # You can change one or both of these to true to have blt automatically scan for deprecated code.
+  # You can change one or both of these to false to disable deprecated code scanning.
   deprecation:
-    modules: false
-    themes: false
+    modules: true
+    themes: true
 
   deprecated:
     filesets:


### PR DESCRIPTION
Fixes #3921 
--------

Changes proposed
---------
- Enable deprecated code scanning of custom modules and themes by default. Note that this will not apply if a user has manually overridden this via blt.yml.

Steps to replicate the issue
----------
1. Run `blt validate`
2. Ensure that `tests:deprecated:modules` and `tests:deprecated:themes` are run automatically as part of the tests.