### PR TITLE
Fixes #4275: Cannot run Yaml validator multiple times

### DIFF
--- a/src/Robo/Commands/Validate/YamlCommand.php
+++ b/src/Robo/Commands/Validate/YamlCommand.php
@@ -42,7 +42,7 @@ class YamlCommand extends BltTasks {
     /** @var \Acquia\Blt\Robo\Filesets\FilesetManager $fileset_manager */
     $fileset_manager = $this->getContainer()->get('filesetManager');
     $fileset_ids = $this->getConfigValue('validate.yaml.filesets');
-    $filesets = $fileset_manager->getFilesets($fileset_ids);
+    $filesets = $fileset_manager->getFilesets($fileset_ids, TRUE);
 
     $bin = $this->getConfigValue('composer.bin');
     $command = "'$bin/yaml-cli' lint '%s'";


### PR DESCRIPTION
Motivation
----------
Fixes #4275 

Proposed changes
---------
Use this reset parameter for the Yaml validator so that subsequent runs don't contaminate each other.

Testing steps
---------
Follow steps in #4275 . Verify that only the first Yaml error is reported.

Steps to verify the solution
---------
Same as above, but verify that errors in both files are reported all ten times.

An upstream issue (symfony/symfony#8871) indicates this is a common problem and offers alternative solutions, but this one is what has been implemented for the `TwigCommand` _and_  in addition has been already implemented in v`10.x`.