### PR TITLE
'all' is not a valid multisite

### DIFF
--- a/src/Robo/Config/DefaultConfig.php
+++ b/src/Robo/Config/DefaultConfig.php
@@ -81,8 +81,8 @@ class DefaultConfig extends BltConfig {
   /**
    * Gets an array of sites for the Drupal application.
    *
-   * I.e., sites under docroot/sites, not including acsf 'g' pseudo-site and
-   * 'settings' directory globbed in blt.settings.php.
+   * Include sites under docroot/sites, excluding 'all' and acsf 'g'
+   * pseudo-sites and 'settings' directory globbed in blt.settings.php.
    *
    * @return array
    *   An array of sites.
@@ -102,7 +102,7 @@ class DefaultConfig extends BltConfig {
       ->in($sites_dir)
       ->directories()
       ->depth('< 1')
-      ->exclude(['g', 'settings'])
+      ->exclude(['g', 'settings', 'all'])
       ->sortByName();
     foreach ($dirs->getIterator() as $dir) {
       $sites[] = $dir->getRelativePathname();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
BLT considers "all" to be a valid multisite, which it's obviously not.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Exclude 'all' from the list of returned sites.

**Merge requirements**
- [x] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
