### PR TITLE
Switch to Acquia Coding Standards.

### DIFF
--- a/subtree-splits/blt-project/composer.json
+++ b/subtree-splits/blt-project/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": ">=7.3",
         "acquia/blt": "12.x-dev",
+        "acquia/coding-standards": "^0.4.2",
         "acquia/drupal-spec-tool": "*",
         "acquia/lightning": "dev-8.x-4.x",
         "acquia/memcache-settings": "*",

--- a/subtree-splits/blt-project/phpcs.xml.dist
+++ b/subtree-splits/blt-project/phpcs.xml.dist
@@ -25,11 +25,7 @@
   <arg value="p"/>
 
   <!-- Include existing standards. -->
-  <rule ref="Drupal"/>
-  <rule ref="DrupalPractice">
-    <!-- Ignore specific sniffs. -->
-    <exclude name="DrupalPractice.InfoFiles.NamespacedDependency"/>
-  </rule>
+  <rule ref="AcquiaDrupalTransitional"/>
 
   <file>docroot/modules/custom</file>
   <file>docroot/themes/custom</file>


### PR DESCRIPTION
Before merging, I need to think about how this should work for users adding BLT to an existing project. We can't add acquia/coding-standards to composer dynamically on install. Could be a hard dependency of BLT, but that's not ideal.

Probably put the coding standards in a separate composer package and suggest that people install it after installing BLT.