### PR TITLE
DT-1082: Fixes #3957: Fix unexpected PHPCS behavior with Coder 8.3.7.

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -883,4 +883,20 @@ class Updates {
     }
   }
 
+  /**
+   * Version 11.0.2.
+   *
+   * @Update(
+   *   version = "11000020",
+   *   description = "Update phpcs.xml.dist."
+   * )
+   */
+  public function update_11000020() {
+    $this->updater->syncWithTemplate('phpcs.xml.dist', TRUE);
+    $this->updater->getOutput()->writeln("phpcs.xml.dist has been updated to accommodate changes in Coder 8.3.7. You should review and commit the changes.");
+    if (file_exists($this->updater->getRepoRoot() . '/phpcs.xml')) {
+      $this->updater->getOutput()->writeln('Also review phpcs.xml.dist for changes that should be copied to your custom phpcs.xml');
+    }
+  }
+
 }

--- a/subtree-splits/blt-project/phpcs.xml.dist
+++ b/subtree-splits/blt-project/phpcs.xml.dist
@@ -12,7 +12,12 @@
 
   <!-- Set ignore extensions. -->
   <!-- @see https://www.drupal.org/node/2867601#comment-12075633 -->
+  <!-- This can probably be removed by setting a dependency on Coder 8.3.7 -->
   <arg name="ignore" value="*.css,*.md,*.txt,*.png,*.gif,*.jpeg,*.jpg,*.svg"/>
+
+  <!-- Set extensions to scan (taken from Coder 8.3.6). -->
+  <!-- @see https://git.drupalcode.org/project/coder/blob/8.3.6/coder_sniffer/Drupal/ruleset.xml#L8 -->
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,info,yml"/>
 
   <!-- Use colors in output. -->
   <arg name="colors"/>


### PR DESCRIPTION
Fixes #3957 
--------

Changes proposed
---------
- Add PHPCS extensions to scan to phpcs.xml.dist. These were originally provided in the upstream ruleset, but were [removed unexpectedly in Coder 8.3.7](https://www.drupal.org/node/3074176). The Coder [8.3.7 release notes](https://www.drupal.org/project/coder/releases/8.x-3.7) have been updated to recommend this change.

Steps to replicate the issue
----------
1. Create some dummy `foo.js` and `foo.install` files in your custom modules directory with code style errors that should be caught.
2. Ensure you are using drupal/coder:8.3.7.
3. Run `blt validate`

Previous (bad) behavior, before applying PR
----------
The code style errors in foo.install are missed, while the ones in foo.js are caught.

Expected behavior, after applying PR and re-running test steps
-----------
The code style errors in foo.install are caught, while the ones in foo.js are ignored (we don't intend to scan js files).