### PR TITLE
Fix warnings due to missing env var during blt updates.

### DIFF
--- a/src/Robo/Common/UserConfig.php
+++ b/src/Robo/Common/UserConfig.php
@@ -39,7 +39,7 @@ class UserConfig {
     }
     else {
       if (!file_exists($configDir)) {
-        if (is_writeable(dirname($configDir))) {
+        if (is_writable(dirname($configDir))) {
           mkdir($configDir, 0777, TRUE);
         }
         else {

--- a/src/Robo/Common/UserConfig.php
+++ b/src/Robo/Common/UserConfig.php
@@ -38,7 +38,14 @@ class UserConfig {
       $this->config = json_decode(file_get_contents($this->configPath), TRUE);
     }
     else {
-      mkdir($configDir, 0777, TRUE);
+      if (!file_exists($configDir)) {
+        if (is_writeable(dirname($configDir))) {
+          mkdir($configDir, 0777, TRUE);
+        }
+        else {
+          return;
+        }
+      }
       $this->setTelemetryUserData();
     }
   }


### PR DESCRIPTION
Not sure why, but `getenv('HOME')` returns nothing during the BLT update process, producing warnings due to an invalid directory.