### PR TITLE
Fix #4177: Missing docroot on default file_public_path

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -151,7 +151,7 @@ $settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-pr
  * This is always set and exposed by the Drupal Kernel.
  */
 // phpcs:ignore
-$settings['file_public_path'] = EnvironmentDetector::getRepoRoot() . '/sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
+$settings['file_public_path'] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.


### PR DESCRIPTION
Fixes #4177 
--------

Changes proposed
---------
- Change default file path locally to uses sites directory in docroot (duh)