### PR TITLE
Allow admin password to be set by config if present.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -54,13 +54,16 @@ deploy:
   exclude_additions_file: ${repo.root}/blt/deploy-exclude-additions.txt
   gitignore_file: ${blt.root}/scripts/blt/deploy/.gitignore
 
-# File and Directory locations.
+# Drupal docroot.
 docroot: ${repo.root}/docroot
 
-# Drupal Account Credentials. These are used for installing Drupal.
+# Settings for installing Drupal.
 drupal:
-  #account.name: admin
-  account.mail: no-reply@example.com
+  account:
+    # Admin account name and password will be randomly generated unless set here.
+    #name: admin
+    #pass:
+    mail: no-reply@example.com
   site.mail: ${drupal.account.mail}
   locale: en
   local_settings_file: ${docroot}/sites/${site}/settings/local.settings.php

--- a/src/Robo/Commands/Drupal/InstallCommand.php
+++ b/src/Robo/Commands/Drupal/InstallCommand.php
@@ -120,6 +120,11 @@ class InstallCommand extends BltTasks {
       ->verbose(TRUE)
       ->printOutput(TRUE);
 
+    // Allow installs to define a custom user 1 password.
+    if ($this->getConfigValue('drupal.account.pass') !== NULL) {
+      $task->option('account-pass', $this->getConfigValue('drupal.account.pass'));
+    }
+
     // Install site from existing config if supported.
     $strategy = $this->getConfigValue('cm.strategy');
     $cm_core_key = 'sync';


### PR DESCRIPTION
**Motivation**
Currently BLT always generates a random password for user 1. On local environments we want to be able to define a username and password so we don't have to reset it after every single setup or use drush uli to get into the site.

**Proposed changes**
Since site:install allows for the --account-pass option, if a password is given in the blt config files, use it.

**Testing steps**
1. apply this patch
2. without changing anything else, run blt setup:drupal:instal -y --no-interaction
3. confirm random user name and password
4. add drupal.account.pass to your blt.yml file (optionally define a drupal.account.name as well for an easier test).
5. re-run blt setup:drupal:instal -y --no-interaction
6. confirm admin name and password are set to your custom ones defined in step 4.

