### PR TITLE
Fix memory exhaustion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ env:
     - DRUPAL_CORE_HEAD=8.9.x-dev
     # Change to 1 to debug failed tests.
     - BLT_PRINT_COMMAND_OUTPUT=1
+    # Remove this after updating to Composer 2
+    - COMPOSER_MEMORY_LIMIT=-1
 
 jobs:
   fast_finish: true
@@ -63,7 +65,7 @@ before_install:
   - cp -r subtree-splits/blt-project /tmp/
   - composer config --global repositories.blt path /tmp/blt-project
   # Install ORCA.
-  - COMPOSER_MEMORY_LIMIT=-1 composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
+  - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
   - ../orca/bin/travis/before_install.sh
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,8 @@ before_install:
   # Prepare local testing version of blt-project so it can be used by ORCA.
   - cp -r subtree-splits/blt-project /tmp/
   - composer config --global repositories.blt path /tmp/blt-project
-  - composer global require zaporylie/composer-drupal-optimizations
   # Install ORCA.
-  - composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
+  - COMPOSER_MEMORY_LIMIT=-1 composer create-project --no-dev acquia/orca ../orca "$ORCA_VERSION"
   - ../orca/bin/travis/before_install.sh
 
 install:


### PR DESCRIPTION
Motivation
----------
All of our Travis builds on the 11.x branch started failing 10 days ago. The only significant diff between the builds was that zaporylie/composer-drupal-optimizations was updated from 1.1.1 to 1.1.2. It seems highly likely that this change is the cause of the memory exhaustion, though it's not clear why: https://github.com/zaporylie/composer-drupal-optimizations/pull/22

Alternatives considered
---------
Try disabling the Composer memory limit, but I'm not sure what other limits we might encounter.

Testing steps
---------
Tests should pass