### PR TITLE
Adding PHPCS validation to preCommitHook.

### DIFF
--- a/src/Robo/Commands/Internal/GitCommand.php
+++ b/src/Robo/Commands/Internal/GitCommand.php
@@ -79,6 +79,12 @@ class GitCommand extends BltTasks {
       );
     }
 
+    $collection->addCode(
+      function() {
+        return $this->invokeCommand('validate:phpcs');
+      }
+    );
+
     $result = $collection
       ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
       ->run();


### PR DESCRIPTION
When we get PHPCS errors on Pipeline builds, it's usually a surprise.  We want to avoid that surprise.

This change makes it so that PHPCS validate runs as part of precommit hooks.

I don't have alternate solutions, but I acknowledge that this PR may get refused because no everyone wants PHPCS validate on commit.  But since it's part of Pipelines, I think it should be.  

To test, make a code change that you know will fail PHPCS validation and commit it.  Before this PR, you can proceed and then you don't know there's a problem until your pipeline build fails.  Maybe that's 30 minutes later?  The next day?  With my change, you see the validation failure before you complete the commit.

The twig and yaml linters accept a file_list param, but it looks like PHPCS doesn't.  

I'd say this is an enhancement.
