### PR TITLE
Add support for drush's deploy hook.

### DIFF
--- a/src/Robo/Commands/Drupal/ConfigCommand.php
+++ b/src/Robo/Commands/Drupal/ConfigCommand.php
@@ -186,7 +186,8 @@ class ConfigCommand extends BltTasks {
 
   /**
    * Runs drush's deploy hook.
-   * See: https://www.drush.org/latest/commands/deploy_hook/.
+   *
+   * @see https://www.drush.org/latest/commands/deploy_hook/
    *
    * @command drupal:deploy:hook
    *

--- a/src/Robo/Commands/Drupal/ConfigCommand.php
+++ b/src/Robo/Commands/Drupal/ConfigCommand.php
@@ -41,6 +41,7 @@ class ConfigCommand extends BltTasks {
     }
 
     $this->invokeCommand('drupal:config:import');
+    $this->invokeCommand('drupal:deploy:hook');
   }
 
   /**
@@ -181,6 +182,29 @@ class ConfigCommand extends BltTasks {
     }
 
     return NULL;
+  }
+
+  /**
+   * Runs drush's deploy hook.
+   * See: https://www.drush.org/latest/commands/deploy_hook/.
+   *
+   * @command drupal:deploy:hook
+   *
+   * @throws \Robo\Exception\TaskException
+   * @throws \Acquia\Blt\Robo\Exceptions\BltException
+   */
+  public function deployHook(): void {
+    $task = $this->taskDrush()
+      ->stopOnFail()
+      // Execute drush's deploy:hook. This runs "deploy" functions.
+      // These are one-time functions that run AFTER config is imported.
+      // See:
+      ->drush("deploy:hook");
+
+    $result = $task->run();
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Failed to run deploy:hook!");
+    }
   }
 
 }

--- a/src/Robo/Commands/Drupal/ConfigCommand.php
+++ b/src/Robo/Commands/Drupal/ConfigCommand.php
@@ -198,12 +198,11 @@ class ConfigCommand extends BltTasks {
       ->stopOnFail()
       // Execute drush's deploy:hook. This runs "deploy" functions.
       // These are one-time functions that run AFTER config is imported.
-      // See:
       ->drush("deploy:hook");
 
     $result = $task->run();
     if (!$result->wasSuccessful()) {
-      throw new BltException("Failed to run deploy:hook!");
+      throw new BltException("Failed to run 'drush deploy:hook'!");
     }
   }
 


### PR DESCRIPTION
**Motivation**
In certain cases we want to run update hooks that need to happen after updatedb and config:import have ran. E.g to update content after new fields have been added to a content type. Or to update module configuration that do not use drupal's configuration api and as such their configuration is not captured by the config management system.

**Proposed changes**
Drush provides a hook we can implement to facilitate such changes which runs when invoking `drush deploy` or `drush deploy:hook`. See: 
- https://www.drush.org/latest/commands/deploy_hook/ 
- https://github.com/drush-ops/drush/blob/master/tests/functional/resources/modules/d8/woot/woot.deploy.php
- https://github.com/drush-ops/drush/pull/4359

**Alternatives considered**
BLT's native "[post-config-import](https://docs.acquia.com/blt/extending-blt/#pre-and-post-command-hooks)" command.
- Not every project is running BLT and customers adopting BLT may already be used to running their drush deploy hooks since that's a more prevalent Drupal tool in the community.

**Testing steps**
- Implement a deploy hook as shown in the 2nd bullet point above. 
- Apply the patch from this PR.
- Run `blt drupal:update`

Related issue: #4522 