### PR TITLE
Fixes #4500 to resolve config split recipe issues and #4501 for deprecated Twig code.

### DIFF
--- a/scripts/config-split/templates/.htaccess
+++ b/scripts/config-split/templates/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/scripts/config-split/templates/config_split.config_split.env.yml.twig
+++ b/scripts/config-split/templates/config_split.config_split.env.yml.twig
@@ -1,6 +1,6 @@
 uuid: {{ uuid }}
 langcode: en
-status: true
+status: false
 dependencies: {  }
 id: {{ id }}
 label: {{ name }}

--- a/src/Robo/Commands/Recipes/ConfigSplitCommand.php
+++ b/src/Robo/Commands/Recipes/ConfigSplitCommand.php
@@ -7,6 +7,8 @@ use Drupal\Component\Uuid\Php;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Acquia\Blt\Robo\Common\YamlMunge;
 use Robo\Contract\VerbosityThresholdInterface;
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
 
 /**
  * Defines commands in the recipes:config:init:splits namespace.
@@ -23,7 +25,7 @@ class ConfigSplitCommand extends BltTasks {
   /**
    * An instance of the Twig template environment.
    *
-   * @var \Twig_Environment
+   * @var \Twig\Environment
    */
   protected $twig;
 
@@ -49,8 +51,8 @@ class ConfigSplitCommand extends BltTasks {
   public function initialize() {
     $this->uuidGenerator = new Php();
     $template_dir = $this->getConfigValue('blt.root') . '/scripts/config-split/templates';
-    $loader = new \Twig_Loader_Filesystem($template_dir);
-    $this->twig = new \Twig_Environment($loader);
+    $loader = new FilesystemLoader($template_dir);
+    $this->twig = new Environment($loader);
     $docroot = $this->getConfigValue('docroot');
     $this->configSyncDir = $docroot . '/' . $this->getConfigValue('cm.core.dirs.sync.path');
     $this->configSplitDir = $docroot . '/' . $this->getConfigValue('cm.core.path') . '/envs';

--- a/src/Robo/Commands/Recipes/ConfigSplitCommand.php
+++ b/src/Robo/Commands/Recipes/ConfigSplitCommand.php
@@ -6,6 +6,7 @@ use Acquia\Blt\Robo\BltTasks;
 use Drupal\Component\Uuid\Php;
 use Acquia\Blt\Robo\Exceptions\BltException;
 use Acquia\Blt\Robo\Common\YamlMunge;
+use Robo\Contract\VerbosityThresholdInterface;
 
 /**
  * Defines commands in the recipes:config:init:splits namespace.
@@ -130,6 +131,17 @@ class ConfigSplitCommand extends BltTasks {
         'name' => $split,
       ]);
       file_put_contents($split_dir . '/README.md', $readme);
+    }
+    if (!file_exists($split_dir . '/.htaccess')) {
+      $result = $this->taskFilesystemStack()
+        ->copy($this->getConfigValue('repo.root') . '/vendor/acquia/blt/scripts/config-split/templates/.htaccess', $split_dir . '/.htaccess', TRUE)
+        ->stopOnFail()
+        ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+        ->run();
+
+      if (!$result->wasSuccessful()) {
+        throw new BltException("Could not place .htaccess file in $split_dir.");
+      }
     }
   }
 

--- a/src/Robo/Commands/Recipes/ConfigSplitCommand.php
+++ b/src/Robo/Commands/Recipes/ConfigSplitCommand.php
@@ -4,6 +4,8 @@ namespace Acquia\Blt\Robo\Commands\Recipes;
 
 use Acquia\Blt\Robo\BltTasks;
 use Drupal\Component\Uuid\Php;
+use Acquia\Blt\Robo\Exceptions\BltException;
+use Acquia\Blt\Robo\Common\YamlMunge;
 
 /**
  * Defines commands in the recipes:config:init:splits namespace.
@@ -66,6 +68,22 @@ class ConfigSplitCommand extends BltTasks {
     $default_splits = ['Local', 'CI', 'Dev', 'Stage', 'Prod'];
     foreach ($default_splits as $split) {
       $this->createSplitConfig($split);
+    }
+
+    // Automatically add config split and config ignore to project configuration.
+    $core_extensions = YamlMunge::parseFile($this->configSyncDir . '/core.extension.yml');
+    if (!array_key_exists("config_split", $core_extensions['module'])) {
+      $core_extensions['module']['config_split'] = 0;
+    }
+    if (!array_key_exists("config_filter", $core_extensions['module'])) {
+      $core_extensions['module']['config_filter'] = 0;
+    }
+    try {
+      ksort($core_extensions['module']);
+      YamlMunge::writeFile($this->configSyncDir . '/core.extension.yml', $core_extensions);
+    }
+    catch (\Exception $e) {
+      throw new BltException("Unable to update core.extension.yml");
     }
   }
 

--- a/tests/phpunit/src/ConfgSplitTest.php
+++ b/tests/phpunit/src/ConfgSplitTest.php
@@ -2,8 +2,6 @@
 
 namespace Acquia\Blt\Tests;
 
-use Acquia\Blt\Robo\Common\YamlMunge;
-
 /**
  * Tests Config Split recipe.
  */
@@ -22,15 +20,6 @@ class ConfgSplitTest extends BltProjectTestBase {
   }
 
   /**
-   * Tests recipes:config:init:splits to validate core.extension manipulation.
-   */
-  public function testCoreExtension() {
-    $core_extensions = YamlMunge::parseFile($this->sandboxInstance . '/config/default/core.extension.yml');
-    $this->assertArrayHasKey("config_filter", $core_extensions['module']);
-    $this->assertArrayHasKey("config_split", $core_extensions['module']);
-  }
-
-  /**
    * Defines the default BLT config splits.
    *
    * @return array
@@ -46,4 +35,5 @@ class ConfgSplitTest extends BltProjectTestBase {
     ];
     return $splits;
   }
+
 }

--- a/tests/phpunit/src/ConfgSplitTest.php
+++ b/tests/phpunit/src/ConfgSplitTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Acquia\Blt\Tests;
+
+use Acquia\Blt\Robo\Common\YamlMunge;
+
+/**
+ * Tests Config Split recipe.
+ */
+class ConfgSplitTest extends BltProjectTestBase {
+
+  /**
+   * Tests recipes:config:init:splits to validate split creation.
+   */
+  public function testConfigSplitRecipe() {
+    $this->blt('recipes:config:init:splits');
+    $splits = $this->getSplits();
+    foreach ($splits as $split) {
+      $this->assertFileExists("$this->sandboxInstance/config/default/config_split.config_split.$split.yml");
+      $this->assertDirectoryExists("$this->sandboxInstance/config/envs/$split");
+    }
+  }
+
+  /**
+   * Tests recipes:config:init:splits to validate core.extension manipulation.
+   */
+  public function testCoreExtension() {
+    $core_extensions = YamlMunge::parseFile($this->sandboxInstance . '/config/default/core.extension.yml');
+    $this->assertArrayHasKey("config_filter", $core_extensions['module']);
+    $this->assertArrayHasKey("config_split", $core_extensions['module']);
+  }
+
+  /**
+   * Defines the default BLT config splits.
+   *
+   * @return array
+   *   An array of default config splits.
+   */
+  public function getSplits() {
+    $splits = [
+      'local',
+      'dev',
+      'stage',
+      'prod',
+      'ci',
+    ];
+    return $splits;
+  }
+}


### PR DESCRIPTION
**Motivation**
The config split recipe has a few gaps (which I have to fix manually all the time) and some deprecated code. See #4500 and #4501.

**Proposed changes**
* recipe creates .htaccess files for all splits
* split templates are not "off" by default (status to false)
* recipe enables config split and config filter by default in core.extension
* expanded tests
* replaced deprecated Twig_Loader_Filesystem and Twig_Environment. see https://twig.symfony.com/doc/2.x/deprecated.html#environment
