### PR TITLE
checks for existing settings files before adding default files

### DIFF
--- a/src/Robo/Commands/Source/SettingsCommand.php
+++ b/src/Robo/Commands/Source/SettingsCommand.php
@@ -100,6 +100,7 @@ WARNING;
       // Generate sites/settings/default.global.settings.php.
       $blt_glob_settings_file = $this->getConfigValue('blt.root') . '/settings/default.global.settings.php';
       $default_glob_settings_file = $this->getConfigValue('docroot') . "/sites/settings/default.global.settings.php";
+      $global_settings_file = $this->getConfigValue('docroot') . "/sites/settings/global.settings.php";
 
       // Generate local.drush.yml.
       $blt_local_drush_file = $this->getConfigValue('blt.root') . '/settings/default.local.drush.yml';
@@ -110,7 +111,6 @@ WARNING;
         $blt_local_settings_file => $default_local_settings_file,
         $default_local_settings_file => $project_local_settings_file,
         $blt_includes_settings_file => $default_includes_settings_file,
-        $blt_glob_settings_file => $default_glob_settings_file,
         $blt_local_drush_file => $default_local_drush_file,
         $default_local_drush_file => $project_local_drush_file,
       ];
@@ -120,12 +120,17 @@ WARNING;
         $default_local_drush_file => $project_local_drush_file,
       ];
 
+      // Add default.global.settings.php if global.settings.php does not exist.
+      if (!file_exists($global_settings_file)) {
+        $copy_map[$blt_glob_settings_file] = $default_glob_settings_file;
+      }
+
       // Only add the settings file if the default exists.
       if (file_exists($default_project_default_settings_file)) {
         $copy_map[$default_project_default_settings_file] = $project_default_settings_file;
         $copy_map[$project_default_settings_file] = $project_settings_file;
       }
-      else {
+      elseif (!file_exists($project_settings_file)) {
         $this->logger->warning("No $default_project_default_settings_file file found.");
       }
 


### PR DESCRIPTION
Fixes #4156  
--------

Changes proposed
---------
On a `blt:init:settings` run, check for the existence of `sites/settings/global.settings.php` file and only copy the default file if it does not exist. Also, check if the `site/settings.php` file exists and only issue the warning if it does not.


Steps to replicate the issue
----------
1. Rename `sites/settings/default.global.settings.php` to `sites/settings/global.settings.php`
2. Remove the `default.settings.php` file from the `sites/default` directory where a multisite already has a `settings.php` file.
3. See `sites/settings/default.global.settings.php` added and warnings issued.


Expected behavior, after applying PR and re-running test steps
-----------
No warnings should be generated where a settings.php exists for a site. It should still be given if it does not exist. The `sites/settings/default.global.settings.php` should not reappear.

Additional details
-----------
This is against the 12.x branch. Please also port to 11.x.