### PR TITLE
Allow environment detector subclasses to override the isLocalEnv()

### DIFF
--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -104,6 +104,11 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
    * Is local.
    */
   public static function isLocalEnv() {
+    $results = self::getSubclassResults(__FUNCTION__);
+    if ($results) {
+      return TRUE;
+    }
+
     return parent::isLocalEnv() && !self::isPantheonEnv() && !self::isCiEnv();
   }
 


### PR DESCRIPTION
Motivation
----------
We wan't to treat the Acquia IDE as a "local" environment. For that purpose we'd like to override the isLocalEnv() function but without this we can't as BLT won't check for subclasses when checking if it's a local environment.

Proposed changes
---------
This PR adds the same check as other overridable functions to check for subclasses of the EnvironmentDetector and return their results. 

Testing steps
---------
To replicate the issue, instantiate an Acquia IDE and run blt setup. The setup will ask you for Drupal database settings and look for private file paths that are all usually defined in local.settings.php. Because it can't find these it will fail. An alternative would be to create a settings.local.php and edit the settings.php file to get around this but then the local config split won't import unless you add a symlink for an IDE split and configure one.

IMO these are too many hoops a developer needs to jump through to make the IDE run and behave like a local environment would. With this PR in place we can use https://github.com/pavlosdan/blt-ide-local to have BLT recognize the IDE as a local environment. 