### PR TITLE
Fixes #4229: Stop modifying local db name for ACSF

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -9,9 +9,6 @@ use Acquia\Blt\Robo\Common\EnvironmentDetector;
 use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
-if (EnvironmentDetector::isAcsfInited()) {
-  $db_name .= '_' . EnvironmentDetector::getAcsfDbName();
-}
 
 /**
  * Database configuration.


### PR DESCRIPTION
Fixes #4229 
--------

Motivation
----------
This conditional does nothing meaningful because the environment detector has no way to find the ACSF db name locally, but it does cause confusion by adding extra characters to the db name.

Proposed changes
---------
This doesn't fully restore dynamic db support for local ACSF apps, but it at least fixes the confusing behavior. Adding full support for multiple ACSF dbs OOTB is a perennial challenge, because we have no way to determine ACSF db names locally unless they are hardcoded somewhere. In BLT 11, this was hardcoded in `multisite` config but this is a bad solution since it adds 100s of ms to each page request (to bootstrap the config loader).
