### PR TITLE
DT-1178: Moved PHPUnit out of blt-project and blt-require-dev.

### DIFF
--- a/src/Robo/Commands/Recipes/PhpUnitCommand.php
+++ b/src/Robo/Commands/Recipes/PhpUnitCommand.php
@@ -31,6 +31,11 @@ class PhpUnitCommand extends BltTasks {
       throw new BltException("Could not copy example files into the repository root.");
     }
 
+    $this->taskExec("composer require --dev --no-update phpunit/phpunit:'^4.8.35 || ^6.5 || ^7'")
+      ->run();
+    $this->taskExec("composer update")
+      ->run();
+
     $this->say("<info>Example PHPUnit files were copied to your application.</info>");
   }
 

--- a/subtree-splits/blt-require-dev/composer.json
+++ b/subtree-splits/blt-require-dev/composer.json
@@ -10,7 +10,6 @@
         "dmore/behat-chrome-extension": "^1.0.0",
         "drupal/drupal-extension": "~3.2",
         "jarnaiz/behat-junit-formatter": "^1.3.2",
-        "phpunit/phpunit": "^4.8.35 || ^6.5 || ^7",
         "squizlabs/php_codesniffer": "^3.0.1"
     },
     "extra": {


### PR DESCRIPTION
From now on, PHPUnit dependencies and configuration will not exist in the project template by default, but only if they are specifically used or initialized.