### PR TITLE
Fix #4392: [config_split] ah_other shouldn't apply to dev/stage/prod

### DIFF
--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -289,7 +289,7 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
       'prod' => self::isProdEnv(),
       'ci' => self::isCiEnv(),
       'ode' => self::isAhOdeEnv(),
-      'ah_other' => self::isAhEnv() && !self::isDevEnv() && !self::isStageEnv() && !self::isAhOdeEnv() && !self:isProdEnv(),
+      'ah_other' => self::isAhEnv() && !self::isDevEnv() && !self::isStageEnv() && !self::isAhOdeEnv() && !self::isProdEnv(),
     ];
   }
 

--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -289,7 +289,7 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
       'prod' => self::isProdEnv(),
       'ci' => self::isCiEnv(),
       'ode' => self::isAhOdeEnv(),
-      'ah_other' => self::isAhEnv(),
+      'ah_other' => self::isAhEnv() && !self::isDevEnv() && !self::isStageEnv() && !self::isAhOdeEnv() && !self:isProdEnv(),
     ];
   }
 


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #4392

**Proposed changes**
ah_other split should only be active in AH environments not otherwise recognized as dev/stage/prod. This replicates behavior prior to https://github.com/acquia/blt/commit/affea1d67ef7267177a174e4c19d9d144061733a

**Merge requirements**
- [x] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
