### PR TITLE
Fixes #4439: adds site argument into BLT Task context.

### DIFF
--- a/src/Robo/BltTasks.php
+++ b/src/Robo/BltTasks.php
@@ -88,6 +88,9 @@ class BltTasks implements ConfigAwareInterface, InspectorAwareInterface, LoggerA
       if ($this->input()->hasParameterOption('--environment')) {
         $args['--environment'] = $this->input()->getParameterOption('--environment');
       }
+      if ($this->input()->hasParameterOption('--site')) {
+        $args['--site'] = $this->input()->getParameterOption('--site');
+      }
       $input = new ArrayInput($args);
       $input->setInteractive($this->input()->isInteractive());
 


### PR DESCRIPTION
Fixes #4439. This ensures that any --site context passed into a command is preserved, similar to the work done in #4324 to do this with the --environment argument. 