### PR TITLE
BLT-ACSF-3: Preserve gitignore files required by ACSF

### DIFF
--- a/src/Robo/Commands/Artifact/DeployCommand.php
+++ b/src/Robo/Commands/Artifact/DeployCommand.php
@@ -590,6 +590,10 @@ class DeployCommand extends BltTasks {
       ->ignoreDotFiles(FALSE)
       ->files()
       ->name('.gitignore')
+      ->notPath([
+        "sites/g/.gitignore",
+        "sites/default/.gitignore",
+      ])
       ->in("{$this->deployDocroot}");
     if ($gitignoreFinder->hasResults()) {
       $sanitizeFinder->append($gitignoreFinder);


### PR DESCRIPTION
Fixes https://github.com/acquia/blt-acsf/issues/3
--------

Motivation
----------

The `blt artifact:build` command removes `.gitignore` files from the document root. This breaks deployment to ACSF, since the ACSF module specifically requires `.gitignore` files at `docroot/sites/g` and `docroot/sites/default`.

Proposed changes
---------

Exclude the required files from being removed.

Alternatives considered
---------

Testing steps
---------

Prepare a Drupal 9 site for deployment to ACSF:

- Install the packages `drupal/acsf`, `acquia/blt-acsf`, and their dependencies.
- Run the commands `blt recipes:acsf:init:drush` and `recipes:acsf:init:all`.
- Commit the results to Git.
- Run the command `blt artifact:deploy`.
- Update your site's code from the ACSF dashboard.