### PR TITLE
Fixes #4632 comment to indicate where Acquia include file is set

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -86,6 +86,8 @@ $site_name = EnvironmentDetector::getSiteName($site_path);
 if (EnvironmentDetector::isAhEnv()) {
   try {
     if (!EnvironmentDetector::isAcsfEnv()) {
+      // Pull in Acquia environment settings file
+      // Note: this eliminates the need to add the Acquia require line in settings.php
       $settings_files[] = FilePaths::ahSettingsFile(EnvironmentDetector::getAhGroup(), $site_name);
     }
   }


### PR DESCRIPTION
I ran a Drutiny report for a site, and the Drutiny report issued a warning that the Acquia Require Line was missing from settings.php, as per [docs.acquia.com/cloud-platform/manage/code/require-line](https://docs.acquia.com/cloud-platform/manage/code/require-line/)

I did some investigating and saw that the site was using BLT, and since the site was "working", I assumed that BLT must be pulling in the environment's settings file, e.g., '/var/www/site-php/' . $_ENV['AH_SITE_GROUP'] . '/' . $_ENV['AH_SITE_GROUP'] . '-settings.inc'

However in looking through BLT's settings, specifically blt.settings.php, it is not obvious where that settings.inc file is being pulled in.

I think it would be helpful (and harmless) to add an extra comment to blt.settings.php to indicate the line where it is pulling in the Acquia environment settings file (/var/www/site-php/' . $_ENV['AH_SITE_GROUP'] . '/' . $_ENV['AH_SITE_GROUP'] . '-settings.inc' file), much like we do for the secret.settings.php files a few lines below.