### PR TITLE
replaces composer check for config_split module with drush check

### DIFF
--- a/src/Robo/Commands/Drupal/ConfigCommand.php
+++ b/src/Robo/Commands/Drupal/ConfigCommand.php
@@ -100,7 +100,12 @@ class ConfigCommand extends BltTasks {
         break;
 
       case 'config-split':
-        if (!$this->getInspector()->isComposerPackageInstalled('drupal/config_split')) {
+        // Drush task explicitly to turn on config_split and check if it was
+        // successfully enabled. Otherwise default to core-only.
+        $check_task = $this->taskDrush();
+        $check_task->drush("pm-enable")->arg('config_split');
+        $result = $check_task->run();
+        if (!$result->wasSuccessful()) {
           $this->logger->warning('Import strategy is config-split, but the config_split module does not exist. Falling back to core-only.');
           $this->importCoreOnly($task, $cm_core_key);
           break;
@@ -143,7 +148,6 @@ class ConfigCommand extends BltTasks {
    *   Cm core key.
    */
   protected function importConfigSplit($task, $cm_core_key) {
-    $task->drush("pm-enable")->arg('config_split');
     $task->drush("config-import")->arg($cm_core_key);
     // Runs a second import to ensure splits are
     // both defined and imported.


### PR DESCRIPTION
Motivation
----------
Fixes #4331

What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above.
Drush is already a known and required tool. Drush can return if the config_split module is successfully enabled. If it is not because the module was not found, then the import strategy can be defaulted to core-only.

Proposed changes
---------
What does this PR change? How does this impact end users? Are manual or automatic updates required?
This replaces the composer check that was created in #4314. Removing the dependency of composer means that users on Acquia Cloud or other providers without access to a global composer deploying only an artifact, can safely use the config-split import strategy.

Alternatives considered
---------
How else could the original issue / use case be addressed? Why did you choose this solution over any others?
Other options were discussed in #4331, but I thought this would make the best use of existing tools. Maintainers may see this PR and still think there is a more elegant solution, but I believe the approach is on the right path.

Testing steps
---------
How can we replicate the issue and verify that this PR fixes it?
Deploy an artifact to Acquia Cloud using cm strategy of config-split and run the following commands:
```
blt internal:drupal:install
drush cache-rebuild
blt drupal:config:import
```
