### PR TITLE
Fix #4310 Skip assigning all drupal databases on local settings file

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -13,20 +13,14 @@ $db_name = '${drupal.db.database}';
 /**
  * Database configuration.
  */
-$databases = [
-  'default' =>
-  [
-    'default' =>
-    [
-      'database' => $db_name,
-      'username' => '${drupal.db.username}',
-      'password' => '${drupal.db.password}',
-      'host' => '${drupal.db.host}',
-      'port' => '${drupal.db.port}',
-      'driver' => 'mysql',
-      'prefix' => '',
-    ],
-  ],
+$databases['default']['default'] = [
+  'database' => $db_name,
+  'username' => '${drupal.db.username}',
+  'password' => '${drupal.db.password}',
+  'host' => '${drupal.db.host}',
+  'port' => '${drupal.db.port}',
+  'driver' => 'mysql',
+  'prefix' => '',
 ];
 
 // Use development service parameters.


### PR DESCRIPTION
Instead set only the default database key, to prevent removing any added
database key from other include files.

Motivation
----------
Fixes #4310 
Allow setting up other drupal database keys from include files.

Proposed changes
---------
Set only default database key.

Testing steps
---------
See #4310
