### PR TITLE
Revert "MS-4593| Prevents test command to kill wrong processes"

### DIFF
--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -127,7 +127,7 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
     // phpcs:ignore
     exec("command -v lsof && lsof -ti tcp:$port | xargs kill l 2>&1");
     // phpcs:ignore
-    exec("pkill -f :$port 2>&1");
+    exec("pkill -f $port 2>&1");
   }
 
   /**


### PR DESCRIPTION
Reverts acquia/blt#3971 as a possible root cause for #3992