### PR TITLE
DX-3021: Fix #4292: Check for Composer 2 instead of prestissimo

### DIFF
--- a/src/Robo/Doctor/ComposerCheck.php
+++ b/src/Robo/Doctor/ComposerCheck.php
@@ -29,9 +29,13 @@ class ComposerCheck extends DoctorCheck {
    * DoctorCheck constructor.
    *
    * @param \Robo\Config\Config $config
+   *   Robo config.
    * @param \Acquia\Blt\Robo\Inspector\Inspector $inspector
+   *   BLT inspector.
    * @param \Acquia\Blt\Robo\Common\Executor $executor
+   *   BLT executor.
    * @param array $drush_status
+   *   Drush status.
    */
   public function __construct(Config $config, Inspector $inspector, Executor $executor, array $drush_status) {
     parent::__construct($config, $inspector, $executor, $drush_status);
@@ -103,7 +107,7 @@ class ComposerCheck extends DoctorCheck {
     if (!$this->getInspector()->isComposerMinimumVersionSatisfied('2')) {
       $this->logProblem(__FUNCTION__, [
         "Composer 1 detected.",
-        "  Composer 1 is end of life, and Composer 2 includes significant performance improvements. Upgrade to Composer 2 as soon as possible."
+        "  Composer 1 is end of life, and Composer 2 includes significant performance improvements. Upgrade to Composer 2 as soon as possible.",
       ], 'comment');
     }
   }

--- a/src/Robo/Doctor/ComposerCheck.php
+++ b/src/Robo/Doctor/ComposerCheck.php
@@ -27,6 +27,11 @@ class ComposerCheck extends DoctorCheck {
 
   /**
    * DoctorCheck constructor.
+   *
+   * @param \Robo\Config\Config $config
+   * @param \Acquia\Blt\Robo\Inspector\Inspector $inspector
+   * @param \Acquia\Blt\Robo\Common\Executor $executor
+   * @param array $drush_status
    */
   public function __construct(Config $config, Inspector $inspector, Executor $executor, array $drush_status) {
     parent::__construct($config, $inspector, $executor, $drush_status);
@@ -73,8 +78,7 @@ class ComposerCheck extends DoctorCheck {
    */
   public function performAllChecks() {
     $this->checkRequire();
-    $this->checkPrestissimo();
-    $this->checkDrupalCore();
+    $this->checkVersion();
 
     return $this->problems;
   }
@@ -93,27 +97,13 @@ class ComposerCheck extends DoctorCheck {
   }
 
   /**
-   * Check prestissimo.
+   * Check Composer version.
    */
-  protected function checkPrestissimo() {
-    $prestissimo_intalled = $this->getExecutor()->execute("composer global show | grep hirak/prestissimo")->run()->wasSuccessful();
-    if (!$prestissimo_intalled) {
-      $this->logProblem(__FUNCTION__ . ":plugins", [
-        "hirak/prestissimo plugin for composer is not installed.",
-        "  Run <comment>composer global require hirak/prestissimo</comment> to install it.",
-        "  This will improve composer install/update performance by parallelizing the download of dependency information.",
-      ], 'comment');
-    }
-  }
-
-  /**
-   * Check Drupal core.
-   */
-  protected function checkDrupalCore() {
-    if (empty($this->composerJson['require']['drupal/core']) && empty($this->composerJson['require']['drupal/core-recommended'])) {
-      $this->logProblem(__FUNCTION__ . ":plugins", [
-        "drupal/core or drupal/core-recommended are not required by the root composer.json.",
-        "  This impairs performance by preventing zaporylie/composer-drupal-optimizations from taking effect.",
+  protected function checkVersion() {
+    if (!$this->getInspector()->isComposerMinimumVersionSatisfied('2')) {
+      $this->logProblem(__FUNCTION__, [
+        "Composer 1 detected.",
+        "  Composer 1 is end of life, and Composer 2 includes significant performance improvements. Upgrade to Composer 2 as soon as possible."
       ], 'comment');
     }
   }

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -600,6 +600,24 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
   }
 
   /**
+   * Verifies that installed minimum Composer version is met.
+   *
+   * @param string $minimum_version
+   *   The minimum Composer version that is required.
+   *
+   * @return bool
+   *   TRUE if minimum version is satisfied.
+   */
+  public function isComposerMinimumVersionSatisfied($minimum_version) {
+    // phpcs:ignore
+    exec("composer --version | cut -d' ' -f3", $output, $exit_code);
+    if (version_compare($output[0], $minimum_version, '>=')) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Checks to see if BLT alias is installed on CLI.
    *
    * @return bool


### PR DESCRIPTION
Motivation
----------
Fixes #4292

Proposed changes
---------
Consider Composer 1 end of life, and advise users to upgrade. Specifically:
- Get rid of prestissimo and composer-drupal-optimizations checks, as these are no longer necessary with Composer 2
- Advise (not warn or error, yet) if Composer 1 is detected
