### PR TITLE
Allow pre-push hook to fail invalid commit

### DIFF
--- a/src/Robo/Commands/Internal/GitCommand.php
+++ b/src/Robo/Commands/Internal/GitCommand.php
@@ -103,7 +103,7 @@ class GitCommand extends BltTasks {
     }
     catch (BltException $e) {
       $this->yell('Your code has failed pre-push validation.');
-      return;
+      return 1;
     }
 
     $this->say("<info>Your local code has passed git pre-push validation.</info>");


### PR DESCRIPTION
Fixes # 
--------
- Allows `pre-push` hook to fail invalid commit.

Changes proposed
---------
- The `pre-push` hook introduced in https://github.com/acquia/blt/pull/3925 is currently not breaking any invalid commits.  I think it makes no sense to run the hook every time before a `git push` if it's not preventing invalid commit from being pushed to remote.

Steps to replicate the issue
----------
1. Make some changes that are going to fail when doing `blt validate`.
2. Disable `pre-commit` hook or commit using `git commit --no-verify`
3. Push the commit.

Previous (bad) behavior, before applying PR
----------
`pre-push` is not preventing invalid commit from being pushed to remote.
![image](https://user-images.githubusercontent.com/13445723/75898424-07b0d480-5e08-11ea-9b5a-46a7efbb15eb.png)

Expected behavior, after applying PR and re-running test steps
-----------
`pre-push` will prevent invalid commit from being pushed to remote.
![image](https://user-images.githubusercontent.com/13445723/75898335-ebad3300-5e07-11ea-941a-b558ecb76a56.png)

Additional details
-----------
