### PR TITLE
Fixes #4341: package.json & package-lock.json not rsynced by default (main).

### DIFF
--- a/scripts/blt/deploy/.gitignore
+++ b/scripts/blt/deploy/.gitignore
@@ -257,3 +257,10 @@ Session.vim
 # Temporary files.
 .netrwhist
 *~
+
+# ------------
+# - Prevent supply chain attacks
+# - Reference: https://www.bleepingcomputer.com/news/security/researcher-hacks-over-35-tech-firms-in-novel-supply-chain-attack/
+# ------------
+package.json
+package-lock.json


### PR DESCRIPTION
**Motivation**
Fixes #4341 
`package.json` and `package-lock.json` files not rsynced by default. Addresses this supply-chain vulnerability: https://www.bleepingcomputer.com/news/security/researcher-hacks-over-35-tech-firms-in-novel-supply-chain-attack/

Sorry I did the 11.x branch instead of main first.

**Proposed changes**
As mentioned in @danepowell 's comments in #4341, users can opt to do this themselves on their own repos. Once this is in place, new projects would have it available by default.

**Alternatives considered**
I considered possibly putting a `.htaccess` file in the theme, but @danepowell 's suggestion seemed far more elegant, robust and reliable.

**Testing steps**
I've only verified this on a client's DEV env with a manual `blt deploy` and worked for our single use case.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [x] Manual testing by a reviewer

Maybe a security hardening label?
