### PR TITLE
Set file_public_path relative to the Drupal root in local.settings.php

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -151,7 +151,7 @@ $settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-pr
  * This is always set and exposed by the Drupal Kernel.
  */
 // phpcs:ignore
-$settings['file_public_path'] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
+$settings['file_public_path'] = 'sites/' . EnvironmentDetector::getSiteName($site_path) . '/files';
 
 /**
  * Trusted host configuration.


### PR DESCRIPTION
Fixes # 
--------
None.

Changes proposed
---------
file_public_path is set wrong in local.settings.php. Drupal explicitly documents that it needs to be relative to the Drupal root, not an absolute path. My references are default.settings.php, and Drupal\system\Form\FileSystemForm. Both say this:

>  A local file system path where public files will be stored. This directory must exist and be writable by Drupal. This directory **must be relative to the Drupal installation directory** and be accessible over the web.

This was originally changed in 5a4aa878aa17a7dc305eb7ac431b32e72a982a9a. Why, I don't know. But it is not correct, and breaks Drupal-level code. A concrete example is Cohesion -- it needs this value to be configured properly, or it cannot resolve the location of its CSS and JavaScript, thus breaking it in a big way, since it relies utterly on those assets in order to not only be usable by administrators, but also to display its output correctly.

Steps to replicate the issue
----------
None needed. You'll see it when you create a BLT project. 

Previous (bad) behavior, before applying PR
----------
file_public_path will be a /full/path/to/site/directory/files. It needs to simply be site/directory/files.

-----------

Additional details
-----------
