### PR TITLE
Update drush executor uri check

### DIFF
--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -82,8 +82,8 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
 
     // URIs do not work on remote drush aliases in Drush 9. Instead, it is
     // expected that the alias define the uri in its configuration.
-    if ($this->getConfigValue('drush.alias') != 'self') {
-      $drush_array[] = ' --uri=' . $this->getConfigValue('site');
+    if ($this->getConfigValue('site') !== 'default') {
+      $drush_array[] = '--uri=' . $this->getConfigValue('drush.uri');
     }
 
     if (is_array($command)) {

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -189,8 +189,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    */
   public function isDrupalInstalled() {
     $this->logger->debug("Verifying that Drupal is installed...");
-    $uri = $this->getConfigValue('drush.uri');
-    $result = $this->executor->drush(["--uri=$uri", "status", "bootstrap"])->run();
+    $result = $this->executor->drush(["status", "bootstrap"])->run();
     $output = trim($result->getMessage());
     $installed = $result->wasSuccessful() && strpos($output, 'Drupal bootstrap : Successful') !== FALSE;
     $this->logger->debug("Drupal bootstrap results: $output");

--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -614,6 +614,8 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
   public function isActiveConfigIdentical() {
     $result = $this->executor->drush(["config:status"])->run();
     $message = trim($result->getMessage());
+    $this->logger->debug("Config status check results:");
+    $this->logger->debug($message);
 
     // A successful test here results in "no message" so check for null.
     if ($message == NULL) {


### PR DESCRIPTION
**Motivation**
Solves issue where different site is compared than the site original check on config-status. 
Fixes #4561

**Proposed changes**
Wider solution also to correctly set the `--uri` in the Executor drush function so that ALL executions will have `--uri` preloaded and it will not need to be added to individual functions.
This PR changes the check of the drush alias to check that the site is not default. Sets the drush_array to include the `--uri` from the config value.
Also changed is removing the redundant check (no longer necessary by virtue of change above) in the inspector `isDrupalInstalled` function.
Added is the debug logging for the actual status difference so that when users are running in verbose mode and the inspector  `isActiveConfigIdentical` contains a difference, the user will know exactly what that difference being returned is without having to make additional calls to find that difference. (In the case of this bug, it was not the same as calling the drush command directly, which made finding the issue to be more difficult.)

This should not impact users or require any additional changes to user code or blt code.


**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
The `--uri` check could have been added back to inspector function, but that is less efficient than providing it for all executed drush functions and removing redundancies.

**Testing steps**
Issue #4561 contains testing steps.
