### PR TITLE
Silence PHP notices or warnings when HOME is not set or writable.

### DIFF
--- a/src/Robo/Common/UserConfig.php
+++ b/src/Robo/Common/UserConfig.php
@@ -39,11 +39,11 @@ class UserConfig {
     }
     else {
       // Make sure directory tree for user config file exists.
-      if (!file_exists($configDir) && !mkdir($configDir, 0777, TRUE)) {
+      if (!file_exists($configDir) && !@mkdir($configDir, 0777, TRUE)) {
         return;
       }
       // Make sure directory for user config file is writable.
-      if (is_writable($configDir) || chmod($configDir, 0777)) {
+      if (is_writable($configDir) || @chmod($configDir, 0777)) {
         $this->setTelemetryUserData();
       }
     }
@@ -109,7 +109,7 @@ class UserConfig {
    * Write user config to disk.
    */
   public function save() {
-    file_put_contents($this->configPath, json_encode($this->config));
+    @file_put_contents($this->configPath, json_encode($this->config));
   }
 
 }

--- a/src/Robo/Common/UserConfig.php
+++ b/src/Robo/Common/UserConfig.php
@@ -24,7 +24,7 @@ class UserConfig {
    *
    * @var array
    */
-  private $config;
+  private $config = [];
 
   /**
    * UserConfig constructor.
@@ -87,7 +87,7 @@ class UserConfig {
    *   Telemetry user data.
    */
   public function getTelemetryUserData() {
-    $data = $this->config['telemetryUserData'];
+    $data = isset($this->config['telemetryUserData']) ? $this->config['telemetryUserData'] : [];
     $data['app_version'] = Blt::VERSION;
 
     return $data;


### PR DESCRIPTION
Fixes # 
--------

Changes proposed
---------

- Silence PHP errors, notices and warnings when mkdir, chmod or file_put_contents fails for environments where $HOME is not a writable environment.

Steps to replicate the issue
----------
1. Set $HOME path as a non-writable location.
2. Run any command that uses the UserConfig class where telemetry data may be stored or used.

Previous (bad) behavior, before applying PR
----------

On standard BLT deployment routine:

```
    W: PHP Warning:  mkdir(): Read-only file system in /app/vendor/acquia/blt/src/Robo/Common/UserConfig.php on line 42
    
    Warning: mkdir(): Read-only file system in /app/vendor/acquia/blt/src/Robo/Common/UserConfig.php on line 42
    W: [debug] Drupal VM is not initialized.
    W: PHP Warning:  mkdir(): Read-only file system in /app/vendor/acquia/blt/src/Robo/Common/UserConfig.php on line 42
    
    Warning: mkdir(): Read-only file system in /app/vendor/acquia/blt/src/Robo/Common/UserConfig.php on line 42
    W: [debug] Switching site context to default.
    W: [debug] Verifying that Drupal is installed...
    W: [Robo\Common\ProcessExecutor] Running /app/vendor/bin/drush @self --uri= status bootstrap in /app/docroot
     Drupal bootstrap : Successful 
    W: [debug] Drupal bootstrap results: Drupal bootstrap : Successful
    Deploying updates to default...
    > drupal:update
    
    Warning: mkdir(): Read-only file system in /app/vendor/acquia/blt/src/Robo/Common/UserConfig.php on line 42
    W: PHP Warning:  mkdir(): Read-only file system in /app/vendor/acquia/blt/src/Robo/Common/UserConfig.php on line 42
```


Expected behavior, after applying PR and re-running test steps
-----------

1. No errors or warnings are produced.
