### PR TITLE
Fixes #4609 to refactor runserver command.

### DIFF
--- a/src/Robo/Commands/Tests/ServerCommand.php
+++ b/src/Robo/Commands/Tests/ServerCommand.php
@@ -54,7 +54,7 @@ class ServerCommand extends TestsCommandBase {
     /** @var \Acquia\Blt\Robo\Common\Executor $executor */
     $executor = $this->getContainer()->get('executor');
     $result = $executor
-      ->drush("runserver --quiet --uri=$this->serverUrl > $log_file 2>&1")
+      ->drush("runserver --quiet $this->serverUrl > $log_file 2>&1")
       ->background(TRUE)
       ->printOutput(TRUE)
       ->run();


### PR DESCRIPTION
**Motivation**
Fixes #4609 to remove the --uri option from the `drush runserver` command. 
 
**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
