### PR TITLE
Introduce new FilesetsTrait and move all protected filesets helper methods to it

### DIFF
--- a/src/Robo/Filesets/Filesets.php
+++ b/src/Robo/Filesets/Filesets.php
@@ -16,6 +16,7 @@ use Symfony\Component\Finder\Finder;
 class Filesets implements ConfigAwareInterface {
 
   use ConfigAwareTrait;
+  use FilesetsTrait;
 
   /**
    * Get fileset php custom modules.
@@ -107,88 +108,6 @@ class Filesets implements ConfigAwareInterface {
       $this->getConfigValue('repo.root') . '/config',
       $this->getConfigValue('docroot') . '/modules/custom',
     ]);
-
-    return $finder;
-  }
-
-  /**
-   * Adds Drupalistic PHP patterns to a Symfony finder object.
-   *
-   * @return \Symfony\Component\Finder\Finder
-   *   The finder object.
-   */
-  protected function getPhpFilesetFinder() {
-    $finder = new Finder();
-    $finder
-      ->files()
-      ->name("*.inc")
-      ->name("*.install")
-      ->name("*.module")
-      ->name("*.php")
-      ->name("*.profile")
-      ->name("*.test")
-      ->name("*.theme")
-      // Behat php files are ignored because method names and comments do not
-      // conform to Drupal coding standards by default.
-      ->notPath('behat')
-      ->notPath('node_modules')
-      ->notPath('vendor');
-    return $finder;
-  }
-
-  /**
-   * Adds Drupalistic JS patterns to a Symfony finder object.
-   *
-   * @return \Symfony\Component\Finder\Finder
-   *   The finder object.
-   */
-  protected function getFrontendFilesetFinder() {
-    $finder = new Finder();
-    $finder
-      ->files()
-      ->path("*/js/*")
-      ->name("*.js")
-      ->notName('*.min.js')
-      ->notPath('bower_components')
-      ->notPath('node_modules')
-      ->notPath('vendor');
-
-    return $finder;
-  }
-
-  /**
-   * Adds Drupalistic YAML patterns to a Symfony finder object.
-   *
-   * @return \Symfony\Component\Finder\Finder
-   *   The finder object.
-   */
-  protected function getYamlFilesetFinder() {
-    $finder = new Finder();
-    $finder
-      ->files()
-      ->name("*.yml")
-      ->name("*.yaml")
-      ->notPath('bower_components')
-      ->notPath('node_modules')
-      ->notPath('vendor');
-
-    return $finder;
-  }
-
-  /**
-   * Adds Drupalistic Twig patterns to a Symfony finder object.
-   *
-   * @return \Symfony\Component\Finder\Finder
-   *   The finder object.
-   */
-  protected function getTwigFilesetFinder() {
-    $finder = new Finder();
-    $finder
-      ->files()
-      ->name("*.twig")
-      ->notPath('bower_components')
-      ->notPath('node_modules')
-      ->notPath('vendor');
 
     return $finder;
   }

--- a/src/Robo/Filesets/Filesets.php
+++ b/src/Robo/Filesets/Filesets.php
@@ -8,7 +8,6 @@ use Acquia\Blt\Annotations\Fileset;
 // @codingStandardsIgnoreEnd
 use Acquia\Blt\Robo\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
-use Symfony\Component\Finder\Finder;
 
 /**
  * Defines filesets.

--- a/src/Robo/Filesets/FilesetsTrait.php
+++ b/src/Robo/Filesets/FilesetsTrait.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Acquia\Blt\Robo\Filesets;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Defines a trait for filesets helper methods.
+ */
+trait FilesetsTrait {
+
+  /**
+   * Adds Drupalistic PHP patterns to a Symfony finder object.
+   *
+   * @return \Symfony\Component\Finder\Finder
+   *   The finder object.
+   */
+  protected function getPhpFilesetFinder() {
+    $finder = new Finder();
+    $finder
+      ->files()
+      ->name("*.inc")
+      ->name("*.install")
+      ->name("*.module")
+      ->name("*.php")
+      ->name("*.profile")
+      ->name("*.test")
+      ->name("*.theme")
+      // Behat php files are ignored because method names and comments do not
+      // conform to Drupal coding standards by default.
+      ->notPath('behat')
+      ->notPath('node_modules')
+      ->notPath('vendor');
+    return $finder;
+  }
+
+  /**
+   * Adds Drupalistic JS patterns to a Symfony finder object.
+   *
+   * @return \Symfony\Component\Finder\Finder
+   *   The finder object.
+   */
+  protected function getFrontendFilesetFinder() {
+    $finder = new Finder();
+    $finder
+      ->files()
+      ->path("*/js/*")
+      ->name("*.js")
+      ->notName('*.min.js')
+      ->notPath('bower_components')
+      ->notPath('node_modules')
+      ->notPath('vendor');
+
+    return $finder;
+  }
+
+  /**
+   * Adds Drupalistic YAML patterns to a Symfony finder object.
+   *
+   * @return \Symfony\Component\Finder\Finder
+   *   The finder object.
+   */
+  protected function getYamlFilesetFinder() {
+    $finder = new Finder();
+    $finder
+      ->files()
+      ->name("*.yml")
+      ->name("*.yaml")
+      ->notPath('bower_components')
+      ->notPath('node_modules')
+      ->notPath('vendor');
+
+    return $finder;
+  }
+
+  /**
+   * Adds Drupalistic Twig patterns to a Symfony finder object.
+   *
+   * @return \Symfony\Component\Finder\Finder
+   *   The finder object.
+   */
+  protected function getTwigFilesetFinder() {
+    $finder = new Finder();
+    $finder
+      ->files()
+      ->name("*.twig")
+      ->notPath('bower_components')
+      ->notPath('node_modules')
+      ->notPath('vendor');
+
+    return $finder;
+  }
+
+}


### PR DESCRIPTION
Fixes #4198 
--------

Changes proposed
---------

- Introduces and implements new `Acquia\Blt\Robo\Filesets\FilesetsTrait` containing all protected helper methods previously contained in `Acquia\Blt\Robo\Filesets\Filesets` class, so users may reuse these when creating custom filesets


Additional details
-----------

The following protected methods from `Acquia\Blt\Robo\Filesets\Filesets` class are moved to the new trait:

* `getPhpFilesetFinder()`
* `getFrontendFilesetFinder()`
* `getYamlFilesetFinder()`
* `getTwigFilesetFinder()`