### PR TITLE
Fixes #4067: Adds a redundant cache-rebuild after drupal:update.

### DIFF
--- a/src/Robo/Commands/Drupal/ConfigCommand.php
+++ b/src/Robo/Commands/Drupal/ConfigCommand.php
@@ -124,6 +124,11 @@ class ConfigCommand extends BltTasks {
 
     $result = $this->invokeHook('post-config-import');
 
+    // Redundant cache-rebuild upon the conclusion of drupal:config:import
+    // to resolve fatal errors post-config actions.
+    $task = $this->taskDrush();
+    $task->drush("cache-rebuild")->run();
+
     return $result;
   }
 


### PR DESCRIPTION
Fixes #4067
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- adds a redundant cache-rebuild in `drupal:config:import` command to resolve fatal errors post-config-import.