### PR TITLE
BLT-4677: Add EnvironmentDetector for acquia cloud IDE.

### DIFF
--- a/settings/blt.settings.php
+++ b/settings/blt.settings.php
@@ -138,7 +138,7 @@ if (EnvironmentDetector::isCiEnv()) {
 }
 
 // Local global and site-specific settings.
-if (EnvironmentDetector::isLocalEnv()) {
+if (EnvironmentDetector::isLocalEnv() || EnvironmentDetector::isAhIdeEnv()) {
   $settings_files[] = DRUPAL_ROOT . '/sites/settings/local.settings.php';
   $settings_files[] = DRUPAL_ROOT . "/sites/$site_name/settings/local.settings.php";
 }


### PR DESCRIPTION
**Motivation**
Issue link: https://github.com/acquia/blt/issues/4677
BLT-5213: local.settings.php is not detecting on Acquia cloud IDE.

Fixes #4677 

**Proposed changes**
Adds a check to IDE Environment Detector and set path to local.settings.php file.


**Testing steps**

- Create an IDE on Acquia cloud.
- Setup the project on Acquia cloud with BLT.
- Make changes to local.settings.php. Example change the database settings or add site studio keys.
- Verify the changes reflect.
