### PR TITLE
ORCA-535: Allow drush 12.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "dflydev/dot-access-data": "^1.1.0 || ^2 || ^3",
         "doctrine/annotations": "^1.10.0",
         "drupal/core": "^9.0.0-alpha1 || ^10.0.0-alpha1",
-        "drush/drush": "^11",
+        "drush/drush": "^11 || ^12",
         "enlightn/security-checker": "^1.3",
         "grasmash/yaml-cli": "^2.0.0 || ^3.0.0",
         "grasmash/yaml-expander": "^3.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "935e1d6fe57036f6bdabda1f8314c2bb",
+    "content-hash": "40d7a25c2e9f012a061b7d20098fc83c",
     "packages": [
         {
             "name": "acquia/drupal-environment-detector",


### PR DESCRIPTION
Details in [ORCA-535](https://backlog.acquia.com/browse/ORCA-535) : Allow `drush 12.x` installations to make ORCA `dev` tests work.

