### PR TITLE
DT-1036: Command to migrate projects to Composer Scaffold.

### DIFF
--- a/src/Robo/Commands/Recipes/ScaffoldCommand.php
+++ b/src/Robo/Commands/Recipes/ScaffoldCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Acquia\Blt\Robo\Commands\Recipes;
+
+use Acquia\Blt\Robo\BltTasks;
+
+/**
+ * Defines commands in the "recipes:scaffold:*" namespace.
+ */
+class ScaffoldCommand extends BltTasks {
+
+  /**
+   * Migrate a project from Drupal Scaffold to Composer Scaffold.
+   *
+   * @see https://www.drupal.org/docs/develop/using-composer/using-drupals-composer-scaffold#s-migrating-composer-scaffold
+   *
+   * @command recipes:scaffold:migrate
+   */
+  public function migrate() {
+    $this->logger->notice("This command will migrate your project from Drupal Scaffold to Composer Scaffold by modifying your composer.json file. Note the following important prerequisites and caveats:");
+    $this->logger->notice("  * Your project must already be on Drupal 8.8 or higher.");
+    $this->logger->notice("  * This script will run `composer update`, so it's best to already have all dependencies updated before proceeding.");
+    $this->logger->notice("  * Certain Drupal Scaffold customizations such as excluded files will be preserved, but more advanced configuration may need to be manually migrated.");
+    $this->logger->notice("After finishing, be sure to commit all modified files to Git. If you wish to undo the changes, simply discard the modified files.");
+
+    if (!$this->confirm("Ready to go?")) {
+      return;
+    }
+
+    $repo_root = $this->getConfigValue('repo.root');
+    $composer_filepath = $repo_root . '/composer.json';
+    $composer_contents = json_decode(file_get_contents($composer_filepath), TRUE);
+    $template_composer_contents = json_decode(file_get_contents($repo_root . '/vendor/acquia/blt/subtree-splits/blt-project/composer.json'), TRUE);
+
+    // Set up the migration.
+    $legacy_packages = [
+      'drupal-composer/drupal-scaffold',
+      'drupal/core',
+      'webflo/drupal-core-strict',
+    ];
+    $legacy_dev_packages = [
+      'webflo/drupal-core-require-dev',
+    ];
+    $new_packages = [
+      'drupal/core-composer-scaffold' => '^8.8',
+      'drupal/core-recommended' => '^8.8.0',
+    ];
+    $new_dev_packages = [];
+    $new_config = $template_composer_contents['extra']['drupal-scaffold'];
+    // Try to preserve some specific dependencies and configuration.
+    if (isset($composer_contents['require']['drupal/core'])) {
+      $new_packages['drupal/core-recommended'] = $composer_contents['require']['drupal/core'];
+    }
+    if (isset($composer_contents['extra']['drupal-scaffold']['excludes'])) {
+      foreach ($composer_contents['extra']['drupal-scaffold']['excludes'] as $exclude) {
+        $new_config['file-mapping']['[web-root]/' . $exclude] = FALSE;
+      }
+    }
+    if (isset($composer_contents['require-dev']['webflo/drupal-core-require-dev'])) {
+      $new_dev_packages['drupal/core-dev'] = $new_packages['drupal/core-recommended'];
+    }
+
+    // Time to go. Start by removing legacy packages and configuration.
+    foreach ($legacy_packages as $package) {
+      unset($composer_contents['require'][$package]);
+    }
+    foreach ($legacy_dev_packages as $package) {
+      unset($composer_contents['require-dev'][$package]);
+    }
+    unset($composer_contents['extra']['drupal-scaffold']['initial']);
+    unset($composer_contents['scripts']['drupal-scaffold']);
+    // Add new packages and configuration.
+    foreach ($new_packages as $package => $version) {
+      $composer_contents['require'][$package] = $version;
+    }
+    foreach ($new_dev_packages as $package => $version) {
+      $composer_contents['require-dev'][$package] = $version;
+    }
+    $composer_contents['extra']['drupal-scaffold'] = $new_config;
+
+    // Apply the changes.
+    file_put_contents($composer_filepath, json_encode($composer_contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+    // This just sorts the new dependencies in composer.json. It's shockingly
+    // the least hacky way to do so.
+    $this->taskExec("composer require drupal/core-composer-scaffold:{$new_packages['drupal/core-composer-scaffold']} --no-update")
+      ->dir($repo_root)
+      ->run();
+    // This actually applies the changes.
+    $this->taskExec('composer update')
+      ->dir($repo_root)
+      ->run();
+
+    $this->logger->notice('Migration to Composer Scaffold complete. Be sure to git commit all modified files (especially composer.json and composer.lock).');
+  }
+
+}

--- a/src/Robo/Doctor/ComposerCheck.php
+++ b/src/Robo/Doctor/ComposerCheck.php
@@ -169,7 +169,6 @@ class ComposerCheck extends DoctorCheck {
     $this->compareComposerConfig('extra', 'patchLevel');
     $this->compareComposerConfig('repositories', 'drupal');
     $this->compareComposerConfig('scripts', 'nuke');
-    $this->compareComposerConfig('scripts', 'drupal-scaffold');
   }
 
   /**

--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php": ">=7.2",
         "acquia/blt": "11.x-dev",
-        "acquia/composer-scaffold": "dev-master",
         "acquia/drupal-spec-tool": "*",
         "acquia/lightning": "dev-8.x-4.x",
         "acquia/memcache-settings": "*",
@@ -14,6 +13,7 @@
         "drupal/acquia_purge": "^1.0-beta3",
         "drupal/cog": "^1.0.0",
         "drupal/config_split": "^1.0.0",
+        "drupal/core-composer-scaffold": "^8.8",
         "drupal/core-recommended": "^8.8.0",
         "drupal/devel": "^2.0.0",
         "drupal/features": "^3.8.0",
@@ -119,7 +119,6 @@
         "post-create-project-cmd": [
             "blt internal:create-project:init-repo"
         ],
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "nuke": [
             "rm -rf vendor composer.lock docroot/core docroot/modules/contrib docroot/profiles/contrib docroot/themes/contrib",
             "@composer clearcache --ansi",


### PR DESCRIPTION
Changes proposed
---------
- Add a command to migrate existing projects from Drupal Scaffold to Composer Scaffold.
- Clean up the template composer.json: remove drupal scaffold cruft and the dependency on Acquia Scaffold, which no longer works anyway (its configuration can't be inherited and is already duplicated in this file).

Steps to replicate the issue
----------
1. Start with a BLT 10 project, which is based on Drupal Scaffold: `composer create-project acquia/blt-project:^10.0 --no-interaction`
2. Update to BLT 11: `composer require acquia/blt:11.x-dev --no-update && composer update && composer update`
3. Commit changed files, apply this patch.
4. Run the new command: `blt recipes:scaffold:migrate`
5. Ensure that Composer Scaffold runs and the site still runs fine (you should see a lot of output related to moving assets into `[web-root]`).