### PR TITLE
Exclude dependency updates from release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,6 @@ Fixes #NNN
 <!-- How can we replicate the issue and verify that this PR fixes it? -->
 
 **Merge requirements**
-- [ ] _Major change_, _Minor change_, _Bug_, _Enhancement_, and/or _Chore_ label applied
+- [ ] _Major change_ or _Minor change_ semver label applied, if relevant
+- [ ] _Bug_, _Enhancement_, or _Chore_ label applied, if relevant
 - [ ] Manual testing by a reviewer

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,7 @@ include-labels:
   - 'Minor change'
   - 'Enhancement'
   - 'Bug'
+  - 'Chore'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,11 @@ categories:
     label: 'Bug'
   - title: '🧰 Maintenance'
     label: 'Chore'
+include-labels:
+  - 'Major change'
+  - 'Minor change'
+  - 'Enhancement'
+  - 'Bug'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:


### PR DESCRIPTION
composer.lock updates aren't relevant except to contributors. Going forward, if a PR doesn't include a label it won't be included in release notes.