### PR TITLE
DT-980: Fixes #3922: Anonymous telemetry commands.

### DIFF
--- a/src/Robo/Commands/Blt/TelemetryCommand.php
+++ b/src/Robo/Commands/Blt/TelemetryCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Acquia\Blt\Robo\Commands\Blt;
+
+use Acquia\Blt\Robo\Blt;
+use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Common\UserConfig;
+
+/**
+ * Defines commands in the 'blt:telemetry' namespace.
+ */
+class TelemetryCommand extends BltTasks {
+
+  /**
+   * Enables telemetry.
+   *
+   * @command blt:telemetry:enable
+   */
+  public function telemetryEnable() {
+    $userConfig = new UserConfig(Blt::configDir());
+    $userConfig->setTelemetryEnabled(TRUE);
+    $this->say($userConfig::OPT_IN_MESSAGE);
+  }
+
+  /**
+   * Disables telemetry.
+   *
+   * @command blt:telemetry:disable
+   */
+  public function telemetryDisable() {
+    $userConfig = new UserConfig(Blt::configDir());
+    $userConfig->setTelemetryEnabled(FALSE);
+    $this->say($userConfig::OPT_OUT_MESSAGE);
+  }
+
+}

--- a/src/Robo/Common/UserConfig.php
+++ b/src/Robo/Common/UserConfig.php
@@ -9,6 +9,9 @@ use Acquia\Blt\Robo\Blt;
  */
 class UserConfig {
 
+  const OPT_IN_MESSAGE = "🎉 Awesome! Thank you for helping out!";
+  const OPT_OUT_MESSAGE = "Ok, no data will be tracked and reported.\nWe take privacy seriously.";
+
   /**
    * User configuration file path.
    *

--- a/src/Robo/Hooks/CommandEventHook.php
+++ b/src/Robo/Hooks/CommandEventHook.php
@@ -57,10 +57,10 @@ class CommandEventHook extends BltTasks {
       $preference = $this->confirm("Do you want to help us make this tool even better?", TRUE);
       $userConfig->setTelemetryEnabled($preference);
       if ($preference) {
-        $this->say("🎉 Awesome! Thank you for helping out!");
+        $this->say($userConfig::OPT_IN_MESSAGE);
       }
       else {
-        $this->say("Ok, no data will be tracked and reported.\nWe take privacy seriously.");
+        $this->say($userConfig::OPT_OUT_MESSAGE);
       }
       sleep(2);
     }


### PR DESCRIPTION
Fixes #3922 
--------

Changes proposed
---------
- Add commands `blt:telemetry:enable` and `blt:telemetry:disable` to opt-in/out of telemetry manually (users already must opt-in/out explicitly at least once when first running BLT.)

Steps to replicate the issue
----------
1. Run BLT 11 at least once on your system so that `~/.config/blt/user.json` is generated.
2. Run `blt blt:telemetry:disable`, and verify that `telemetry: false` is set in `user.json`.
3. Run `blt blt:telemetry:enable`, and verify that `telemetry: true` is set in `user.json`.