### PR TITLE
DX-3042: toggle:modules should use normal environment detection

### DIFF
--- a/src/Robo/Commands/Drupal/ToggleModulesCommand.php
+++ b/src/Robo/Commands/Drupal/ToggleModulesCommand.php
@@ -28,14 +28,8 @@ class ToggleModulesCommand extends BltTasks {
    * @validateDrushConfig
    */
   public function toggleModules() {
-    if ($this->input()->hasArgument('environment')) {
-      $environment = $this->input()->getArgument('environment');
-    }
-    elseif ($this->getConfig()->has('environment')) {
+    if ($this->getConfig()->has('environment')) {
       $environment = $this->getConfigValue('environment');
-    }
-    elseif (getenv('environment')) {
-      $environment = getenv('environment');
     }
 
     if (isset($environment)) {


### PR DESCRIPTION
Motivation
----------
The toggle modules command uses custom environment detection. This can produce unexpected results compared to other commands that use BLT core environment detection.

Proposed changes
---------
Rely on core environment detection by just checking the environment config.
