### PR TITLE
Fixes #4397 to place ci.blt.yml by default.

### DIFF
--- a/scripts/blt/ci/internal/ci.yml
+++ b/scripts/blt/ci/internal/ci.yml
@@ -1,8 +1,5 @@
-modules.ci.enable: [ views_ui ]
-# We cannot use 127.0.0.1:8888 for vm hostname due to vagrant restrictions.
-vm.vagrant.hostname: local.${project.machine_name}.com
-drush.debug: false
-drush.verbose: true
 tests.run-server: true
 tests.drupal.sudo-run-tests: false
-project.local.hostname: 127.0.0.1:8080
+# The local.hostname must be set to 127.0.0.1:8888 because we are using drush runserver to test the site.
+project.local.hostname: 127.0.0.1:8888
+drush.debug: false

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -51,8 +51,13 @@ class UpdateCommand extends BltTasks {
    * @throws \Acquia\Blt\Robo\Exceptions\BltException
    */
   public function addToProject() {
+    // Initializes the project template / scaffold.
     $this->initializeBlt();
+    // Creates the blt/blt.yml file.
     $this->setProjectName();
+    // Places the blt/ci.blt.yml file.
+    $this->createCiConfig();
+    // Adds default BLT values into the project .gitignore file.
     $this->initGitignore();
     // Invoke command instead of calling method to ensure hooks run.
     $this->invokeCommand('internal:create-project:init-repo');
@@ -231,6 +236,21 @@ class UpdateCommand extends BltTasks {
     $project_config = $yamlWriter->getContents();
     $project_config['project']['machine_name'] = $project_name;
     $yamlWriter->write($project_config);
+  }
+
+  /**
+   * Sets project.name using the directory name of repo.root.
+   */
+  protected function createCiConfig() {
+    $result = $this->taskFilesystemStack()
+      ->copy($this->getConfigValue('blt.root') . '/scripts/blt/ci/internal/ci.yml', $this->getConfigValue('repo.root') . '/blt/ci.blt.yml', TRUE)
+      ->stopOnFail()
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+      ->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Could not initialize the CI specific BLT file.");
+    }
   }
 
 }

--- a/tests/phpunit/src/DrupalSettingsTest.php
+++ b/tests/phpunit/src/DrupalSettingsTest.php
@@ -2,8 +2,6 @@
 
 namespace Acquia\Blt\Tests;
 
-use Acquia\Blt\Robo\Common\YamlMunge;
-
 /**
  * Tests Drupal settings.
  */
@@ -20,6 +18,7 @@ class DrupalSettingsTest extends BltProjectTestBase {
       $this->assertFileExists("$this->sandboxInstance/docroot/sites/$site/settings/default.local.settings.php");
       $this->assertFileExists("$this->sandboxInstance/docroot/sites/$site/default.settings.php");
       $this->assertFileExists("$this->sandboxInstance/docroot/sites/$site/settings/local.settings.php");
+      $this->assertFileExists("$this->sandboxInstance/docroot/sites/$site/settings/local.settings.php");
 
       $this->assertStringContainsString('${drupal.db.database}', file_get_contents("$this->sandboxInstance/docroot/sites/$site/settings/default.local.settings.php"));
       $this->assertStringContainsString($this->config->get("drupal.db.database"), file_get_contents("$this->sandboxInstance/docroot/sites/$site/settings/local.settings.php"));
@@ -35,10 +34,8 @@ class DrupalSettingsTest extends BltProjectTestBase {
       $this->assertFileExists("$this->sandboxInstance/docroot/sites/$site/local.drush.yml");
       $this->assertFileExists("$this->sandboxInstance/docroot/sites/$site/default.local.drush.yml");
 
-      $output_array = $this->drushJson(['status']);
-      $this->assertEquals($output_array['uri'], $this->config->get('project.local.uri'));
-      $drush_local_site_yml = YamlMunge::parseFile("$this->sandboxInstance/docroot/sites/$site/local.drush.yml");
-      $this->assertEquals($output_array['uri'], $drush_local_site_yml['options']['uri']);
+      $this->assertFileExists("$this->sandboxInstance/blt/blt.yml");
+      $this->assertFileExists("$this->sandboxInstance/blt/ci.blt.yml");
     }
   }
 

--- a/tests/phpunit/src/SecurityTestsTest.php
+++ b/tests/phpunit/src/SecurityTestsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Acquia\Blt\Tests;
+
+/**
+ * Test security test commands.
+ */
+class SecurityTestsTest extends BltProjectTestBase {
+
+  /**
+   * Test that executes the blt drupal security test.
+   */
+  public function testDrupalSecurity() {
+    list($response) = $this->blt('tests:security-drupal');
+    $this->assertStringContainsString("0", $response);
+  }
+
+  /**
+   * Test that executes the blt composer security test.
+   */
+  public function testComposerSecurity() {
+    list($response) = $this->blt('tests:security-composer');
+    $this->assertStringContainsString("0", $response);
+  }
+
+}


### PR DESCRIPTION
**Motivation**
BLT ships with a ci.yml file (see https://github.com/acquia/blt/blob/main/scripts/blt/ci/internal/ci.yml) but it no longer places it as ci.blt.yml in the blt folder.

**Proposed changes**
Place the file during the scaffolding process.

**Testing steps**
1. Setup a new project using acquia/drupal-recommended-project
2. Add BLT
3. confirm that blt/ci.blt.yml is in place
