### PR TITLE
Updates suggest for latest version of typhonius/acquia_cli.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "suggest": {
         "davereid/drush-acquia-hook-invoke": "dev-master",
         "hirak/prestissimo": "^0.3",
-        "typhonius/acquia_cli": "^1.0"
+        "typhonius/acquia_cli": "^2.0"
     },
     "config": {
         "php": "7",


### PR DESCRIPTION
Fixes # 
--------

Changes proposed
---------
Update the suggest parameter for the latest version of the Acquia Cli library as it contains more up-to-date features and a better representative example for Acquia API v2.


Additional details
-----------
Acquia Cli v1 and associated libraries were released a couple of years ago. This change provides a more up-to-date version of underlying libraries and one that is compatible directly with BLT 12.x.