### PR TITLE
adds null coalescing operator check for bootstrap key index

### DIFF
--- a/src/Robo/Inspector/Inspector.php
+++ b/src/Robo/Inspector/Inspector.php
@@ -189,7 +189,7 @@ class Inspector implements BuilderAwareInterface, ConfigAwareInterface, Containe
    */
   public function isDrupalInstalled() {
     $this->logger->debug("Verifying that Drupal is installed...");
-    $output = $this->getDrushStatus()['bootstrap'];
+    $output = $this->getDrushStatus()['bootstrap'] ?? '';
     $installed = $output === 'Successful';
     $this->logger->debug("Drupal bootstrap results: $output");
 


### PR DESCRIPTION
Fixes issue for inspector check for installed Drupal bootstrap value when not installed and no value is returned.

**Motivation**
Fixes #4684 

**Proposed changes**
Add null coalescing operator to check for key existence when Drupal is not install and there is no bootstrap value.


**Testing steps**
Running any command on a Drupal site that does not yet have Drupal installed. It will no longer show the php warning message.
