### PR TITLE
Fixes #4046: Remove dependency on MySQL database

### DIFF
--- a/src/Robo/Wizards/SetupWizard.php
+++ b/src/Robo/Wizards/SetupWizard.php
@@ -40,7 +40,7 @@ class SetupWizard extends Wizard {
    * Executes blt drupal:install.
    */
   public function wizardInstallDrupal() {
-    if (!$this->getInspector()->isMySqlAvailable()) {
+    if (!$this->getInspector()->isDatabaseAvailable()) {
       return FALSE;
     }
     if (!$this->getInspector()->isDrupalInstalled()) {


### PR DESCRIPTION
Fixes # 
--------

https://github.com/acquia/blt/issues/4046

Changes proposed
---------
- Separate checks for database availability
- isDrupalInstalled to use "drush status bootstrap" so not dependent on MySQL
