### PR TITLE
Fixes UserConfig warnings for read-only systems

### DIFF
--- a/src/Robo/Common/UserConfig.php
+++ b/src/Robo/Common/UserConfig.php
@@ -39,7 +39,7 @@ class UserConfig {
     }
     else {
       // Make sure directory tree for user config file exists.
-      if (!file_exists($configDir) && !mkdir($configDir, 0777, TRUE)) {
+      if (!file_exists($configDir) && (!is_writable(getenv('HOME')) || !mkdir($configDir, 0777, TRUE))) {
         return;
       }
       // Make sure directory for user config file is writable.
@@ -87,7 +87,7 @@ class UserConfig {
    *   Telemetry user data.
    */
   public function getTelemetryUserData() {
-    $data = $this->config['telemetryUserData'];
+    $data = $this->config['telemetryUserData'] ?? [];
     $data['app_version'] = Blt::getVersion();
 
     return $data;


### PR DESCRIPTION
**Motivation**
Fixes #4454 

Prevents PHP warnings for `mkdir()` when a home directory is read-only. Also fixes a warning produced from UserConfig as a result of the read-only system.

**Testing steps**
- Set $HOME to readonly
- Run any blt command

Patch will prevent warnings and carry on.
