### PR TITLE
Sets initializer to use docroot from already processed files.

### DIFF
--- a/src/Robo/Config/ConfigInitializer.php
+++ b/src/Robo/Config/ConfigInitializer.php
@@ -162,6 +162,8 @@ class ConfigInitializer {
    */
   public function loadSiteConfig() {
     if ($this->site) {
+      // Since docroot can change in the project, we need to respect that here.
+      $this->config->replace($this->processor->export());
       $this->processor->extend($this->loader->load($this->config->get('docroot') . "/sites/{$this->site}/blt.yml"));
       $this->processor->extend($this->loader->load($this->config->get('docroot') . "/sites/{$this->site}/{$this->environment}.blt.yml"));
     }


### PR DESCRIPTION
Fixes #4105
--------

Changes proposed
---------
Change the config initializer to use the already processed config to determine docroot rather than just the default. 

Steps to replicate the issue
----------
1. Change docroot in your project blt.yml
2. Attempt to run a site command with overridden config in <other docroot>/sites/<site>/blt.yml
3. Site yml will not be found/used

