### PR TITLE
Fix #4375: Swap EnvironmentDetector to use new loophp/phposinfo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "enlightn/security-checker": "^1.3",
         "grasmash/yaml-cli": "^2.0.0",
         "grasmash/yaml-expander": "^1.2.0",
-        "loophp/phposinfo": "^1.7",
+        "loophp/phposinfo": "^1.7.1",
         "symfony/config": "^4.4",
         "symfony/console": "^4.4.6",
         "symfony/twig-bridge": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "dflydev/dot-access-data": "^1.1.0",
         "doctrine/annotations": "^1.10.0",
         "drupal/core": "^9.0.0-alpha1",
-        "drupol/phposinfo": "^1.6",
         "drush/drush": "^10.2.2",
         "enlightn/security-checker": "^1.3",
         "grasmash/yaml-cli": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "enlightn/security-checker": "^1.3",
         "grasmash/yaml-cli": "^2.0.0",
         "grasmash/yaml-expander": "^1.2.0",
-        "loophp/phposinfo": "^1.6",
+        "loophp/phposinfo": "^1.7",
         "symfony/config": "^4.4",
         "symfony/console": "^4.4.6",
         "symfony/twig-bridge": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "dflydev/dot-access-data": "^1.1.0",
         "doctrine/annotations": "^1.10.0",
         "drupal/core": "^9.0.0-alpha1",
+        "drupol/phposinfo": "^1.6",
         "drush/drush": "^10.2.2",
         "enlightn/security-checker": "^1.3",
         "grasmash/yaml-cli": "^2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2e6b9e83ef3189faba4af316f2b5f3f",
+    "content-hash": "629294503ea4c675a24ea722483dc452",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -1472,62 +1472,6 @@
                 "source": "https://github.com/drupal/core/tree/9.1.8"
             },
             "time": "2021-05-05T11:09:15+00:00"
-        },
-        {
-            "name": "drupol/phposinfo",
-            "version": "1.6.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/drupol/phposinfo.git",
-                "reference": "36b0250d38279c8a131a1898a31e359606024507"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/drupol/phposinfo/zipball/36b0250d38279c8a131a1898a31e359606024507",
-                "reference": "36b0250d38279c8a131a1898a31e359606024507",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">= 7.1.3"
-            },
-            "require-dev": {
-                "drupol/php-conventions": "^1.7.1",
-                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2",
-                "infection/infection": "^0.13.6 || ^0.15.0",
-                "phpspec/phpspec": "^5.1.2 || ^6.1.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "drupol\\phposinfo\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Pol Dellaiera",
-                    "email": "pol.dellaiera@protonmail.com"
-                }
-            ],
-            "description": "Try to guess the host operating system.",
-            "keywords": [
-                "operating system detection"
-            ],
-            "support": {
-                "issues": "https://github.com/drupol/phposinfo/issues",
-                "source": "https://github.com/drupol/phposinfo/tree/master"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/drupol",
-                    "type": "github"
-                }
-            ],
-            "abandoned": "loophp/phposinfo",
-            "time": "2020-05-19T14:14:28+00:00"
         },
         {
             "name": "drush/drush",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "629294503ea4c675a24ea722483dc452",
+    "content-hash": "d2e6b9e83ef3189faba4af316f2b5f3f",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -1472,6 +1472,62 @@
                 "source": "https://github.com/drupal/core/tree/9.1.8"
             },
             "time": "2021-05-05T11:09:15+00:00"
+        },
+        {
+            "name": "drupol/phposinfo",
+            "version": "1.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/drupol/phposinfo.git",
+                "reference": "36b0250d38279c8a131a1898a31e359606024507"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/drupol/phposinfo/zipball/36b0250d38279c8a131a1898a31e359606024507",
+                "reference": "36b0250d38279c8a131a1898a31e359606024507",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7.1.3"
+            },
+            "require-dev": {
+                "drupol/php-conventions": "^1.7.1",
+                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2",
+                "infection/infection": "^0.13.6 || ^0.15.0",
+                "phpspec/phpspec": "^5.1.2 || ^6.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "drupol\\phposinfo\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pol Dellaiera",
+                    "email": "pol.dellaiera@protonmail.com"
+                }
+            ],
+            "description": "Try to guess the host operating system.",
+            "keywords": [
+                "operating system detection"
+            ],
+            "support": {
+                "issues": "https://github.com/drupol/phposinfo/issues",
+                "source": "https://github.com/drupol/phposinfo/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/drupol",
+                    "type": "github"
+                }
+            ],
+            "abandoned": "loophp/phposinfo",
+            "time": "2020-05-19T14:14:28+00:00"
         },
         {
             "name": "drush/drush",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "629294503ea4c675a24ea722483dc452",
+    "content-hash": "a5a34722afb6282e83f6e34189bcb798",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -7290,5 +7290,5 @@
         "composer-runtime-api": "^2.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5a34722afb6282e83f6e34189bcb798",
+    "content-hash": "cadfcb2945ab6788bffa392241c251ff",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -4,8 +4,8 @@ namespace Acquia\Blt\Robo\Common;
 
 use Acquia\Blt\Robo\Config\ConfigInitializer;
 use Acquia\DrupalEnvironmentDetector\AcquiaDrupalEnvironmentDetector;
-use drupol\phposinfo\Enum\FamilyName;
-use drupol\phposinfo\OsInfo;
+use loophp\phposinfo\Enum\FamilyName;
+use loophp\phposinfo\OsInfo;
 use Symfony\Component\Console\Input\ArgvInput;
 
 /**


### PR DESCRIPTION
**Motivation**
Fixes #4375 

**Proposed changes**
Update the `src/Robo/Common/EnvironmentDetector.php` to use the new `loophp/phposinfo` instead of the abandoned `drupol/phposinfo`

**Testing steps**
- Run at least `composer update acquia/blt --with-all-dependences` and confirm no errors

**Merge requirements**
- [x] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer

