### PR TITLE
Fix #4244 and #4247: Set better config defaults, switch profile to minimal

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -127,12 +127,13 @@ phpcbf:
 
 project:
   human_name: My BLT site
+  machine_name: my_blt_site
   local:
     hostname: local.${project.machine_name}.com
     protocol: http
     uri: ${project.local.protocol}://${project.local.hostname}
   profile:
-    name: standard
+    name: minimal
 
 setup:
   # Valid values are install, sync, import.


### PR DESCRIPTION
Fixes #4244 
Fixes #4247 

Motivation
----------
See linked issues.

Proposed changes
---------
Set a default machine name and switch the default profile to minimal to fix linked issues.

Alternatives considered
---------
Many, all of them even worse than this one. See linked issues.