### PR TITLE
Fixes #3984: updates docs to refer to PHP 7.2 and 7.3 instead of 7.1.

### DIFF
--- a/docs/_markdown/INSTALL.md
+++ b/docs/_markdown/INSTALL.md
@@ -8,7 +8,7 @@ You must have the following tools on the command line of your *host operating sy
 
 * [Git](https://git-scm.com/)
 * [Composer](https://getcomposer.org/download/)
-* [PHP 7.1+](http://php.net/manual/en/install.php)
+* [PHP 7.2+ minimum, 7.3+ recommended](http://php.net/manual/en/install.php)
 
 Instructions for installing _all_ requirements for various operating systems are listed below. In general, make sure all installed tools are the most recent version unless otherwise noted.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,7 +32,7 @@ installed tools available for use from the command line:
 
 -  `Git <https://git-scm.com/>`__
 -  `Composer <https://getcomposer.org/download/>`__
--  `PHP 7.1 or greater <http://php.net/manual/en/install.php>`__
+-  `PHP 7.2+ minimum, 7.3+ recommended <http://php.net/manual/en/install.php>`__
 
 Install the most recent version of these tools, unless otherwise noted.
 


### PR DESCRIPTION
Fixes #3984 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- update docs to remove references to PHP 7.1