### PR TITLE
Make private files path in default.local.settings.php multisite-aware.

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -133,7 +133,7 @@ $settings['skip_permissions_hardening'] = TRUE;
 /**
  * Files paths.
  */
-$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/default';
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/' . EnvironmentDetector::getSiteName($site_path);
 /**
  * Site path.
  *


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #4458 

**Proposed changes**
I think to get this change, developers will have to remove all `default.local.settings.php` files and then run `blt bis`.

**Alternatives considered**
This setting could be set in `filesystem.settings.php` instead.

**Testing steps**
- See that the default `file_private_directory` is unaffected by this change.
- Create a multisite and see that the `file_private_directory` is different than the default `file_private_directory`, set to the name of the multisite within the `{repo.root}/files-private` directory. 

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
