### PR TITLE
Log more details about the response from the test server.

### DIFF
--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -224,7 +224,6 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
       }
       else {
         $this->logger->info("Response code: " . $res->getStatusCode());
-        $this->logger->info($res->getBody());
         $this->logger->debug($res->getBody());
         return FALSE;
       }

--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -154,7 +154,7 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
    *   The URL to wait for.
    */
   public function waitForUrlAvailable($url) {
-    $this->wait([$this, 'checkUrl'], [$url], "Waiting for response from $url...");
+    $this->wait([$this, 'checkUrl'], [$url], "Waiting for non-50x response from $url...");
   }
 
   /**
@@ -223,6 +223,8 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
         return TRUE;
       }
       else {
+        $this->logger->info("Response code: " . $res->getStatusCode());
+        $this->logger->info($res->getBody());
         $this->logger->debug($res->getBody());
         return FALSE;
       }


### PR DESCRIPTION
Fixes #3968  
--------

Changes proposed
---------
Make BLT's log output during automated tests more informative

Steps to replicate the issue
----------
1. Run a CI build in which the app returns a 500 after the setup-app step. 

Previous (bad) behavior, before applying PR
----------
My tests were failing in the exact same way as #3968 , but for a different reason. The drush runserver was started successfully, but responding with a 500 due to the kind of fatal error reported in https://github.com/acquia/blt/pull/4068

This took me a while to realize, because the output from BLT indicates that we are waiting for a response from the server, which never responds, so we eventually get a timeout error:

```
[info] Waiting for response from http://127.0.0.1:8888...

[info] Waiting for response from http://127.0.0.1:8888...

[info] Waiting for response from http://127.0.0.1:8888...

[error]  Timed out.
```

What's actually happening is that `waitForUrlAvailable` is waiting for a *non-50x* response, but without any further details, it looks like there is no response received at all.

Expected behavior, after applying PR and re-running test steps
-----------
This patch updates the message from `waitForUrlAvailable` for better clarity, and updates `checkUrl` so that each failed check reports the code and body of the response:

```
[info] Waiting for response from http://127.0.0.1:8888...

[info] Response code: 500

[info] The website encountered an unexpected error. Please try again later.</br></br><em class="placeholder">Symfony\Component\Routing\Exception\RouteNotFoundException</em>: Route &quot;cohesion.error_logger&quot; does not exist. in <em class="placeholder">Drupal\Core\Routing\RouteProvider-&gt;getRouteByName()</em> (line <em class="placeholder">208</em> of <em class="placeholder">core/lib/Drupal/Core/Routing/RouteProvider.php</em>). <pre class="backtrace">Drupal\Core\Routing\UrlGenerator-&gt;getRoute(&#039;cohesion.error_logger&#039;) (Line: 271)
Drupal\Core\Routing\UrlGenerator-&gt;generateFromRoute(&#039;cohesion.error_logger&#039;, Array, Array, 1) (Line: 105)
Drupal\Core\Render\MetadataBubblingUrlGenerator-&gt;generateFromRoute(&#039;cohesion.error_logger&#039;, Array, Array, ) (Line: 754)
Drupal\Core\Url-&gt;toString() (Line: 278)
cohesion_page_attachments(Array) (Line: 297)
Drupal\Core\Render\MainContent\HtmlRenderer-&gt;invokePageAttachmentHooks(Array) (Line: 273)
Drupal\Core\Render\MainContent\HtmlRenderer-&gt;prepare(Array, Object, Object) (Line: 117)
Drupal\Core\Render\MainContent\HtmlRenderer-&gt;renderResponse(Array, Object, Object) (Line: 90)
Drupal\Core\EventSubscriber\MainContentViewSubscriber-&gt;onViewRenderArray(Object, &#039;kernel.view&#039;, Object)
call_user_func(Array, Object, &#039;kernel.view&#039;, Object) (Line: 111)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher-&gt;dispatch(&#039;kernel.view&#039;, Object) (Line: 156)
Symfony\Component\HttpKernel\HttpKernel-&gt;handleRaw(Object, 1) (Line: 68)
Symfony\Component\HttpKernel\HttpKernel-&gt;handle(Object, 1, 1) (Line: 67)
Drupal\simple_oauth\HttpMiddleware\BasicAuthSwap-&gt;handle(Object, 1, 1) (Line: 57)
Drupal\Core\StackMiddleware\Session-&gt;handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\KernelPreHandle-&gt;handle(Object, 1, 1) (Line: 191)
Drupal\page_cache\StackMiddleware\PageCache-&gt;fetch(Object, 1, 1) (Line: 128)
Drupal\page_cache\StackMiddleware\PageCache-&gt;lookup(Object, 1, 1) (Line: 82)
Drupal\page_cache\StackMiddleware\PageCache-&gt;handle(Object, 1, 1) (Line: 47)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware-&gt;handle(Object, 1, 1) (Line: 52)
Drupal\Core\StackMiddleware\NegotiationMiddleware-&gt;handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel-&gt;handle(Object, 1, 1) (Line: 694)
Drupal\Core\DrupalKernel-&gt;handle(Object) (Line: 19)
</pre>

[error]  Timed out.
```

Additional details
-----------
The response body is already sent to a debug log (`$this->logger->debug($res->getBody());`) but since this is happening in a Pipelines CI environment, I'm not sure where to find that.
