### PR TITLE
DX-2286: Fix #4233: Don't overwrite default.site.yml for multisite init

### DIFF
--- a/src/Robo/Commands/Recipes/MultisiteCommand.php
+++ b/src/Robo/Commands/Recipes/MultisiteCommand.php
@@ -341,10 +341,12 @@ class MultisiteCommand extends BltTasks {
   protected function createSiteDrushAlias($site_name, $site_url = '') {
     $aliases = [
       'local' => [
-        'uri' => $site_url ?: $site_name,
         'root' => '${env.cwd}/docroot',
       ],
     ];
+    if ($site_url) {
+      $aliases['local']['uri'] = $site_url;
+    }
     $defaultDrupalVmDrushAliasesFile = $this->getConfigValue('blt.root') . '/scripts/drupal-vm/drupal-vm.site.yml';
     if ($this->getInspector()->isDrupalVmConfigPresent() && file_exists($defaultDrupalVmDrushAliasesFile)) {
       $aliases = Expander::parse(file_get_contents($defaultDrupalVmDrushAliasesFile), $this->getConfig()->export());


### PR DESCRIPTION
Motivation
----------
Fixes #4233

Proposed changes
---------
If the URI is not provided (as should only be the case for the default site), don't try to set the URI.

Alternatives considered
---------
Don't mess with the default site at all. Unfortunately the rest of the multisite init command uses the default site as a template, so it must be initialized. Keeping this logic in place is the easiest solution.
