### PR TITLE
Behat tests giving timeout error on lando.

### DIFF
--- a/src/Robo/Commands/Tests/TestsCommandBase.php
+++ b/src/Robo/Commands/Tests/TestsCommandBase.php
@@ -104,7 +104,7 @@ class TestsCommandBase extends BltTasks {
     $this->logger->info("Launching headless chrome...");
     $this->getContainer()
       ->get('executor')
-      ->execute("'$chrome_bin' --headless --disable-web-security --remote-debugging-port={$this->chromePort} {$this->chromeArgs} $chrome_host")
+      ->execute("'$chrome_bin' --headless --no-sandbox --disable-web-security --remote-debugging-port={$this->chromePort} {$this->chromeArgs} $chrome_host")
       ->background(TRUE)
       ->printOutput(TRUE)
       ->printMetadata(TRUE)


### PR DESCRIPTION
Motivation
----------
https://support.acquia.com/hc/en-us/articles/360047166273-Configuring-Acquia-BLT-with-Lando

This resolves the "Chrome timeouts" issue on behat test while running on lando.

Changes
---------
Add `--no-sandbox` option to launchChrome function.


Alternatives considered
---------
We might not able merge this as it can affect everyone but, just adding ready patch here for all lando users facing same issue.
