### PR TITLE
adds bootstrap results to debug log

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -233,6 +233,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
     $result = $this->executor->drush("--uri=$uri status bootstrap")->run();
     $output = trim($result->getMessage());
     $installed = $result->wasSuccessful() && $output == 'Drupal bootstrap : Successful';
+    $this->logger->debug("Drupal bootstrap results: $output");
 
     return $installed;
   }


### PR DESCRIPTION
Fixes #4127 
--------

Changes proposed
---------
Add Drupal bootstrap results to the debug log output so that when running command with verbose, developers can see what the actual result was.

-
-

Steps to replicate the issue
----------
```
if ($this->getInspector()->isDrupalInstalled()) {
        // Run update.
        $this->invokeCommand('artifact:update:drupal');
        $this->sendMMNotification("{$multisite} site update complete on {$environment} ({$loop} of {$total}).");
        $loop++;
      }
      else {
        $newinstall[] = $multisite;
      }
```

Previous (bad) behavior, before applying PR
----------
Running the above in a custom command, I'm seeing all sites of a multisite getting put into the newinstall array. During my run, all of the sites are existing sites and the bootstrap status check *should* be returning successful. I need to debug further.

Expected behavior, after applying PR and re-running test steps
-----------
 [debug] Drupal bootstrap results: Drupal bootstrap : Successful


