### PR TITLE
Guzzle 7 Breaks Run-server Command

### DIFF
--- a/src/Robo/Common/Executor.php
+++ b/src/Robo/Common/Executor.php
@@ -244,7 +244,7 @@ class Executor implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInt
       $res = $client->request('GET', $url, [
         'connection_timeout' => 2,
         'timeout' => 2,
-        'exceptions' => FALSE,
+        'http_errors' => FALSE,
       ]);
       if ($res->getStatusCode() && substr($res->getStatusCode(), 0, 1) != '5') {
         return TRUE;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #4656
We noticed that the run-server command constantly fails on our Travis build after upgrading to Drupal 10. After looking into the code, we found that the `exceptions` used in the `checkUrl` method is no longer respected in Guzzle 7 and causing a client error to be thrown when curl returns a 404 response .

![image](https://user-images.githubusercontent.com/13445723/219493605-90326df3-b051-4c9e-85d2-7de9088f5c5c.png)

The option was deprecated in Guzzle 6 and was removed in 7 according to this PR https://github.com/guzzle/guzzle/pull/2464 (I don't see the option being marked deprecated anywhere)

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

Switch to use the new option `http_errors`. The option was introduced in Guzzle 6, so it should be safe to use without changing anything in the `composer.json` file as Guzzle 6 was the minimum version required by Drupal 9.

**Testing steps**
1. Set up a Drupal 10 site with BLT.
2. Run ` blt tests:server:start -vvvv`.