### PR TITLE
DX-3088: Fix #4300: Do not assume presence of config_split

### DIFF
--- a/src/Robo/Commands/Drupal/ConfigCommand.php
+++ b/src/Robo/Commands/Drupal/ConfigCommand.php
@@ -100,6 +100,11 @@ class ConfigCommand extends BltTasks {
         break;
 
       case 'config-split':
+        if (!$this->getInspector()->isComposerPackageInstalled('drupal/config_split')) {
+          $this->logger->warning('Import strategy is config-split, but the config_split module does not exist. Falling back to core-only.');
+          $this->importCoreOnly($task, $cm_core_key);
+          break;
+        }
         $this->importConfigSplit($task, $cm_core_key);
         break;
     }

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -600,6 +600,20 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
   }
 
   /**
+   * Checks if a Composer package is installed.
+   *
+   * @return bool
+   *   True if package exists, false otherwise.
+   */
+  public function isComposerPackageInstalled($package_name) {
+    $result = $this->executor->execute("composer show $package_name")
+      ->interactive(FALSE)
+      ->silent(TRUE)
+      ->run();
+    return $result->wasSuccessful();
+  }
+
+  /**
    * Verifies that installed minimum Composer version is met.
    *
    * @param string $minimum_version


### PR DESCRIPTION
Motivation
----------
Fixes #4300

Proposed changes
---------
Check for the presence of config_split on disk before attempting to execute the config_split import strategy. Otherwise fall back to core strategy.
