### PR TITLE
DX-3091: Rename default branch from 12.x to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   global:
     # ORCA configuration.
     - ORCA_SUT_NAME=acquia/blt
-    - ORCA_SUT_BRANCH=12.x
+    - ORCA_SUT_BRANCH=main
     - ORCA_VERSION=^3
     - ORCA_PHPCS_STANDARD=AcquiaDrupalStrict
     # Change to 1 to debug failed tests.


### PR DESCRIPTION
This will allow us to move to a rolling release cadence instead of maintaining a bunch of branches in parallel. More documentation on this effort will be posted on docs.acquia.com/blt