### PR TITLE
Fixes #4626 removes trailing && from build.

### DIFF
--- a/config/build.yml
+++ b/config/build.yml
@@ -7,7 +7,7 @@ behat:
     # - ${docroot}/modules
     # - ${docroot}/profiles
     - ${repo.root}/tests/behat
-  tags: '~ajax&&~experimental&&'
+  tags: '~ajax&&~experimental'
   extra: ''
   validate: true
   # May be chrome, selenium.


### PR DESCRIPTION
Accidentally left trailing && in the build file.