### PR TITLE
Fix #4251: TTY mode errors on Pipelines artifact builds

### DIFF
--- a/scripts/pipelines/build_artifact
+++ b/scripts/pipelines/build_artifact
@@ -10,7 +10,7 @@ export PATH=${COMPOSER_BIN}:${PATH}
 # Generate artifact in a separate directory.
 export NEW_BUILD_DIR=/tmp/artifact
 blt deploy:check-dirty --ansi --verbose
-blt artifact:build -D deploy.dir=${NEW_BUILD_DIR} -D deploy.docroot=${NEW_BUILD_DIR}/docroot --ansi --verbose
+blt artifact:build -D deploy.dir=${NEW_BUILD_DIR} -D deploy.docroot=${NEW_BUILD_DIR}/docroot --ansi --verbose --no-interaction
 # Move git history to artifact directory. Required for pipelines to commit and push.
 mv ${SOURCE_DIR}/.git ${NEW_BUILD_DIR}/
 # Allow dotfiles (hidden) to be globbed (via *).


### PR DESCRIPTION
Motivation
----------
Fixes #4251 

Proposed changes
---------
Run Pipelines artifact builds explicitly non-interactively.

Alternatives considered
---------
Chase down whatever component of the Symfony/Robo stack is incorrectly treating Pipelines as an interactive environment when it's not, as it's definitely a bug. Unfortunately I don't have time to chase it down right now.

Coincidentally, the other major open bug in the BLT queue is about Drupal Check, which was the last component to have TTY problems. Maybe there's some useful info here if anyone wants to dive in: https://github.com/mglaman/drupal-check/pull/135

Testing steps
---------
Apply this PR as patch, run a Pipelines build with a deploy step.