### PR TITLE
Fixes #3940: DT-1053: $config_directories deprecated in Drupal 8.8.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -39,6 +39,8 @@ cm:
     path: ../config
     # The default config key to use for imports. This is the key used in Drupal's global $config_directories variable.
     # E.g., $config_directories['sync']. It must have a corresponding key in cm.core.dirs. E.g., `cm.core.dirs.sync`.
+    # @todo This feature is deprecated in Drupal 8.8, remove it when we drop support for Drupal 8.8.
+    # @see https://www.drupal.org/node/3018145
     key: sync
     dirs:
       # Corresponding value is defined in config.settings.php.

--- a/scripts/factory-hooks/post-settings-php/includes.php
+++ b/scripts/factory-hooks/post-settings-php/includes.php
@@ -10,5 +10,5 @@
  */
 
 // Set config directories to default location.
-$config_directories['vcs'] = '../config/default';
 $config_directories['sync'] = '../config/default';
+$settings['config_sync_directory'] = '../config/default';

--- a/scripts/factory-hooks/post-settings-php/includes.php
+++ b/scripts/factory-hooks/post-settings-php/includes.php
@@ -10,5 +10,6 @@
  */
 
 // Set config directories to default location.
+$config_directories['vcs'] = '../config/default';
 $config_directories['sync'] = '../config/default';
 $settings['config_sync_directory'] = '../config/default';

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -16,8 +16,8 @@ use Acquia\Blt\Robo\Common\EnvironmentDetector;
  * applications may prefer to manage the configuration for each multisite
  * completely separately. If this is the case, they can set
  * $blt_override_config_directories to FALSE and
- * $config_directories['sync'] = $dir . "/config/$site_dir" in settings.php,
- * and we will not overwrite it.
+ * $settings['config_sync_directory'] = $dir . "/config/$site_dir" in
+ * settings.php, and we will not overwrite it.
  */
 // phpcs:ignore
 if (!isset($blt_override_config_directories)) {
@@ -28,10 +28,17 @@ if (!isset($blt_override_config_directories)) {
 if ($blt_override_config_directories) {
   // phpcs:ignore
   $config_directories['sync'] = $repo_root . "/config/default";
+  // phpcs:ignore
+  $settings['config_sync_directory'] = $repo_root . "/config/default";
 }
 
 $split_filename_prefix = 'config_split.config_split';
-$split_filepath_prefix = $config_directories['sync'] . '/' . $split_filename_prefix;
+if (isset($config_directories['sync'])) {
+  $split_filepath_prefix = $config_directories['sync'] . '/' . $split_filename_prefix;
+}
+else {
+  $split_filepath_prefix = $settings['config_sync_directory'] . '/' . $split_filename_prefix;
+}
 
 /**
  * Set environment splits.
@@ -66,7 +73,6 @@ if (!isset($split)) {
   }
   // Acquia only envs.
   if (EnvironmentDetector::isAhEnv()) {
-    $config_directories['vcs'] = $config_directories['sync'];
     $split = 'ah_other';
   }
 

--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -73,6 +73,7 @@ if (!isset($split)) {
   }
   // Acquia only envs.
   if (EnvironmentDetector::isAhEnv()) {
+    $config_directories['vcs'] = $config_directories['sync'];
     $split = 'ah_other';
   }
 


### PR DESCRIPTION
Fixes #3940 
--------

Changes proposed
---------
- Set `$settings['config_sync_directory']` in addition to existing `$config_directories['sync']`, to support both Drupal 8.7 and Drupal 8.8+: https://www.drupal.org/node/3018145

Additional details
-----------
I should start the BLT 12 branch and forward-port this to completely remove `$config_directories` references, including `vcs` references that are no longer relevant on Cloud (originally introduced in https://github.com/acquia/blt/issues/678)