### PR TITLE
Fixes #4258: Project prefix missing by default

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -132,6 +132,8 @@ project:
     hostname: local.${project.machine_name}.com
     protocol: http
     uri: ${project.local.protocol}://${project.local.hostname}
+  # Used for enforcing correct git commit msg syntax.
+  prefix: CHANGEME
   profile:
     name: minimal
 


### PR DESCRIPTION
Motivation
----------
Fixes #4258 

Proposed changes
---------
Set the project prefix by default. Should have no effect on existing users (if commits were failing before, they'll still fail... if they've overridden the prefix, it'll stay overridden). For new users though, will provide a clearer clue that it needs to be changed.

Alternatives considered
---------
Disable commit message checking OOTB.

Testing steps
---------
See steps in #4258