### PR TITLE
Fix #4261: Allow site mail and account mail to be set separately

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -61,6 +61,7 @@ docroot: ${repo.root}/docroot
 drupal:
   #account.name: admin
   account.mail: no-reply@acquia.com
+  site.mail: ${drupal.account.mail}
   locale: en
   local_settings_file: ${docroot}/sites/${site}/settings/local.settings.php
   settings_file: ${docroot}/sites/${site}/settings.php

--- a/src/Robo/Commands/Drupal/InstallCommand.php
+++ b/src/Robo/Commands/Drupal/InstallCommand.php
@@ -113,7 +113,7 @@ class InstallCommand extends BltTasks {
       ->rawArg($this->getConfigValue('setup.install-args'))
       ->option('sites-subdir', $this->getConfigValue('site'))
       ->option('site-name', $this->getConfigValue('project.human_name'))
-      ->option('site-mail', $this->getConfigValue('drupal.account.mail'))
+      ->option('site-mail', $this->getConfigValue('drupal.site.mail'))
       ->option('account-name', $username, '=')
       ->option('account-mail', $this->getConfigValue('drupal.account.mail'))
       ->option('locale', $this->getConfigValue('drupal.locale'))


### PR DESCRIPTION
Motivation
----------
Fixes #4261

Proposed changes
---------
- Add a `drupal.site.mail` configuration key that defaults to `drupal.account.mail`
