### PR TITLE
Fix README.md 404 links.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ You can find compiled BLT documentation on [docs.acquia.com](https://docs.acquia
 
 ## Getting started
 
-See [INSTALL.md](INSTALL.md) for a list of prequisites and links to instructions for [creating new projects](creating-new-project.md), [adding BLT to existing projects](adding-to-project.md), and [updating BLT](updating-blt.md).
+See [Installing Acquia BLT](https://docs.acquia.com/blt/install/) for a list of prequisites and links to instructions for [creating a new project](https://docs.acquia.com/blt/install/creating-new-project/), [adding BLT to an existing project](https://docs.acquia.com/blt/install/adding-to-project/), and [updating BLT](https://docs.acquia.com/blt/install/updating-blt/).
 
 ## Videos
 
@@ -53,32 +53,29 @@ Its scope is discretely defined. It is *not* intended to provide:
 
 ## Features
 
-* [Local Git Hooks](https://github.com/acquia/blt/tree/9.x/scripts/git-hooks)
+* [Local Git Hooks](https://github.com/acquia/blt/tree/11.x/scripts/git-hooks)
     * pre-commit: Checks for Drupal coding standards compliance
     * commit-msg: Check for proper formatting and syntax
-* [Testing Framework](https://github.com/acquia/blt/tree/9.x/template/tests).
+* [Testing Framework](https://github.com/acquia/blt/tree/11.x/template/tests).
     * Behat: default `local.yml` configuration, example tests, `FeatureContext.php`
     * PHPUnit: default tests for ensuring proper functioning of BLT provided components
-* [Commands to automate project tasks](project-tasks.md), like:
+* [Commands to automate project tasks](https://docs.acquia.com/blt/developer/project-tasks/), like:
     * Test execution
     * Frontend asset compilation
     * Syncing environments
-* [Deployment Artifact Generation](deploy.md)
+* [Deployment Artifact Generation](https://docs.acquia.com/blt/tech-architect/deploy/)
     * Building production-only dependencies
     * Sanitation of production code
-* [Continuous Integration & Deployment](ci.md)
+* [Continuous Integration & Deployment](https://docs.acquia.com/blt/tech-architect/ci/)
     * [Acquia Pipelines](https://dev.acquia.com/request-invite-acquia-pipelines)
     * [Travis CI](https://travis-ci.com)
     * [GitHub](https://github.com)
 
 # Support and contribution
 
-BLT is provided as an open source tool in the hope that it will enable developers to easily generate new Drupal projects that conform to Acquia Professional Services' best practices.
+BLT is provided as an open source tool in the hope that it will enable developers to easily generate new Drupal projects that conform to Acquia Professional Services' best practices. See [Acquia BLT support](https://docs.acquia.com/blt/support/) to find resources that are available for support with BLT issues.
 
-Please feel free to contribute to the project or file issues via the GitHub issue queue. See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and instructions.
-
-We also provide a limited [FAQ](FAQ.md) for common issues.
-
+Please feel free to contribute to the project or file issues via the GitHub issue queue. See [Contributing to Acquia BLT](https://docs.acquia.com/blt/contributing/) for contribution guidelines and instructions.
 # License
 
 Copyright (C) 2016 Acquia, Inc.


### PR DESCRIPTION
Now that the docs were changed to RST instead of markdown, a lot of links produce 404s. I replaced these links with absolute links to the generated docs on https://docs.acquia.com. I couldn't find any replacement for the FAQs.

Actually the LICENSE on the very bottom of the README probably should be updated or removed completely as well.  