### PR TITLE
4218: Add an option to bypass installing the shell alias

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -26,6 +26,7 @@ blt:
   command-cache-dir: ${blt.root}/cache/commands
   alias:
     auto-install: true
+    bypass: false
 
 composer:
   bin: ${repo.root}/${bin.path}

--- a/src/Robo/Commands/Blt/ShellAliasCommand.php
+++ b/src/Robo/Commands/Blt/ShellAliasCommand.php
@@ -20,6 +20,9 @@ class ShellAliasCommand extends BltTasks {
    * @aliases blt:init:shell-alias alias install-alias
    */
   public function installBltAlias() {
+    if ($this->getConfigValue('blt.alias.bypass')) {
+      return;
+    }
     if (isset($_SERVER['ComSpec'])) {
       $bltRoot = $this->getConfigValue('blt.root') . '\\vendor\\bin';
       $this->logger->error("Setting a blt alias is not supported in cmd.exe");


### PR DESCRIPTION
Fixes #4218 
--------

Changes proposed
---------

- Add a new option, `blt.alias.bypass`, to `config/build.yml`, with default value `false`.
- Check for this option at the start of `installBltAlias()` and exit early if it is set.
- The change will have no effect on users unless they choose to override the new option in `blt/blt.yml`.

Steps to replicate the issue
----------
1. Without installing the alias, run the `setup` task. For example, `vendor/bin/blt/setup`.
2. Note the warning message at the end of the task.

Previous (bad) behavior, before applying PR
----------

Noise:

```bash
> blt:init:shell-alias
[warning] Could not find your CLI configuration file.
[warning] Looked in ~/.zsh, ~/.bash_profile, ~/.bashrc, ~/.profile, and ~/.functions.
[warning] Please create one of the aforementioned files, or create the BLT alias manually.
```

Expected behavior, after applying PR and re-running test steps
-----------

Much less noise:

```bash
> blt:init:shell-alias
```

Additional details
-----------
