### PR TITLE
Travis CI remove Composer caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
 
 cache:
   directories:
-    - "$HOME/.composer/cache"
     - "$HOME/.drush/cache"
     - "$HOME/.rvm"
     - "${TMPDIR:-/tmp}/phpstan/cache"

--- a/scripts/travis/.travis.yml
+++ b/scripts/travis/.travis.yml
@@ -12,7 +12,6 @@ env:
 
 cache:
   directories:
-    - "$HOME/.composer/cache"
     - "$HOME/.drush/cache"
   # Cache front end dependencies to dramatically improve build time.
   # - "docroot/themes/custom/mytheme/node_modules"


### PR DESCRIPTION
**Motivation**
Fixes #4327

**Proposed changes**
Remove Composer caching from end-user and internal Travis CI tests, as it's not beneficial.

**Merge requirements**
- [x] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
