### PR TITLE
Backport #4084 to 11.x

### DIFF
--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -373,11 +373,14 @@ class EnvironmentDetector {
    * @throws \ReflectionException
    */
   private static function getSubclassResults($functionName) {
-    $autoloader = require self::getRepoRoot() . '/vendor/autoload.php';
-    $classMap = $autoloader->getClassMap();
-    $detectors = array_filter($classMap, function ($classPath) {
-      return strpos($classPath, 'Blt/Plugin/EnvironmentDetector') !== FALSE;
-    });
+    static $detectors;
+    if (!isset($detectors)) {
+      $autoloader = require self::getRepoRoot() . '/vendor/autoload.php';
+      $classMap = $autoloader->getClassMap();
+      $detectors = array_filter($classMap, function ($classPath) {
+        return strpos($classPath, 'Blt/Plugin/EnvironmentDetector') !== FALSE;
+      });
+    }
     $results = [];
     foreach ($detectors as $detector => $classPath) {
       // Only call this method if it's been overridden by the child class.


### PR DESCRIPTION
Here's a backport of #4085 for `11.x` which we're still on.