### PR TITLE
Fixes #4242: defaults the stock hostname to self.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -128,7 +128,7 @@ phpcbf:
 project:
   human_name: My BLT site
   local:
-    hostname: local.${project.machine_name}.com
+    hostname: self
     protocol: http
     uri: ${project.local.protocol}://${project.local.hostname}
   profile:


### PR DESCRIPTION
Fixes #4242 
--------
If this fixes an existing issue, link to that issue. Otherwise remove this section.

Motivation
----------
Working with a DDev / Lando VM, all commands (lando blt, ddev blt) will run inside the container (so `self` is appropriate). In a DrupalVM workflow all BLT commands should also be run inside the container after running `vagrant ssh.` Again, `self` is the appropriate default. 

Proposed changes
---------
Remove the local drush alias and set to self. 

Alternatives considered
---------
N/A

Testing steps
---------
Start a new project with a VM and attempt to run a blt script inside the vm. it will fail (because you can't ssh into the vm from inside the vm).
