### PR TITLE
Fix #4183: Notice when running blt drupal:install

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -130,6 +130,8 @@ project:
     hostname: local.${project.machine_name}.com
     protocol: http
     uri: ${project.local.protocol}://${project.local.hostname}
+  profile:
+    name: standard
 
 setup:
   # Valid values are install, sync, import.


### PR DESCRIPTION
Fixes #4183 
--------

Changes proposed
---------
- Explicitly default to installing standard profile (users can still override this via blt.yml)