### PR TITLE
Fix #4174: Pipelines and Travis CI missing tests:all command

### DIFF
--- a/scripts/pipelines/tests
+++ b/scripts/pipelines/tests
@@ -7,6 +7,6 @@ set -ev
 
 export PATH=${COMPOSER_BIN}:${PATH}
 
-blt tests:all --define drush.alias='${drush.aliases.ci}' -D behat.web-driver=chrome --no-interaction --ansi --verbose
+blt tests --define drush.alias='${drush.aliases.ci}' -D behat.web-driver=chrome --no-interaction --ansi --verbose
 
 set +v

--- a/scripts/travis/run_tests
+++ b/scripts/travis/run_tests
@@ -7,6 +7,6 @@ set -v
 
 blt validate --no-interaction || { set +v && return 1; }
 travis_wait blt setup --define drush.alias='${drush.aliases.ci}' --no-interaction --verbose || { set +v && return 1; }
-blt tests:all --define drush.alias='${drush.aliases.ci}' --define tests.run-server=true --no-interaction --verbose || { set +v && return 1; }
+blt tests --define drush.alias='${drush.aliases.ci}' --define tests.run-server=true --no-interaction --verbose || { set +v && return 1; }
 
 set +v


### PR DESCRIPTION
Fixes #4174 
--------

Changes proposed
---------
- Call `tests` instead of `tests:all` on Travis and Pipelines (same command, renamed)
