### PR TITLE
Issue #4164: Changing twig and yaml linting namespace

### DIFF
--- a/docs/extending-blt.rst
+++ b/docs/extending-blt.rst
@@ -125,8 +125,8 @@ To create your own fileset definition, complete the following steps:
 #.  Instantiate and return a ``Symfony\Component\Finder\Finder`` object. The
     files found by the finder form the fileset.
 
-To change the filesets used in commands such as ``tests:twig:lint:all``,
-``tests:yaml:lint:all``, and ``tests:php:lint``, add the following
+To change the filesets used in commands such as ``validate:twig:lint:all``,
+``validate:yaml:lint:all``, and ``tests:php:lint``, add the following
 configuration key to ``blt/blt.yml``:
 
 .. code-block:: yaml
@@ -387,7 +387,7 @@ The following list includes some commonly customized Acquia BLT targets:
       XML. For more information, see the official `PHPCS documentation
       <https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file>`__.
 
-   -  **tests:twig:lint:all**: To prevent validation failures on any Twig
+   -  **validate:twig:lint:all**: To prevent validation failures on any Twig
       filters or functions created in custom or contrib module
       ``twig.extension`` services, add filters and functions like the
       following:

--- a/src/Robo/Commands/Internal/GitCommand.php
+++ b/src/Robo/Commands/Internal/GitCommand.php
@@ -63,8 +63,8 @@ class GitCommand extends BltTasks {
     $collection->addCode(
       function () use ($changed_files) {
         return $this->invokeCommands([
-          'tests:twig:lint:files' => ['file_list' => $changed_files],
-          'tests:yaml:lint:files' => ['file_list' => $changed_files],
+          'validate:twig:lint:files' => ['file_list' => $changed_files],
+          'validate:yaml:lint:files' => ['file_list' => $changed_files],
         ]);
       }
     );

--- a/src/Robo/Commands/Internal/GitCommand.php
+++ b/src/Robo/Commands/Internal/GitCommand.php
@@ -74,7 +74,7 @@ class GitCommand extends BltTasks {
       || in_array('composer.lock', $changed_files_list)) {
       $collection->addCode(
         function () {
-          return $this->invokeCommand('tests:composer:validate');
+          return $this->invokeCommand('validate:composer');
         }
       );
     }

--- a/src/Robo/Commands/Validate/TwigCommand.php
+++ b/src/Robo/Commands/Validate/TwigCommand.php
@@ -11,7 +11,7 @@ use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
 /**
- * Defines commands in the "tests:twig:lint:all*" namespace.
+ * Defines commands in the "validate:twig:lint:all*" namespace.
  */
 class TwigCommand extends BltTasks {
 

--- a/src/Robo/Commands/Validate/YamlCommand.php
+++ b/src/Robo/Commands/Validate/YamlCommand.php
@@ -5,7 +5,7 @@ namespace Acquia\Blt\Robo\Commands\Validate;
 use Acquia\Blt\Robo\BltTasks;
 
 /**
- * Defines commands in the "tests:yaml:lint:all*" namespace.
+ * Defines commands in the "validate:yaml:lint:all*" namespace.
  */
 class YamlCommand extends BltTasks {
 

--- a/tests/phpunit/src/SetupGitHooksTest.php
+++ b/tests/phpunit/src/SetupGitHooksTest.php
@@ -105,8 +105,8 @@ class SetupGitHooksTest extends BltProjectTestBase {
     $process->run();
     $output = $process->getOutput();
     $this->assertStringContainsString('tests:phpcs:sniff:staged', $output);
-    $this->assertStringContainsString('tests:yaml:lint:files', $output);
-    $this->assertStringContainsString('tests:twig:lint:files', $output);
+    $this->assertStringContainsString('validate:yaml:lint:files', $output);
+    $this->assertStringContainsString('validate:twig:lint:files', $output);
   }
 
   /**


### PR DESCRIPTION
... references from tests: to validate: namespace.

Fixes #4164  

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- Change the namespace used for twig and yaml linting from tests: to validate:. The commands themselves appear to already have been moved and only their invocation in a couple places and documentation still needs to change.

- Found essentially the same thing with the git commit invocation of `tests:composer:validate`, which should be `validate:composer`.

Steps to replicate the issue
----------
1. With BLT 12.0.0, make some changes, add them to git, and run `git commit -m "Whatever."`
2. Observe error message as below.

Previous (bad) behavior, before applying PR
----------
Running git commit without --no-verify on the 12.0.0 release of BLT results in an error saying
```
[CompletionWrapper] There are no commands defined in the "tests:twig:lint" namespace.
```

Expected behavior, after applying PR and re-running test steps
-----------
No error message displayed
