### PR TITLE
local.settings.php not populated correctly from example.local.blt.yml

### DIFF
--- a/src/Robo/Commands/Source/SettingsCommand.php
+++ b/src/Robo/Commands/Source/SettingsCommand.php
@@ -4,6 +4,7 @@ namespace Acquia\Blt\Robo\Commands\Source;
 
 use Acquia\Blt\Robo\BltTasks;
 use Acquia\Blt\Robo\Common\RandomString;
+use Acquia\Blt\Robo\Config\ConfigInitializer;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Robo\Contract\VerbosityThresholdInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -43,6 +44,13 @@ WARNING;
    */
   public function generateSiteConfigFiles() {
     $this->generateLocalConfigFile();
+
+    // Reload config.
+    $config_initializer = new ConfigInitializer($this->getConfigValue('repo.root'), $this->input());
+    $new_config = $config_initializer->initialize();
+
+    // Replaces config.
+    $this->getConfig()->replace($new_config->export());
 
     // Generate hash file in salt.txt.
     $this->hashSalt();


### PR DESCRIPTION
**Motivation**
Fixes #4369

** BLT 12 **
@danepowell 
Since the main branch contains breaking changes that are planned for BLT 13 and this is to address a but in BLT 12, I based my branch off of the last tag of 12.8.2.

**Proposed changes**
This makes a call to reload the configurations. If an `example.local.blt.yml` file exists in the code repository and that is used to make the `local.blt.yml` file, it may contain configuration that is needed the the files that are generated in the rest of the `source:build:settings` command function.

**Alternatives considered**
A local script could call  `source:build:settings` and then delete the `local.settings.php` file and re-run the command. This is a severe work around to the problem putting it on the shoulders of the developer to fix the configuration issue.

**Testing steps**
The same steps from the issue can be used to verify that this fixes the issue.

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
