### PR TITLE
DX-5125: multisite context not respected in blt drupal:sync:all-sites command

### DIFF
--- a/src/Robo/Commands/Source/SettingsCommand.php
+++ b/src/Robo/Commands/Source/SettingsCommand.php
@@ -47,6 +47,7 @@ WARNING;
 
     // Reload config.
     $config_initializer = new ConfigInitializer($this->getConfigValue('repo.root'), $this->input());
+    $config_initializer->setSite($this->getConfig()->get('site'));
     $new_config = $config_initializer->initialize();
 
     // Replaces config.


### PR DESCRIPTION
**Motivation**
Fixes https://github.com/acquia/blt/issues/4535

**Proposed changes**
When setting the new config in `blt:init:settings`, grab the target site from the existing config and set it

**Alternatives considered**
There may be better approaches like ensuring the site context is passed around correctly via the `Input` object.
Related issues and discussion:
https://github.com/acquia/blt/issues/4439
https://github.com/acquia/blt/pull/4324

This approach mimicks code in the existing `BltTasks::switchSiteContext()` function.  The code from this PR (https://github.com/acquia/blt/pull/4370) is already almost an exact copy.

**Testing steps**
Reproducible steps in https://github.com/acquia/blt/issues/4535

Confirm the issue is fixed by requiring this branch of BLT via composer and following the steps linked above

**Merge requirements**
- [ ] _Bug_
- [ ] Manual testing by a reviewer
