### PR TITLE
Fixed #4229: Use the correct check before munging database name

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -9,7 +9,7 @@ use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (EnvironmentDetector::isAcsfInited()) {
+if (EnvironmentDetector::isAcsfEnv()) {
   $db_name .= '_' . EnvironmentDetector::getAcsfDbName();
 }
 


### PR DESCRIPTION
Fixes #4229 
--------

Motivation
----------

After `blt recipes:acsf:init:all`, the command `blt setup` fails.

Proposed changes
---------
What does this PR change? How does this impact end users? Are manual or automatic updates required?

This PR checks `isAcsfEnv()` instead of `isAcsfInited()` so that ACSF-specific code is not run on local development environments.

Alternatives considered
---------

Testing steps
---------

```bash
blt recipes:acsf:init:all
blt setup -n
```