### PR TITLE
Fix #4176: Support arbitrary config splits

### DIFF
--- a/settings/config.settings.php
+++ b/settings/config.settings.php
@@ -36,53 +36,9 @@ $split_filepath_prefix = $settings['config_sync_directory'] . '/' . $split_filen
 /**
  * Set environment splits.
  */
-$split_envs = [
-  'local',
-  'dev',
-  'stage',
-  'prod',
-  'ci',
-  'ah_other',
-];
-
-// Disable all split by default.
-foreach ($split_envs as $split_env) {
-  $config["$split_filename_prefix.$split_env"]['status'] = FALSE;
-}
-
-// Enable env splits.
-// Do not set $split unless it is unset. This allows prior scripts to set it.
-// phpcs:ignore
-if (!isset($split)) {
-  $split = 'none';
-
-  // Local envs.
-  if (EnvironmentDetector::isLocalEnv()) {
-    $split = 'local';
-  }
-  // CI envs.
-  if (EnvironmentDetector::isCiEnv()) {
-    $split = 'ci';
-  }
-  // Acquia only envs.
-  if (EnvironmentDetector::isAhEnv()) {
-    $split = 'ah_other';
-  }
-
-  if (EnvironmentDetector::isDevEnv() || EnvironmentDetector::isAhOdeEnv()) {
-    $split = 'dev';
-  }
-  elseif (EnvironmentDetector::isStageEnv()) {
-    $split = 'stage';
-  }
-  elseif (EnvironmentDetector::isProdEnv()) {
-    $split = 'prod';
-  }
-}
-
-// Enable the environment split only if it exists.
-if ($split != 'none') {
-  $config["$split_filename_prefix.$split"]['status'] = TRUE;
+$split_envs = EnvironmentDetector::getEnvironments();
+foreach ($split_envs as $split_env => $status) {
+  $config["$split_filename_prefix.$split_env"]['status'] = $status;
 }
 
 /**

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -286,6 +286,21 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
   }
 
   /**
+   * List detectable environments and whether they are currently active.
+   */
+  public static function getEnvironments() {
+    return [
+      'local' => self::isLocalEnv(),
+      'dev' => self::isDevEnv(),
+      'stage' => self::isStageEnv(),
+      'prod' => self::isProdEnv(),
+      'ci' => self::isCiEnv(),
+      'ode' => self::isAhOdeEnv(),
+      'ah_other' => self::isAhEnv(),
+    ];
+  }
+
+  /**
    * Call a given function in all EnvironmentDetector subclasses.
    *
    * Composer packages can provide their own version of an EnvironmentDetector


### PR DESCRIPTION
Fixes #4176 
--------

Changes proposed
---------
- Move list of possible config split environments to the environment detector
- Make this list overrideable

Additional details
-----------
This is a potentially breaking change because of how we handle ODEs in the context of config splits, they were treated as dev before but now they are a separate environment. This is desirable because it brings them in line with how environments are treated more generally (ODEs are not considered dev except for in config splits). This is overrideable in the environment detector.