### PR TITLE
Project creation fails if Git config not set

### DIFF
--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -54,7 +54,8 @@ class UpdateCommand extends BltTasks {
     $this->initializeBlt();
     $this->setProjectName();
     $this->initGitignore();
-    $this->initAndCommitRepo();
+    // Invoke command instead of calling method to ensure hooks run.
+    $this->invokeCommand('internal:create-project:init-repo');
     $this->displayArt();
     $this->yell("BLT has been added to your project.");
     $this->say("Please continue by following the \"Adding BLT to an existing project\" instructions:");


### PR DESCRIPTION
**Motivation**
Fixes https://github.com/acquia/cli/issues/427

**Proposed changes**
Call init-repo command to ensure Git validation runs and dummy credentials are set.

It looks like we missed this when first adding Git validation because we only tested in the context of the deploy and init-repo commands: https://github.com/acquia/blt/issues/3511

**Alternatives considered**
Get rid of the initial Git commit altogether, it seems like an overstep given BLT's new role as a more focused Composer package. Previous discussion at https://github.com/acquia/blt/issues/3511

**Testing steps**
Run `blt internal:add-to-project -n` on an uninitialized project with no Git username or email set and ensure it passes.

**Merge requirements**
- [x] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
