### PR TITLE
Fix #4271: Remove namespace from local settings

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -23,7 +23,6 @@ $databases = [
       'password' => '${drupal.db.password}',
       'host' => '${drupal.db.host}',
       'port' => '${drupal.db.port}',
-      'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
       'driver' => 'mysql',
       'prefix' => '',
     ],


### PR DESCRIPTION
Motivation
----------
Fixes #4271

Proposed changes
---------
Remove the namespace key from the database definition, since it's superfluous when using core drivers.

Alternatives considered
---------
Change to use the correct namespace.

Testing steps
---------
Regenerate local settings and run `blt setup`.

@b-sharpe can you please review and confirm this fixes the issue for you?