### PR TITLE
Use ORCA's D9 readiness job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,7 @@ jobs:
   include:
     # Standard ORCA jobs.
     - { name: "Static code analysis", env: ORCA_JOB=STATIC_CODE_ANALYSIS }
-    # Force ORCA to install Drupal 9, and avoid installing company packages that don't yet support D9.
-    - { name: "Drupal 9 ORCA testing", env: ORCA_JOB=CUSTOM ORCA_CUSTOM_FIXTURE_INIT_ARGS="--core=9.0.0-alpha2 --sut-only"}
+    - { name: "D9 readiness test", php: "7.3", env: ORCA_JOB=D9_READINESS}
     # Custom jobs.
     - env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal,requires-vm,d8'
     - env: DRUPAL_CORE_VERSION=default PHPUNIT_EXCLUDE_GROUP='drupal,requires-vm,d8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ before_install:
   - composer config --global repositories.blt path /tmp/blt-project
   # Install ORCA.
   - git clone --branch ${ORCA_VERSION} --depth 1 https://github.com/acquia/orca.git ../orca
-  - curl https://patch-diff.githubusercontent.com/raw/acquia/orca/pull/65.patch | git -C ../orca apply
   - curl https://patch-diff.githubusercontent.com/raw/acquia/orca/pull/69.patch | git -C ../orca apply
   - ../orca/bin/travis/before_install.sh
 


### PR DESCRIPTION
Depends on #4057 since the subtree split patch no longer applies. I guess we can just leave it out and we're not in much worse condition.