### PR TITLE
12.x Docs: Add Drupal 8.9 LTS as supported by BLT 11.x

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ This is intended to coincide with the [Drupal core release cycle](https://www.dr
 
 | BLT version | Support status        | End of life    |  Drupal versions*   | Drush versions           |
 |-------------|-----------------------|----------------|---------------------|--------------------------|
-| 12.x        | Unsupported, unstable | \>=May 2021    | 9.  0               | \>=10.0.1<br>\>=9.5.0    |
+| **12.x**    | **Supported, stable** | **\>=May 2021**| **9.0**             | **\>=10.0.1**<br>\>=9.5.0|
 | **11.x**    | **Supported, stable** | **>=Dec 2020** | **8.8, 8.9 LTS**    | **>=10.0.1**<br>\>=9.5.0 |
 | 10.x        | Bug fixes only        | May 2020       | 8.8                 | \>=9.5.0                 |
 | <=9.2.x     | Unsupported           | Dec 2019       | 8.6, 8.7            | \>=9.4.0                 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,16 +25,16 @@ This is intended to coincide with the [Drupal core release cycle](https://www.dr
 
 ### Release support status
 
-| BLT version | Support status        | End of life    |  Drupal versions* | Drush versions         |
-|-------------|-----------------------|----------------|-------------------|------------------------|
-| 12.x        | Unsupported, unstable | \>=May 2021    | 9.0               | \>=10.0.1<br>\>=9.5.0    |
-| **11.x**    | **Supported, stable** | **>=Dec 2020** | **8.7\*\*, 8.8**  | **>=10.0.1**<br>\>=9.5.0 |
-| 10.x        | Bug fixes only        | May 2020       | 8.7, 8.8          | \>=9.5.0               |
-| <=9.2.x     | Unsupported           | Dec 2019       | 8.6, 8.7          | \>=9.4.0               |
+| BLT version | Support status        | End of life    |  Drupal versions*         | Drush versions           |
+|-------------|-----------------------|----------------|---------------------------|--------------------------|
+| 12.x        | Unsupported, unstable | \>=May 2021    | 9.0                       | \>=10.0.1<br>\>=9.5.0    |
+| **11.x**    | **Supported, stable** | **>=Dec 2020** | **8.7\*\*, 8.8, 8.9 LTS** | **>=10.0.1**<br>\>=9.5.0 |
+| 10.x        | Bug fixes only        | May 2020       | 8.7, 8.8                  | \>=9.5.0                 |
+| <=9.2.x     | Unsupported           | Dec 2019       | 8.6, 8.7                  | \>=9.4.0                 |
 
 *When any upstream package release stops being supported by its maintainer, BLT will cease supporting that release as well. For instance, as of December 2019, BLT 10.x will no longer support Drupal 8.6, and will instead support Drupal 8.7 and 8.8  in accordance with [Drupal security policy](https://www.drupal.org/drupal-security-team/general-information).
 
-**Existing Drupal 8.7 projects can use BLT 11. However, when creating _new_ projects, BLT 11 only supports Drupal 8.8 due to its dependency on Composer Scaffold.
+**Existing Drupal 8.7 projects can use BLT 11. However, when creating _new_ projects, BLT 11 only supports Drupal 8.8 and 8.9 due to its dependency on Composer Scaffold.
 
 ## Philosophy and Purpose
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,16 +25,14 @@ This is intended to coincide with the [Drupal core release cycle](https://www.dr
 
 ### Release support status
 
-| BLT version | Support status        | End of life    |  Drupal versions*         | Drush versions           |
-|-------------|-----------------------|----------------|---------------------------|--------------------------|
-| 12.x        | Unsupported, unstable | \>=May 2021    | 9.0                       | \>=10.0.1<br>\>=9.5.0    |
-| **11.x**    | **Supported, stable** | **>=Dec 2020** | **8.7\*\*, 8.8, 8.9 LTS** | **>=10.0.1**<br>\>=9.5.0 |
-| 10.x        | Bug fixes only        | May 2020       | 8.7, 8.8                  | \>=9.5.0                 |
-| <=9.2.x     | Unsupported           | Dec 2019       | 8.6, 8.7                  | \>=9.4.0                 |
+| BLT version | Support status        | End of life    |  Drupal versions*   | Drush versions           |
+|-------------|-----------------------|----------------|---------------------|--------------------------|
+| 12.x        | Unsupported, unstable | \>=May 2021    | 9.  0               | \>=10.0.1<br>\>=9.5.0    |
+| **11.x**    | **Supported, stable** | **>=Dec 2020** | **8.8, 8.9 LTS**    | **>=10.0.1**<br>\>=9.5.0 |
+| 10.x        | Bug fixes only        | May 2020       | 8.8                 | \>=9.5.0                 |
+| <=9.2.x     | Unsupported           | Dec 2019       | 8.6, 8.7            | \>=9.4.0                 |
 
 *When any upstream package release stops being supported by its maintainer, BLT will cease supporting that release as well. For instance, as of December 2019, BLT 10.x will no longer support Drupal 8.6, and will instead support Drupal 8.7 and 8.8  in accordance with [Drupal security policy](https://www.drupal.org/drupal-security-team/general-information).
-
-**Existing Drupal 8.7 projects can use BLT 11. However, when creating _new_ projects, BLT 11 only supports Drupal 8.8 and 8.9 due to its dependency on Composer Scaffold.
 
 ## Philosophy and Purpose
 


### PR DESCRIPTION
Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- Update docs:
    - Add Drupal 8.9 LTS as supported by BLT 11.x
    - Remove Drupal 8.7, it's EOL and so no longer supported by BLT


Steps to replicate the issue
----------
1. Read the docs
2. Check if Drupal 8.9 LTS is supported

Previous (bad) behavior, before applying PR
----------
* Docs don't mention Drupal 8.9 LTS.
* Docs show Drupal 8.7 is still supported.

Expected behavior, after applying PR and re-running test steps
-----------
* Docs mention which BLT supports Drupal 8.9 LTS.
* Docs show Drupal 8.7 is not supported.


Additional details
-----------

* Does BLT 11.x actually support D8.9?

* Does BLT 12.x also support D8.9? I'd guess not.

* Does BLT 10.x also support D8.9?

I can update the other supported branches (`11.x` and `10.x`?) afterwards.

