### PR TITLE
Fixes #4012: Added update hook for #587 (gitignore for simulated deploys)

### DIFF
--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -899,4 +899,20 @@ class Updates {
     }
   }
 
+  /**
+   * Version 11.2.0.
+   *
+   * @Update(
+   *   version = "11002000",
+   *   description = "Update .gitignore with travis_wait."
+   * )
+   */
+  public function update_11002000() {
+    $filename = $this->updater->getRepoRoot() . '/.gitignore';
+    $lines = file($filename);
+    if (!in_array("/travis_wait*\n", $lines)) {
+      file_put_contents($filename, "\n# BLT 11.2.0 update to support simulated deploys\n/travis_wait*\n", FILE_APPEND);
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes #4012 
--------

Changes proposed
---------
- Added an update hook that will add `/travis_wait*` to a project's gitignore file if it doesn't already exist, in order to support #587 and prevent errors about dirty source dirs (#4012)
