### PR TITLE
Support PHPUnit 9 for ACMS

### DIFF
--- a/src/Robo/Commands/Recipes/PhpUnitCommand.php
+++ b/src/Robo/Commands/Recipes/PhpUnitCommand.php
@@ -31,7 +31,7 @@ class PhpUnitCommand extends BltTasks {
       throw new BltException("Could not copy example files into the repository root.");
     }
 
-    $this->taskExec("composer require --dev --no-update phpunit/phpunit:'^4.8.35 || ^6.5 || ^7'")
+    $this->taskExec("composer require --dev --no-update phpunit/phpunit:'^4.8.35 || ^6.5 || ^7 || ^9'")
       ->run();
     $this->taskExec("composer update")
       ->run();


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Currently the `recipes:phpunit:init` command fails with a new version of ACMS.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? --> 
Support version 9.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
