### PR TITLE
DT-1128: Fixes #3952: Contributed Drush commands deployed as subprojects

### DIFF
--- a/src/Robo/Commands/Artifact/DeployCommand.php
+++ b/src/Robo/Commands/Artifact/DeployCommand.php
@@ -573,7 +573,10 @@ class DeployCommand extends BltTasks {
       ->ignoreDotFiles(FALSE)
       ->ignoreVCS(FALSE)
       ->directories()
-      ->in([$this->deployDocroot, "{$this->deployDir}/vendor"])
+      ->in([$this->deployDocroot,
+        "{$this->deployDir}/drush",
+        "{$this->deployDir}/vendor",
+      ])
       ->name('.git');
     if ($vcsFinder->hasResults()) {
       $sanitizeFinder->append($vcsFinder);


### PR DESCRIPTION
Fixes #3952 
--------

Changes proposed
---------
- Remove VCS directories from the `drush` directory on deployment, to avoid committing them as subprojects that tend to break deployments.

Steps to replicate the issue
----------
1. Require a contributed Drush project such as acsf-tools, as would happen after running `blt acsf:init`.
2. Run a deploy.

Previous (bad) behavior, before applying PR
----------
1. See that `drush/Commands/acsf_tools/.git` has been committed to the build artifact.

Expected behavior, after applying PR and re-running test steps
-----------
1. `drush/Commands/acsf_tools/.git` is not committed to the build artifact.
