### PR TITLE
Replace abandoned composer package 'webmozart/path-util'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "loophp/phposinfo": "^1.7.1",
         "symfony/config": "^4.4 || ^6",
         "symfony/console": "^4.4.6 || ^6",
+        "symfony/filesystem": "^5.4 || ^6",
         "symfony/twig-bridge": "^3.4 || ^4 || ^5 || ^6",
         "symfony/yaml": "^4.4 || ^5 || ^6"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "symfony/config": "^4.4 || ^6",
         "symfony/console": "^4.4.6 || ^6",
         "symfony/twig-bridge": "^3.4 || ^4 || ^5 || ^6",
-        "symfony/yaml": "^4.4 || ^5 || ^6",
-        "webmozart/path-util": "^2.3"
+        "symfony/yaml": "^4.4 || ^5 || ^6"
     },
     "conflict": {
         "acquia/blt-behat": "<=1.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32cbfb16c84848702738c7ca897695c0",
+    "content-hash": "2c8d84722fb5d6bd811f4c04104652e2",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -4199,16 +4199,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.19",
+            "version": "v5.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "648bfaca6a494f3e22378123bcee2894045dc9d8"
+                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/648bfaca6a494f3e22378123bcee2894045dc9d8",
-                "reference": "648bfaca6a494f3e22378123bcee2894045dc9d8",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
+                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
                 "shasum": ""
             },
             "require": {
@@ -4243,7 +4243,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.19"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.21"
             },
             "funding": [
                 {
@@ -4259,7 +4259,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T19:14:44+00:00"
+            "time": "2023-02-14T08:03:56+00:00"
         },
         {
             "name": "symfony/finder",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f589ca39846c2116c882b5c786752c71",
+    "content-hash": "32cbfb16c84848702738c7ca897695c0",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",
@@ -6704,115 +6704,6 @@
                 "source": "https://github.com/webflo/drupal-finder/tree/1.2.2"
             },
             "time": "2020-10-27T09:42:17+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
-            },
-            "time": "2022-06-03T18:03:27+00:00"
-        },
-        {
-            "name": "webmozart/path-util",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/path-util.git",
-                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
-                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "webmozart/assert": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\PathUtil\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
-            "support": {
-                "issues": "https://github.com/webmozart/path-util/issues",
-                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
-            },
-            "abandoned": "symfony/filesystem",
-            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -10,6 +10,7 @@ use Acquia\Blt\Update\Updater;
 use Robo\Contract\VerbosityThresholdInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Defines commands for installing and updating BLT..
@@ -119,8 +120,7 @@ class UpdateCommand extends BltTasks {
    */
   public function initGitignore() {
     $gitignore = [];
-    $filesystem = new Filesystem();
-    $gitignore_file = $filesystem->tempnam($this->getConfigValue('repo.root'), '', '.gitignore');
+    $gitignore_file = Path::join($this->getConfigValue('repo.root'), '.gitignore');
     if (file_exists($gitignore_file)) {
       $gitignore = file($gitignore_file, FILE_IGNORE_NEW_LINES);
     }

--- a/src/Robo/Commands/Blt/UpdateCommand.php
+++ b/src/Robo/Commands/Blt/UpdateCommand.php
@@ -10,7 +10,6 @@ use Acquia\Blt\Update\Updater;
 use Robo\Contract\VerbosityThresholdInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
 
 /**
  * Defines commands for installing and updating BLT..
@@ -120,7 +119,8 @@ class UpdateCommand extends BltTasks {
    */
   public function initGitignore() {
     $gitignore = [];
-    $gitignore_file = Path::join($this->getConfigValue('repo.root'), '.gitignore');
+    $filesystem = new Filesystem();
+    $gitignore_file = $filesystem->tempnam($this->getConfigValue('repo.root'), '', '.gitignore');
     if (file_exists($gitignore_file)) {
       $gitignore = file($gitignore_file, FILE_IGNORE_NEW_LINES);
     }


### PR DESCRIPTION
**Motivation**
Fixes #4669 . As outlined in the [projects deprecation notice](https://github.com/webmozart/path-util#deprecation) this should be replaced with the symfony filesystem component.

**Proposed changes**
Replaces the method used from the `Path` utility from `webmozart/path-util` with a replacement method from the `symfony/filesystem` component. Removes the composer direct dependency on the abandoned project.

**Testing steps**
Ensure the `blt internal:add-to-project` command successfully adds custom blt related files to the expected `.gitignore` file within the configured project `repo.root` directory.