### PR TITLE
Fix #4182: Missing project.human_name attribute

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -126,6 +126,7 @@ phpcbf:
     - files.frontend.custom.themes
 
 project:
+  human_name: My BLT site
   local:
     hostname: local.${project.machine_name}.com
     protocol: http


### PR DESCRIPTION
Fixes #4182 
--------

Changes proposed
---------
- Set a default project name (can be overridden via blt.yml)