### PR TITLE
Fixes #4247: defaults the local.drush hostname to self.

### DIFF
--- a/settings/default.local.drush.yml
+++ b/settings/default.local.drush.yml
@@ -1,2 +1,2 @@
 options:
-  uri: '${project.local.uri}'
+  uri: 'self'


### PR DESCRIPTION
Fixes #4247 
--------
If this fixes an existing issue, link to that issue. Otherwise remove this section.

Motivation
----------
The stock BLT 12 default.local.drush.yml file does not align with config/build.yml in that the stock drush alias is not `self`.

Proposed changes
---------
Set it to `self`

Alternatives considered
---------
N/A

Testing steps
---------
1. Spin up a new blt 12 site with a Drupal VM or Lando w/ this patch
2. Run a command (e.g. `blt drupal:update`) that requires a drush alias
3. confirm that it works (not fails)
