### PR TITLE
DX-3308: Remove Travis CI caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
 
 cache:
   directories:
-    - "$HOME/.composer/cache"
     - "$HOME/.drush/cache"
     - "$HOME/.rvm"
     - "${TMPDIR:-/tmp}/phpstan/cache"


### PR DESCRIPTION
Motivation
----------
Fixes #4327

Proposed changes
---------
The Travis CI cache is only really efficient for build artifacts, it doesn't speed up Composer 2 at all and in fact might slow it down.
