### PR TITLE
[WIP] Treat Cloud IDE as local environments.

### DIFF
--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -106,7 +106,8 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
    * Is local.
    */
   public static function isLocalEnv() {
-    return parent::isLocalEnv() && !self::isPantheonEnv() && !self::isCiEnv();
+    return (parent::isLocalEnv() || parent::isAhIdeEnv()) 
+      && !self::isPantheonEnv() && !self::isCiEnv();
   }
 
   /**


### PR DESCRIPTION
Changes proposed
---------
- Adjust the config split determination so that Acquia Cloud IDEs are treated as local and use that split.

Steps to replicate the issue
----------
1. Set up a Cloud IDE instance with local splits
2. 

Previous (bad) behavior, before applying PR
----------
- notice how your local splits are ignored because EnvironmentDetector shows the environment as `ah_other`

Expected behavior, after applying PR and re-running test steps
-----------
- Cloud IDE environment is treated as local and uses that split.
