### PR TITLE
Fixes #4513 to refactor due to symfony/process update.

### DIFF
--- a/src/Robo/Commands/Tests/ServerCommand.php
+++ b/src/Robo/Commands/Tests/ServerCommand.php
@@ -54,7 +54,7 @@ class ServerCommand extends TestsCommandBase {
     /** @var \Acquia\Blt\Robo\Common\Executor $executor */
     $executor = $this->getContainer()->get('executor');
     $result = $executor
-      ->drush("runserver --quiet $this->serverUrl > $log_file 2>&1")
+      ->drush(["runserver", "--quiet", "$this->serverUrl > $log_file 2>&1"])
       ->background(TRUE)
       ->run();
 

--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -56,7 +56,8 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
    * Wrapper for taskExec().
    *
    * @param string $command
-   *   The command to execute.
+   *   The command string|array.
+   *   Warning: symfony/process 5.x expects an array.
    *
    * @return \Robo\Task\Base\Exec
    *   The task. You must call run() on this to execute it!
@@ -68,14 +69,21 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
   /**
    * Executes a drush command.
    *
-   * @param array $command
+   * @param mixed $command
    *   The command to execute, without "drush" prefix.
    *
    * @return \Robo\Common\ProcessExecutor
    *   The unexecuted process.
    */
-  public function drush(array $command) {
+  public function drush($command) {
     $drush_array = [];
+
+    // Backwards compatibility check for legacy commands.
+    if (!is_array($command)) {
+      $this->say(StringManipulator::stringToArrayMsg());
+      $command = StringManipulator::commandConvert($command);
+    }
+
     // @todo Set to silent if verbosity is less than very verbose.
     $drush_array[] = $this->getConfigValue('composer.bin') . DIRECTORY_SEPARATOR . "drush";
     $drush_array[] = "@" . $this->getConfigValue('drush.alias');
@@ -99,13 +107,19 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
   /**
    * Executes a command.
    *
-   * @param array $command
-   *   The command.
+   * @param mixed $command
+   *   The command string|array.
+   *   Warning: symfony/process 5.x expects an array.
    *
    * @return \Robo\Common\ProcessExecutor
    *   The unexecuted command.
    */
-  public function execute(array $command) {
+  public function execute($command) {
+    // Backwards compatibility check for legacy commands.
+    if (!is_array($command)) {
+      $this->say(StringManipulator::stringToArrayMsg());
+      $command = StringManipulator::commandConvert($command);
+    }
     /** @var \Robo\Common\ProcessExecutor $process_executor */
     $process_executor = Robo::process(new Process($command));
     return $process_executor->dir($this->getConfigValue('repo.root'))

--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -68,26 +68,26 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
   /**
    * Executes a drush command.
    *
-   * @param string $command
+   * @param array $command
    *   The command to execute, without "drush" prefix.
    *
    * @return \Robo\Common\ProcessExecutor
    *   The unexecuted process.
    */
-  public function drush($command) {
+  public function drush(array $command) {
+    $drush_array = [];
     // @todo Set to silent if verbosity is less than very verbose.
-    $bin = $this->getConfigValue('composer.bin');
-    /** @var \Robo\Common\ProcessExecutor $process_executor */
-    $drush_alias = $this->getConfigValue('drush.alias');
-    $command_string = $bin . DIRECTORY_SEPARATOR . "drush @$drush_alias $command";
+    $drush_array[] = $this->getConfigValue('composer.bin') . DIRECTORY_SEPARATOR . "drush";
+    $drush_array[] = "@" . $this->getConfigValue('drush.alias');
 
     // URIs do not work on remote drush aliases in Drush 9. Instead, it is
     // expected that the alias define the uri in its configuration.
-    if ($drush_alias != 'self') {
-      $command_string .= ' --uri=' . $this->getConfigValue('site');
+    if ($this->getConfigValue('drush.alias') != 'self') {
+      $drush_array[] = ' --uri=' . $this->getConfigValue('site');
     }
+    $command_array = array_merge($drush_array, $command);
 
-    $process_executor = Robo::process(new Process($command_string));
+    $process_executor = Robo::process(new Process($command_array));
 
     return $process_executor->dir($this->getConfigValue('docroot'))
       ->interactive(FALSE)
@@ -99,13 +99,13 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
   /**
    * Executes a command.
    *
-   * @param string $command
+   * @param array $command
    *   The command.
    *
    * @return \Robo\Common\ProcessExecutor
    *   The unexecuted command.
    */
-  public function execute($command) {
+  public function execute(array $command) {
     /** @var \Robo\Common\ProcessExecutor $process_executor */
     $process_executor = Robo::process(new Process($command));
     return $process_executor->dir($this->getConfigValue('repo.root'))

--- a/src/Robo/Common/StringManipulator.php
+++ b/src/Robo/Common/StringManipulator.php
@@ -95,4 +95,27 @@ class StringManipulator {
     return strtoupper($prefix);
   }
 
+  /**
+   * Converts a command string to command array.
+   *
+   * @param string $command
+   *   The command string to conver to array.
+   *
+   * @return array
+   *   Command array.
+   */
+  public static function commandConvert($command) {
+    return explode(" ", $command);
+  }
+
+  /**
+   * Provides a common warning for command string / array use.
+   *
+   * @return string
+   *   The deprecation warning.
+   */
+  public static function stringToArrayMsg() {
+    return "Deprecation Warning: this command is passing a command string and should pass a command arary.";
+  }
+
 }

--- a/src/Robo/Doctor/WebUriCheck.php
+++ b/src/Robo/Doctor/WebUriCheck.php
@@ -49,7 +49,12 @@ class WebUriCheck extends DoctorCheck {
    * Checks that configured URI responds to requests.
    */
   protected function checkUriResponse() {
-    $site_available = $this->getExecutor()->execute("curl -I --insecure " . $this->drushStatus['uri'])->run()->wasSuccessful();
+    $site_available = $this->getExecutor()->execute([
+      "curl",
+      "-I",
+      "--insecure",
+      $this->drushStatus['uri'],
+    ])->run()->wasSuccessful();
     if (!$site_available) {
       $this->logProblem(__FUNCTION__, [
         "Did not get a response from {$this->drushStatus['uri']}",
@@ -66,7 +71,11 @@ class WebUriCheck extends DoctorCheck {
    */
   protected function checkHttps() {
     if (strstr($this->drushStatus['uri'], 'https')) {
-      if (!$this->getExecutor()->execute('curl -cacert ' . $this->drushStatus['uri'])->run()->wasSuccessful()) {
+      if (!$this->getExecutor()->execute([
+        'curl',
+        '-cacert',
+        $this->drushStatus['uri'],
+      ])->run()->wasSuccessful()) {
         $this->logProblem(__FUNCTION__, [
           "The SSL certificate for your local site appears to be invalid for {$this->drushStatus['uri']}.",
         ], 'error');

--- a/tests/phpunit/src/BltProjectTestBase.php
+++ b/tests/phpunit/src/BltProjectTestBase.php
@@ -3,6 +3,7 @@
 namespace Acquia\Blt\Tests;
 
 use Acquia\Blt\Robo\Blt;
+use Acquia\Blt\Robo\Common\StringManipulator;
 use Acquia\Blt\Robo\Config\ConfigInitializer;
 use PHPUnit\Framework\TestCase;
 use Robo\Robo;
@@ -38,6 +39,11 @@ abstract class BltProjectTestBase extends TestCase {
    * is bootstrapped. Setting BLT_RECREATE_SANDBOX_MASTER=0 will prevent this.
    */
   protected $dbDump;
+
+  /**
+   * @var \Acquia\Blt\Robo\Common\Executor
+   */
+  protected $executor;
 
   /**
    * @var \Symfony\Component\Console\Output\ConsoleOutput
@@ -89,8 +95,9 @@ abstract class BltProjectTestBase extends TestCase {
   }
 
   /**
-   * @param array $command
-   *   Command.
+   * @param mixed $command
+   *   The command string|array.
+   *   Warning: symfony/process 5.x expects an array.
    * @param mixed $cwd
    *   CWD.
    * @param bool $stop_on_error
@@ -101,7 +108,11 @@ abstract class BltProjectTestBase extends TestCase {
    *
    * @throws \Exception
    */
-  protected function execute(array $command, $cwd = NULL, $stop_on_error = TRUE) {
+  protected function execute($command, $cwd = NULL, $stop_on_error = TRUE) {
+    // Backwards compatibility check for legacy commands.
+    if (!is_array($command)) {
+      $command = StringManipulator::commandConvert($command);
+    }
     if (!$cwd) {
       $cwd = $this->sandboxInstance;
     }
@@ -139,8 +150,9 @@ abstract class BltProjectTestBase extends TestCase {
   /**
    * Drush.
    *
-   * @param array $command
-   *   Command.
+   * @param mixed $command
+   *   The command string|array.
+   *   Warning: symfony/process 5.x expects an array.
    * @param mixed $root
    *   Root.
    * @param bool $stop_on_error
@@ -151,7 +163,11 @@ abstract class BltProjectTestBase extends TestCase {
    *
    * @throws \Exception
    */
-  protected function drush(array $command, $root = NULL, $stop_on_error = TRUE) {
+  protected function drush($command, $root = NULL, $stop_on_error = TRUE) {
+    // Backwards compatibility check for legacy commands.
+    if (!is_array($command)) {
+      $command = StringManipulator::commandConvert($command);
+    }
     if (!$root) {
       $root = $this->config->get('docroot');
     }
@@ -170,8 +186,9 @@ abstract class BltProjectTestBase extends TestCase {
   /**
    * Drush JSON.
    *
-   * @param array $command
-   *   Command.
+   * @param mixed $command
+   *   The command string|array.
+   *   Warning: symfony/process 5.x expects an array.
    * @param mixed $root
    *   Root.
    * @param bool $stop_on_error
@@ -182,7 +199,11 @@ abstract class BltProjectTestBase extends TestCase {
    *
    * @throws \Exception
    */
-  protected function drushJson(array $command, $root = NULL, $stop_on_error = TRUE) {
+  protected function drushJson($command, $root = NULL, $stop_on_error = TRUE) {
+    // Backwards compatibility check for legacy commands.
+    if (!is_array($command)) {
+      $command = StringManipulator::commandConvert($command);
+    }
     $command[] = "--format=json";
     $output = $this->drush($command, $root, $stop_on_error);
     $array = json_decode($output, TRUE);

--- a/tests/phpunit/src/CommandArrayTest.php
+++ b/tests/phpunit/src/CommandArrayTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Acquia\Blt\Tests;
+
+use Acquia\Blt\Robo\Common\StringManipulator;
+
+/**
+ * Tests String to Array Conversion for Commands.
+ */
+class CommandArrayTest extends BltProjectTestBase {
+
+  public function testStringToArray() {
+    $string = "site-install minimal --existing-config --ansi -n";
+    $command = StringManipulator::commandConvert($string);
+    $this->assertIsArray($command);
+
+    $keys = $this->getKeys();
+    foreach ($keys as $key) {
+      $result = in_array($key, $command);
+      $this->assertTrue($result);
+    }
+  }
+
+  public function testStringDrush() {
+    $string = "status --yes";
+    $this->drushJson($string);
+  }
+
+  public function getKeys() {
+    return [
+      "site-install",
+      "minimal",
+      "--existing-config",
+      "--ansi",
+      "-n",
+    ];
+  }
+
+}

--- a/tests/phpunit/src/ConfigImportTest.php
+++ b/tests/phpunit/src/ConfigImportTest.php
@@ -16,7 +16,7 @@ class ConfigImportTest extends BltProjectTestBase {
    * @throws \Exception
    */
   public function testNoConfig() {
-    $this->drush("config-export --yes");
+    $this->drush(["config-export", "--yes"]);
     list($status_code) = $this->blt("drupal:config:import", [
       '--define' => [
         'cm.strategy=none',
@@ -29,7 +29,7 @@ class ConfigImportTest extends BltProjectTestBase {
    * @throws \Exception
    */
   public function testNoConfigException() {
-    $this->drush("config-export --yes");
+    $this->drush(["config-export", "--yes"]);
     try {
       list($status_code) = $this->blt("drupal:config:import", [
         '--define' => [
@@ -87,7 +87,7 @@ class ConfigImportTest extends BltProjectTestBase {
    * @throws \Exception
    */
   public function testCoreOnly() {
-    $this->drush("config-export --yes");
+    $this->drush(["config-export", "--yes"]);
     list($status_code) = $this->blt("drupal:config:import", [
       '--define' => [
         'cm.strategy=core-only',
@@ -104,8 +104,8 @@ class ConfigImportTest extends BltProjectTestBase {
    * @throws \Exception
    */
   public function testConfigSplit() {
-    $this->drush("pm-enable config_split --yes");
-    $this->drush("config-export --yes");
+    $this->drush(["pm-enable config_split", "--yes"]);
+    $this->drush(["config-export", "--yes"]);
     $this->fs->copy(
       $this->bltDirectory . "/scripts/blt/ci/internal/config_split.config_split.ci.yml",
       $this->sandboxInstance . "/config/default/config_split.config_split.ci.yml"

--- a/tests/phpunit/src/DrupalSettingsTest.php
+++ b/tests/phpunit/src/DrupalSettingsTest.php
@@ -35,7 +35,7 @@ class DrupalSettingsTest extends BltProjectTestBase {
       $this->assertFileExists("$this->sandboxInstance/docroot/sites/$site/local.drush.yml");
       $this->assertFileExists("$this->sandboxInstance/docroot/sites/$site/default.local.drush.yml");
 
-      $output_array = $this->drushJson('status');
+      $output_array = $this->drushJson(['status']);
       $this->assertEquals($output_array['uri'], $this->config->get('project.local.uri'));
       $drush_local_site_yml = YamlMunge::parseFile("$this->sandboxInstance/docroot/sites/$site/local.drush.yml");
       $this->assertEquals($output_array['uri'], $drush_local_site_yml['options']['uri']);

--- a/tests/phpunit/src/DrushTest.php
+++ b/tests/phpunit/src/DrushTest.php
@@ -23,7 +23,7 @@ class DrushTest extends BltProjectTestBase {
 
     foreach ($dirs as $dir) {
       chdir($dir);
-      $drush_output = $this->drushJson('status');
+      $drush_output = $this->drushJson(['status']);
 
       $config_file = $this->sandboxInstance . '/vendor/drush/drush/drush.yml';
       $message = "Failed asserting that the output of `drush status` contains $config_file when executed from $dir.";

--- a/tests/phpunit/src/SetupCommandTest.php
+++ b/tests/phpunit/src/SetupCommandTest.php
@@ -21,8 +21,8 @@ class SetupCommandTest extends BltProjectTestBase {
    * Test that config import when exported system UUID != installed UUID.
    */
   public function testChangedUuid() {
-    $this->drush("config-export --yes");
-    $this->drush("sql-drop --yes");
+    $this->drush(["config-export", "--yes"]);
+    $this->drush(["sql-drop", "--yes"]);
     list($status_code) = $this->installDrupalMinimal();
     $this->assertEquals(0, $status_code);
   }

--- a/tests/phpunit/src/SetupToggleModulesTest.php
+++ b/tests/phpunit/src/SetupToggleModulesTest.php
@@ -19,7 +19,7 @@ class SetupToggleModulesTest extends BltProjectTestBase {
   public function testModulesEnabled() {
     $env = $this->config->get('environment');
     $modules = (array) $this->config->get("modules.$env.enable");
-    $pm_list = $this->drushJson("pm:list --fields=name,status");
+    $pm_list = $this->drushJson(["pm:list", "--fields=name,status"]);
     foreach ($modules as $module) {
       $this->assertModuleEnabled($module, $pm_list);
     }


### PR DESCRIPTION
**Motivation**
Fixes #4513 to refactor our use of symfony/process throughout (given that we should be passing command arrays and not strings). 

**Proposed changes**
Significant changes to the way we execute, inspect, and test BLT when we are using the "Process" class.

**Alternatives considered**
Exploring the use of the Shell process similar to ACLI. This also would require significant refactoring and feels more hacky. 

**Testing steps**
- Confirm that ->drush and ->drushJson execution continue to function (most likely will not w/o refactoring the command into an array)
- Confirm that ->exec command execution continues to function (most likely will not w/o refactoring the command into an array)

