### PR TITLE
Update simplesamlphp settings file path.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -108,11 +108,15 @@ $blt_settings_files = [
   'config',
   'logging',
   'filesystem',
-  'simplesamlphp',
   'misc',
 ];
 foreach ($blt_settings_files as $blt_settings_file) {
   $settings_files[] = __DIR__ . "/$blt_settings_file.settings.php";
+}
+
+// Add 'simplesamlphp' settings.
+if (is_dir(DRUPAL_ROOT . '/../vendor/acquia/blt-simplesamlphp')) {
+  $settings_files[] = DRUPAL_ROOT . '/../vendor/acquia/blt-simplesamlphp/settings/simplesamlphp.settings.php';
 }
 
 // Custom global and site-specific settings.


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Simplesamlphp has been moved out of blt and into it's own package (acquia/blt-simplesamlphp). The breaks the simplesamlphp_dir path override as the simplesamlphp.settings.php file is not included correctly.

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Update the path to the simplesamlphp settings file.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
