### PR TITLE
DX-3168: invokeCommand() doesn't preserve input options

### DIFF
--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -84,8 +84,10 @@ class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerA
       $application = $this->getContainer()->get('application');
       $command = $application->find($command_name);
 
-      $input = new ArrayInput($args);
-      $input->setInteractive($this->input()->isInteractive());
+      $input = $this->input();
+      foreach ($args as $arg => $value) {
+        $input->setArgument($arg, $value);
+      }
       $prefix = str_repeat(">", $this->invokeDepth);
       $this->output->writeln("<comment>$prefix $command_name</comment>");
       $exit_code = $application->runCommand($command, $input, $this->output());

--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -19,6 +19,7 @@ use Robo\Contract\ConfigAwareInterface;
 use Robo\Contract\IOAwareInterface;
 use Robo\Contract\VerbosityThresholdInterface;
 use Robo\LoadAllTasks;
+use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * Base class for BLT Robo commands.
@@ -83,10 +84,16 @@ class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerA
       $application = $this->getContainer()->get('application');
       $command = $application->find($command_name);
 
-      $input = $this->input();
-      foreach ($args as $arg => $value) {
-        $input->setArgument($arg, $value);
+      // Build a new input object that inherits options from parent command.
+      $definition = $application->getDefinition();
+      $args['command'] = $command_name;
+      if ($this->input()->hasOption('environment')) {
+        $args['--environment'] = $this->input()->getOption('environment');
       }
+      $input = new ArrayInput($args, $definition);
+      $input->setInteractive($this->input()->isInteractive());
+
+      // Now run the command.
       $prefix = str_repeat(">", $this->invokeDepth);
       $this->output->writeln("<comment>$prefix $command_name</comment>");
       $exit_code = $application->runCommand($command, $input, $this->output());

--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -19,7 +19,6 @@ use Robo\Contract\ConfigAwareInterface;
 use Robo\Contract\IOAwareInterface;
 use Robo\Contract\VerbosityThresholdInterface;
 use Robo\LoadAllTasks;
-use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * Base class for BLT Robo commands.


### PR DESCRIPTION
Motivation
----------
Fixes #4313

invokeCommand() builds a new set of input arguments and thus discards any options such as `environment`.

Proposed changes
---------
Input options need to persist through the lifecycle of a BLT process, so let's instead reuse the existing input object and modify with any new args as necessary.
