### PR TITLE
4213: Use the provided URI in the drush site alias

### DIFF
--- a/src/Robo/Commands/Recipes/MultisiteCommand.php
+++ b/src/Robo/Commands/Recipes/MultisiteCommand.php
@@ -57,7 +57,7 @@ class MultisiteCommand extends BltTasks {
     $local_alias = $this->getNewSiteAlias($site_name, $options, 'local');
     $this->createNewBltSiteYml($new_site_dir, $site_name, $url, $local_alias, $remote_alias, $newDBSettings);
     $this->createNewSiteConfigDir($site_name);
-    $this->createSiteDrushAlias($site_name);
+    $this->createSiteDrushAlias($site_name, $domain);
     $this->resetMultisiteConfig();
 
     $this->invokeCommand('blt:init:settings');
@@ -335,11 +335,13 @@ class MultisiteCommand extends BltTasks {
    *
    * @param string $site_name
    *   Site name.
+   * @param string $site_url
+   *   Site URL (optional). Defaults to $site_name.
    */
-  protected function createSiteDrushAlias($site_name) {
+  protected function createSiteDrushAlias($site_name, $site_url = '') {
     $aliases = [
       'local' => [
-        'uri' => $site_name,
+        'uri' => $site_url ?: $site_name,
         'root' => '${env.cwd}/docroot',
       ],
     ];


### PR DESCRIPTION
Fixes #4213 
--------

Changes proposed
---------
(What are you proposing we change? How does this impact end users? Are manual or automatic updates required?)

- Add an optional parameter to `MultisiteCommand::createSiteDrushAlias()`
- Pass the URI to `MultisiteCommand::createSiteDrushAlias()` from ``MultisiteCommand::generate()`

Steps to replicate the issue
----------
1. `blt recipes:multisite:init`
1. At the prompt `Site machine name (e.g. 'example')`, answer `mysite`.
1. At the prompt `Local domain name [http://local.multi1.com]`, answer `https://mysite.lndo.site`.
1. Once the site is running, try `drush @mysite status` or `drush @mysite uli`.

Previous (bad) behavior, before applying PR
----------

Drush uses `http://mysite`.

Expected behavior, after applying PR and re-running test steps
-----------

Drush uses `https://mysite.lndo.site`.

Additional details
-----------

I believe that the `uri` specified in `drush/sites/mysite.yml` overrides the setting in `sites/mysite/local.drush.yml`.