### PR TITLE
Fixes #4558: Error in commit-msg hooks

### DIFF
--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -3,15 +3,15 @@
 echo "Executing .git/hooks/commit-msg...\n";
 $repo_root = getcwd();
 
-$original_argv = $_SERVER['argv'];
+$original_argv = $argv;
 $commit_msg = rtrim(file_get_contents($original_argv[1]), "\n");
 
 // Construct pseudo `blt commit-msg $commit_msg` call.
-$_SERVER['argv'] = [
+$argv = [
   $repo_root . '/bin/blt',
   'internal:git-hook:execute:commit-msg',
   $commit_msg,
 ];
-$_SERVER['argc'] = count($_SERVER['argv']);
+$argc = count($argv);
 
 require __DIR__ . '/../../bin/blt-robo.php';


### PR DESCRIPTION
**Motivation**
The bug identified in #4558 is related to other superglobal refactoring in https://github.com/acquia/blt/blob/main/bin/blt-robo-run.php. This just puts the commit-msg script in-sync with the previous changes.

**Proposed changes**
Replace superglobals.

**Testing steps**
- Ensure that the git hooks are placed by running `blt blt:init:git-hooks`
- Make a commit / amend a commit and confirm that the hook fires properly. there should be no error like `Command ".git/COMMIT_EDITMSG" is not defined.`
