### PR TITLE
DT-1141: Fixes #3980: pre-commit validation doesn't catch code standards errors.

### DIFF
--- a/src/Robo/Commands/Internal/GitCommand.php
+++ b/src/Robo/Commands/Internal/GitCommand.php
@@ -63,7 +63,7 @@ class GitCommand extends BltTasks {
     $collection->addCode(
       function () use ($changed_files) {
         return $this->invokeCommands([
-          'tests:phpcs:sniff:modified',
+          'tests:phpcs:sniff:staged',
           'tests:twig:lint:files' => ['file_list' => $changed_files],
           'tests:yaml:lint:files' => ['file_list' => $changed_files],
         ]);

--- a/src/Robo/Commands/Tests/PhpcsCommand.php
+++ b/src/Robo/Commands/Tests/PhpcsCommand.php
@@ -102,6 +102,26 @@ class PhpcsCommand extends BltTasks {
   }
 
   /**
+   * Executes PHPCS against staged files in repo.
+   *
+   * This command will execute PHP Codesniffer against staged files
+   * if those files are a subset of the phpcs.filesets filesets.
+   *
+   * @command tests:phpcs:sniff:staged
+   * @aliases tpss
+   *
+   * @return int
+   *   Exit code.
+   */
+  public function sniffStaged() {
+    $this->say("Sniffing staged files in repo...");
+    $arguments = "--filter=GitStaged";
+    $exit_code = $this->doSniff($arguments);
+
+    return $exit_code;
+  }
+
+  /**
    * Executes PHP Code Sniffer using specified options/arguments.
    *
    * @param string $arguments

--- a/tests/phpunit/src/SetupGitHooksTest.php
+++ b/tests/phpunit/src/SetupGitHooksTest.php
@@ -105,8 +105,7 @@ class SetupGitHooksTest extends BltProjectTestBase {
     $process = new Process("./.git/hooks/pre-commit", $this->sandboxInstance);
     $process->run();
     $output = $process->getOutput();
-    // @todo Assert only changed files are validated.
-    $this->assertContains('tests:phpcs:sniff:modified', $output);
+    $this->assertContains('tests:phpcs:sniff:staged', $output);
     $this->assertContains('tests:yaml:lint:files', $output);
     $this->assertContains('tests:twig:lint:files', $output);
   }


### PR DESCRIPTION
Fixes #3980 
--------
See testing steps in #3980 

Changes proposed
---------
- Instead of sniffing modified (unstaged) files during the pre-commit hook (which makes no sense), sniff staged files.