### PR TITLE
Handle docroot/.gitignore on deploys.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -48,7 +48,7 @@ cm:
 deploy:
   # If true, dependencies will be built during deploy. If false, you should commit dependencies directly.
   build-dependencies: true
-  dir: ${repo.root}/deploy
+  dir: ${tmp.dir}/blt-deploy
   docroot: ${deploy.dir}/docroot
   exclude_file: ${blt.root}/scripts/blt/deploy/deploy-exclude.txt
   exclude_additions_file: ${repo.root}/blt/deploy-exclude-additions.txt

--- a/src/Robo/Commands/Artifact/DeployCommand.php
+++ b/src/Robo/Commands/Artifact/DeployCommand.php
@@ -574,19 +574,26 @@ class DeployCommand extends BltTasks {
       ->ignoreVCS(FALSE)
       ->directories()
       ->in([$this->deployDocroot,
-        "{$this->deployDir}/drush",
         "{$this->deployDir}/vendor",
       ])
       ->name('.git');
+    $drush_dir = "{$this->deployDir}/drush";
+    if (file_exists($drush_dir)) {
+      $vcsFinder->in($drush_dir);
+    }
     if ($vcsFinder->hasResults()) {
       $sanitizeFinder->append($vcsFinder);
     }
 
     $this->logger->info("Find .gitignore files...");
-    $sanitizeFinder = Finder::create()
+    $gitignoreFinder = Finder::create()
+      ->ignoreDotFiles(FALSE)
       ->files()
       ->name('.gitignore')
       ->in("{$this->deployDocroot}");
+    if ($gitignoreFinder->hasResults()) {
+      $sanitizeFinder->append($gitignoreFinder);
+    }
 
     $this->logger->info("Find Github directories...");
     $githubFinder = Finder::create()

--- a/src/Robo/Commands/Artifact/DeployCommand.php
+++ b/src/Robo/Commands/Artifact/DeployCommand.php
@@ -582,6 +582,12 @@ class DeployCommand extends BltTasks {
       $sanitizeFinder->append($vcsFinder);
     }
 
+    $this->logger->info("Find .gitignore files...");
+    $sanitizeFinder = Finder::create()
+      ->files()
+      ->name('.gitignore')
+      ->in("{$this->deployDocroot}");
+
     $this->logger->info("Find Github directories...");
     $githubFinder = Finder::create()
       ->ignoreDotFiles(FALSE)

--- a/src/Robo/Common/YamlWriter.php
+++ b/src/Robo/Common/YamlWriter.php
@@ -25,7 +25,7 @@ class YamlWriter {
   /**
    * YAML contents.
    *
-   * @var false|string
+   * @var null|string
    */
   private $contents;
 
@@ -37,7 +37,9 @@ class YamlWriter {
    */
   public function __construct($filepath) {
     $this->filepath = $filepath;
-    $this->contents = file_get_contents($filepath);
+    if (file_exists($this->filepath)) {
+      $this->contents = file_get_contents($filepath);
+    }
   }
 
   /**
@@ -47,7 +49,12 @@ class YamlWriter {
    *   Array.
    */
   public function getContents() {
-    return Yaml::parse($this->contents);
+    if ($this->contents) {
+      return Yaml::parse($this->contents);
+    }
+    else {
+      return [];
+    }
   }
 
   /**

--- a/src/Robo/Config/DefaultConfig.php
+++ b/src/Robo/Config/DefaultConfig.php
@@ -23,6 +23,7 @@ class DefaultConfig extends BltConfig {
     $this->set('docroot', $repo_root . '/docroot');
     $this->set('blt.root', $this->getBltRoot());
     $this->set('composer.bin', $repo_root . '/vendor/bin');
+    $this->set('tmp.dir', sys_get_temp_dir());
   }
 
   /**

--- a/tests/phpunit/src/DeployTest.php
+++ b/tests/phpunit/src/DeployTest.php
@@ -12,7 +12,7 @@ class DeployTest extends BltProjectTestBase {
    */
   public function setUp(): void {
     parent::setUp();
-    $this->deploy_dir = $this->sandboxInstance . '/deploy';
+    $this->deploy_dir = sys_get_temp_dir() . '/blt-deploy';
   }
 
   /**


### PR DESCRIPTION
This will help support projects that manageme gitignore files via Composer Scaffold, which puts one in docroot. This breaks BLT deploys by inadvertently excluding files like docroot/index.php.

This PR removes _all_ gitignore files from the deploy docroot, effectively creating a blank slate and assuming files should be deployed unless explicitly excluded by BLT configuration (the deploy/excludes list or deploy gitignore file).