### PR TITLE
DX-2267: Restore local.blt.yml generation

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -19,7 +19,7 @@ For major releases, coordinate with ORCA prior to starting this process to ensur
 
 ## Review issue labels
 
-Review the issues and pull requests that will make up the release and ensure they are labelled correctly so that the changelog and release notes will be generated with the correct categories (new features, bug fixes, etc...).
+Review the issues and pull requests that will make up the release and ensure they are labelled correctly so that the changelog and release notes will be generated with the correct categories (new features, bug fixes, etc...). [Github releases](https://github.com/acquia/blt/releases) have a link to display all commits since a given release.
 
 ## Test via Canary
 

--- a/src/Robo/Commands/Source/LinkPackageCommand.php
+++ b/src/Robo/Commands/Source/LinkPackageCommand.php
@@ -37,7 +37,7 @@ class LinkPackageCommand extends BltTasks {
    */
   public function linkComposer(array $options = [
     'name' => 'acquia/blt',
-    'path' => '../../packages/blt',
+    'path' => '../../src/blt',
     'version-constraint' => '*',
   ]) {
     $path_parts = explode('/', $options['path']);

--- a/src/Robo/Commands/Source/SettingsCommand.php
+++ b/src/Robo/Commands/Source/SettingsCommand.php
@@ -62,20 +62,11 @@ WARNING;
    * @command source:build:settings
    *
    * @aliases blt:init:settings bis settings setup:settings
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function generateSiteConfigFiles() {
-    if (!file_exists($this->getConfigValue('blt.config-files.local'))) {
-      $result = $this->taskFilesystemStack()
-        ->copy($this->getConfigValue('blt.config-files.example-local'), $this->getConfigValue('blt.config-files.local'))
-        ->stopOnFail()
-        ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
-        ->run();
+    $this->generateLocalConfigFile();
 
-      if (!$result->wasSuccessful()) {
-        $filepath = $this->getInspector()->getFs()->makePathRelative($this->getConfigValue('blt.config-files.local'), $this->getConfigValue('repo.root'));
-        throw new BltException("Unable to create $filepath.");
-      }
-    }
     // Generate hash file in salt.txt.
     $this->hashSalt();
 
@@ -357,6 +348,42 @@ WARNING;
     if (!$result->wasSuccessful()) {
       $filepath = $this->getInspector()->getFs()->makePathRelative($deployment_identifier_file, $this->getConfigValue('repo.root'));
       throw new BltException("Unable to write deployment identifier to $filepath.");
+    }
+  }
+
+  /**
+   * Generates local.blt.yml from example.local.blt.yml.
+   *
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  private function generateLocalConfigFile() {
+    $localConfigFile = $this->getConfigValue('blt.config-files.local');
+    $exampleLocalConfigFile = $this->getConfigValue('blt.config-files.example-local');
+    $localConfigFilepath = $this->getInspector()
+      ->getFs()
+      ->makePathRelative($localConfigFile, $this->getConfigValue('repo.root'));
+    $exampleLocalConfigFilepath = $this->getInspector()
+      ->getFs()
+      ->makePathRelative($exampleLocalConfigFile, $this->getConfigValue('repo.root'));
+
+    if (file_exists($localConfigFile)) {
+      // Don't overwrite an existing local.blt.yml.
+      return;
+    }
+
+    if (!file_exists($exampleLocalConfigFile)) {
+      $this->say("Could not find $exampleLocalConfigFilepath. Create and commit this file if you'd like to automatically generate $localConfigFilepath based on this template.");
+      return;
+    }
+
+    $result = $this->taskFilesystemStack()
+      ->copy($exampleLocalConfigFile, $localConfigFile)
+      ->stopOnFail()
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+      ->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Unable to create $localConfigFilepath.");
     }
   }
 

--- a/src/Robo/Commands/Source/SettingsCommand.php
+++ b/src/Robo/Commands/Source/SettingsCommand.php
@@ -64,6 +64,18 @@ WARNING;
    * @aliases blt:init:settings bis settings setup:settings
    */
   public function generateSiteConfigFiles() {
+    if (!file_exists($this->getConfigValue('blt.config-files.local'))) {
+      $result = $this->taskFilesystemStack()
+        ->copy($this->getConfigValue('blt.config-files.example-local'), $this->getConfigValue('blt.config-files.local'))
+        ->stopOnFail()
+        ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+        ->run();
+
+      if (!$result->wasSuccessful()) {
+        $filepath = $this->getInspector()->getFs()->makePathRelative($this->getConfigValue('blt.config-files.local'), $this->getConfigValue('repo.root'));
+        throw new BltException("Unable to create $filepath.");
+      }
+    }
     // Generate hash file in salt.txt.
     $this->hashSalt();
 


### PR DESCRIPTION
Fixes #4231 
--------

This should create `local.blt.yml` if `example.local.blt.yml` exists.

Note that the new project templates no longer provide `example.local.blt.yml` out of the box, you'd need to manually create it if it's missing. I could see an argument for BLT to automatically create `example.local.blt.yml` if it's missing, or on composer install, but that should be a follow-up ticket.

@mikemadison13 can you help test this? I'd like to cut a new BLT release soon, and include this fix.