### PR TITLE
Fixes #4541 to resolve Drush Runserver Issues and Failed Behat Tests.

### DIFF
--- a/src/Robo/Commands/Tests/ServerCommand.php
+++ b/src/Robo/Commands/Tests/ServerCommand.php
@@ -56,18 +56,8 @@ class ServerCommand extends TestsCommandBase {
     $result = $executor
       ->drush("runserver --quiet --uri=$this->serverUrl > $log_file 2>&1")
       ->background(TRUE)
+      ->printOutput(TRUE)
       ->run();
-
-    if (!$result->wasSuccessful()) {
-      $output = NULL;
-      $unsuccessful = "Failed to execute Drush runserver on $this->serverUrl";
-
-      if (file_exists($log_file)) {
-        $output = file_get_contents($log_file);
-      }
-      $executor->executeShell("tail -n 50 $log_file")->run();
-      throw new BltException($unsuccessful . "\n" . $output);
-    }
 
     try {
       $executor->waitForUrlAvailable($this->serverUrl);

--- a/src/Robo/Commands/Tests/TestsCommandBase.php
+++ b/src/Robo/Commands/Tests/TestsCommandBase.php
@@ -104,7 +104,7 @@ class TestsCommandBase extends BltTasks {
     $this->logger->info("Launching headless chrome...");
     $this->getContainer()
       ->get('executor')
-      ->execute("'$chrome_bin' --headless --no-sandbox --disable-web-security --remote-debugging-port={$this->chromePort} {$this->chromeArgs} $chrome_host")
+      ->executeShell("'$chrome_bin' --headless --no-sandbox --disable-web-security --remote-debugging-port={$this->chromePort} {$this->chromeArgs} $chrome_host")
       ->background(TRUE)
       ->printOutput(TRUE)
       ->printMetadata(TRUE)
@@ -157,7 +157,7 @@ class TestsCommandBase extends BltTasks {
    */
   protected function checkChromeVersion($bin) {
     $version = (int) $this->getContainer()->get('executor')
-      ->execute("'$bin' --version | cut -f1 -d'.' | rev | cut -f1 -d' ' | rev")
+      ->executeShell("'$bin' --version | cut -f1 -d'.' | rev | cut -f1 -d' ' | rev")
       ->run()
       ->getMessage();
 
@@ -231,7 +231,7 @@ class TestsCommandBase extends BltTasks {
     /** @var Acquia\Blt\Robo\Common\Executor $executor */
     $executor = $this->getContainer()->get('executor');
     $result = $executor
-      ->execute("$selenium_bin -port {$this->seleniumPort} -log {$this->seleniumLogFile}  > $log_file 2>&1")
+      ->executeShell("$selenium_bin -port {$this->seleniumPort} -log {$this->seleniumLogFile}  > $log_file 2>&1")
       ->background(TRUE)
       // @todo Print output when this command fails.
       ->printOutput(TRUE)

--- a/src/Robo/Commands/Tests/TestsCommandBase.php
+++ b/src/Robo/Commands/Tests/TestsCommandBase.php
@@ -104,7 +104,7 @@ class TestsCommandBase extends BltTasks {
     $this->logger->info("Launching headless chrome...");
     $this->getContainer()
       ->get('executor')
-      ->executeShell("'$chrome_bin' --headless --no-sandbox --disable-web-security --remote-debugging-port={$this->chromePort} {$this->chromeArgs} $chrome_host")
+      ->executeShell("$chrome_bin --headless --no-sandbox --disable-web-security --remote-debugging-port={$this->chromePort} {$this->chromeArgs} $chrome_host")
       ->background(TRUE)
       ->printOutput(TRUE)
       ->printMetadata(TRUE)

--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -129,6 +129,23 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
   }
 
   /**
+   * Executes a shell command.
+   *
+   * @param string $command
+   *   The shell command string.
+   *
+   * @return \Robo\Common\ProcessExecutor
+   *   The unexecuted command.
+   */
+  public function executeShell($command) {
+    $process_executor = Robo::process(Process::fromShellCommandline($command));
+    return $process_executor->dir($this->getConfigValue('repo.root'))
+      ->printOutput(FALSE)
+      ->printMetadata(FALSE)
+      ->interactive(FALSE);
+  }
+
+  /**
    * Kills all system processes that are using a particular port.
    *
    * @param string $port

--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -80,6 +80,7 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
 
     // Backwards compatibility check for legacy commands.
     if (!is_array($command)) {
+      $this->say($command);
       $this->say(StringManipulator::stringToArrayMsg());
       $command = StringManipulator::commandConvert($command);
     }
@@ -117,6 +118,7 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
   public function execute($command) {
     // Backwards compatibility check for legacy commands.
     if (!is_array($command)) {
+      $this->say($command);
       $this->say(StringManipulator::stringToArrayMsg());
       $command = StringManipulator::commandConvert($command);
     }

--- a/src/Robo/Common/StringManipulator.php
+++ b/src/Robo/Common/StringManipulator.php
@@ -115,7 +115,7 @@ class StringManipulator {
    *   The deprecation warning.
    */
   public static function stringToArrayMsg() {
-    return "Deprecation Warning: this command is passing a command string and should pass a command arary.";
+    return "Deprecation Warning: this command is passing a command string and should pass a command array.";
   }
 
 }

--- a/src/Robo/Wizards/SetupWizard.php
+++ b/src/Robo/Wizards/SetupWizard.php
@@ -29,7 +29,12 @@ class SetupWizard extends Wizard {
       if ($confirm) {
         $bin = $this->getConfigValue('composer.bin');
         $this->executor
-          ->execute("$bin/blt blt:init:settings")->printOutput(TRUE)->run();
+          ->execute([
+            "$bin/blt",
+            "blt:init:settings",
+          ])
+          ->printOutput(TRUE)
+          ->run();
       }
     }
   }
@@ -49,7 +54,10 @@ class SetupWizard extends Wizard {
       if ($confirm) {
         $bin = $this->getConfigValue('composer.bin');
         $this->executor
-          ->execute("$bin/blt setup")
+          ->execute([
+            "$bin/blt",
+            "setup",
+          ])
           ->interactive($this->input()->isInteractive())
           ->run();
         $this->getInspector()->clearState();

--- a/tests/phpunit/src/RunServerTest.php
+++ b/tests/phpunit/src/RunServerTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Acquia\Blt\Tests;
+
+/**
+ * Test blt setup.
+ */
+class RunServerTest extends BltProjectTestBase {
+
+  public function testRunServer() {
+    $this->blt("tests:server");
+  }
+
+}


### PR DESCRIPTION
**Motivation**
The refactoring of command structures that occurred in https://github.com/acquia/blt/pull/4514 ended up causing the drush runserver commands in https://github.com/acquia/blt/blob/main/src/Robo/Commands/Tests/ServerCommand.php#L55. This PR refactors that and gets it working again. 
Fixes #4541 

**Proposed changes**
- Refactor the drush execution to diverge between execute and executeShell
- Update the wasSuccessful logic for drush runserver
- Adds a test for drush runserver

**Alternatives considered**
Removing the runserver / chrome logic entirely. This was opted against since runserver is useful for things other than behat.

**Testing steps**
Confirm that blt tests will launch a server properly, specifically `lando blt tests:server:start`

