### PR TITLE
Deprecated usage of setInput()

### DIFF
--- a/src/Robo/Blt.php
+++ b/src/Robo/Blt.php
@@ -76,13 +76,9 @@ class Blt implements ContainerAwareInterface, LoggerAwareInterface {
 
     $this->setConfig($config);
     $application = new Application('BLT', Blt::getVersion());
-    if (self::usingLegacyContainer()) {
-      $container = Robo::createDefaultContainer($input, $output, $application,
-        $config, $classLoader);
-    }
-    else {
-      $container = new Container();
-      Robo::configureContainer($container, $application, $config, $input, $output, $classLoader);
+    $container = new Container();
+    Robo::configureContainer($container, $application, $config, $input, $output, $classLoader);
+    if (!self::usingLegacyContainer()) {
       Robo::finalizeContainer($container);
     }
     $this->setContainer($container);

--- a/src/Robo/Blt.php
+++ b/src/Robo/Blt.php
@@ -75,8 +75,13 @@ class Blt implements ContainerAwareInterface, LoggerAwareInterface {
 
     $this->setConfig($config);
     $application = new Application('BLT', Blt::getVersion());
-    $container = Robo::createDefaultContainer($input, $output, $application,
-      $config, $classLoader);
+    if (self::usingLegacyContainer()) {
+      $container = Robo::createDefaultContainer($input, $output, $application,
+        $config, $classLoader);
+    }
+    else {
+      $container = Robo::createContainer($application, $config, $classLoader);
+    }
     $this->setContainer($container);
     $this->addDefaultArgumentsAndOptions($application);
     $this->configureContainer($container);

--- a/src/Robo/Blt.php
+++ b/src/Robo/Blt.php
@@ -81,6 +81,8 @@ class Blt implements ContainerAwareInterface, LoggerAwareInterface {
     }
     else {
       $container = Robo::createContainer($application, $config, $classLoader);
+      $container->share('input', $input);
+      $container->share('output', $output);
     }
     $this->setContainer($container);
     $this->addDefaultArgumentsAndOptions($application);

--- a/src/Robo/Blt.php
+++ b/src/Robo/Blt.php
@@ -15,6 +15,7 @@ use Acquia\Blt\Update\Updater;
 use Composer\Autoload\ClassLoader;
 use Composer\InstalledVersions;
 use Consolidation\AnnotatedCommand\CommandFileDiscovery;
+use League\Container\Container;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 use League\Container\Definition\DefinitionInterface;
@@ -80,9 +81,9 @@ class Blt implements ContainerAwareInterface, LoggerAwareInterface {
         $config, $classLoader);
     }
     else {
-      $container = Robo::createContainer($application, $config, $classLoader);
-      $container->share('input', $input);
-      $container->share('output', $output);
+      $container = new Container();
+      Robo::configureContainer($container, $application, $config, $input, $output, $classLoader);
+      Robo::finalizeContainer($container);
     }
     $this->setContainer($container);
     $this->addDefaultArgumentsAndOptions($application);

--- a/src/Robo/Tasks/DrushTask.php
+++ b/src/Robo/Tasks/DrushTask.php
@@ -377,9 +377,6 @@ class DrushTask extends CommandStack {
       throw new TaskException($this, 'You must add at least one command');
     }
 
-    // Set $input to NULL so that it is not inherited by the process.
-    $this->setInput(NULL);
-
     // If 'stopOnFail' is not set, or if there is only one command to run,
     // then execute the single command to run.
     if (!$this->stopOnFail || (count($this->exec) == 1)) {

--- a/src/Robo/Tasks/LoadTasks.php
+++ b/src/Robo/Tasks/LoadTasks.php
@@ -16,7 +16,6 @@ trait LoadTasks {
   protected function taskDrush() {
     /** @var \Acquia\Blt\Robo\Tasks\DrushTask $task */
     $task = $this->task(DrushTask::class);
-    $task->setInput($this->input());
     /** @var \Symfony\Component\Console\Output\OutputInterface $output */
     $output = $this->output();
     $task->setVerbosityThreshold($output->getVerbosity());


### PR DESCRIPTION
When using Robo 3, BLT commands produce a warning such as:
> setInput() is deprecated. Please use setProcessInput()

This is because setInput() is deprecated in Robo 3: https://github.com/consolidation/robo/pull/1034/files

From what I can tell, our usage of setInput() doesn't even do anything. It should already be null by default (negating the usage in DrushTask, added in https://github.com/acquia/blt/pull/2018), and propagating arguments like `-y` hasn't worked for a while (negating the usage in LoadTasks, added in https://github.com/acquia/blt/pull/1815)