### PR TITLE
DX-5153: Add support for custom Twig tests in the Twig validator.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -270,10 +270,12 @@ validate:
   twig:
     filesets:
       - files.twig
-    # Add any custom Twig filters for linter to ignore.
+    # Add any custom Twig filters for linter to allow.
     filters: { }
-    # Add any custom Twig functions for linter to ignore.
+    # Add any custom Twig functions for linter to allow.
     functions: { }
+    # Add any custom Twig tests for linter to allow.
+    tests: { }
   yaml:
     filesets:
       - files.yaml

--- a/src/Robo/Commands/Validate/TwigCommand.php
+++ b/src/Robo/Commands/Validate/TwigCommand.php
@@ -11,6 +11,7 @@ use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Twig\TwigTest;
 
 /**
  * Defines commands in the "validate:twig:lint:all*" namespace.
@@ -143,6 +144,19 @@ class TwigCommand extends BltTasks {
       // @see \TwigNode_Expression_Call::getArguments
       // @see \TwigNode_Expression_Call::call()
       $twig->addFunction(new TwigFunction($function, function (array $args = []) {}, [
+        'is_variadic' => TRUE,
+      ]));
+    }
+
+    // Get any custom defined Twig tests to be allowed by linter.
+    $twig_tests = (array) $this->getConfigValue('validate.twig.tests', []);
+
+    foreach ($twig_tests as $test) {
+      // Add default argument and set to variadic so that tests with named
+      // arguments will be whitelisted.
+      // @see \TwigNode_Expression_Call::getArguments
+      // @see \TwigNode_Expression_Call::call()
+      $twig->addTest(new TwigTest($test, function ($value = '', array $args = []) {}, [
         'is_variadic' => TRUE,
       ]));
     }


### PR DESCRIPTION
Fixes #4579

**Testing steps**

1. Add the following code to an existing Twig template:
    ```twig
    <div>{{ myvar is instanceof('\\MyInterface') ? 'yes' : 'no' }}</div>
    ```
2. Run the Twig validation. This is expected to throw an error because the `instanceof` test is not part of core Twig:
    ```sh
    $ blt validate:twig
    ERROR  in /app/docroot/themes/custom/mytheme/templates/mytemplate.html.twig
    >> Unknown "instanceof" test.
    ```
3. Now edit `blt.yml` and add `instanceof` to the whitelisted Twig tests by adding the following section:
    ```yaml
    validate:
      twig:
        tests:
          - instanceof
    ```
4. Run the validation again. Now there should not be any errors.
    ```sh
    $ blt validate:twig
    [OK] All 235 Twig files contain valid syntax.
    ```