### PR TITLE
Fix #4437: Allow child environment detectors to override false

### DIFF
--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -104,8 +104,8 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
    */
   public static function isLocalEnv() {
     $results = self::getSubclassResults(__FUNCTION__);
-    if ($results) {
-      return TRUE;
+    if ( !empty($results) ) {
+      return !in_array(FALSE, $results);
     }
 
     return parent::isLocalEnv() && !self::isPantheonEnv() && !self::isCiEnv();
@@ -116,8 +116,8 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
    */
   public static function isDevEnv() {
     $results = self::getSubclassResults(__FUNCTION__);
-    if ($results) {
-      return TRUE;
+    if ( !empty($results) ) {
+      return !in_array(FALSE, $results);
     }
 
     return self::isAhDevEnv() || self::isPantheonDevEnv();
@@ -128,8 +128,8 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
    */
   public static function isStageEnv() {
     $results = self::getSubclassResults(__FUNCTION__);
-    if ($results) {
-      return TRUE;
+    if ( !empty($results) ) {
+      return !in_array(FALSE, $results);
     }
 
     return self::isAhStageEnv() || self::isPantheonStageEnv();
@@ -140,8 +140,8 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
    */
   public static function isProdEnv() {
     $results = self::getSubclassResults(__FUNCTION__);
-    if ($results) {
-      return TRUE;
+    if ( !empty($results) ) {
+      return in_array(TRUE, $results);
     }
 
     return self::isAhProdEnv() || self::isPantheonProdEnv();
@@ -339,7 +339,7 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
         $results[] = call_user_func([$detector, $functionName]);
       }
     }
-    return array_filter($results);
+    return $results;
   }
 
 }


### PR DESCRIPTION
…e false is returned.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #4437
There is currently no way to allow a custom environment indicator to say that an environment is **not active**. This was due to the parent filtering out any results if they are 'false'. This results in config split applying the 'local' config splits in any remote environment that is not on Acquia. 

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
reserve the results from the custom environment indicator whether they return true or false. Then evaluate what the subclasses have returned. The assumption is that if we have a custom environment detector, that should override the capability and returning true/false within the custom environment indicator should be the end result, and it should not need to continue to the parent to check.  

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
I'm a bit unsure about the logic used. open to suggestions. 

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
Create a custom environment indicator and put it in a state where isLocalEnv returns false. Test in a non-acquia environment. Easiest to test with config split. User should see that local is not active (or local config split is not active) 

Example custom environment detector to test with.
```
<?php

namespace ConcertSetup\Blt\Plugin\EnvironmentDetector;

use Acquia\Blt\Robo\Common\EnvironmentDetector;

class CustomEnvironmentDetector extends EnvironmentDetector {

  public static function isLocalEnv() {  
  
     // This will return false, because we have set isProduction() to return true.
    return !self::isStageEnv() && !self::isProdEnv() && !self::isDevEnv();
  }

  /**
   * Is stage (on google cloud custom hosting).
   */
  public static function isStageEnv() {
    return getenv('ENVIRONMENT_ID') == 'stage';
  }

  /**
   * Is stage (on google cloud custom hosting).
   */
  public static function isDevEnv() {
    return getenv('ENVIRONMENT_ID') == 'dev';
  }

  /**
   * Is Prod (on google cloud custom hosting).
   */
  public static function isProdEnv() {
    return true;
    return $_ENV['ENVIRONMENT_ID'] == 'prod';
  }

}

```

**Merge requirements**
- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
- [ ] Manual testing by a reviewer
