### PR TITLE
Add BLT to ORCA fixtures

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -19,6 +19,7 @@ jobs:
       ORCA_JOB: ${{ matrix.orca-job }}
       ORCA_COVERALLS_ENABLE: ${{ matrix.coveralls-enable }}
       COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ORCA_PACKAGES_CONFIG_ALTER: ../blt/tests/packages_alter.yml
     strategy:
       matrix:
         orca-job:

--- a/tests/packages_alter.yml
+++ b/tests/packages_alter.yml
@@ -1,0 +1,4 @@
+acquia/blt:
+  type: composer-plugin
+  version: 13.x
+  version_dev: 13.x-dev


### PR DESCRIPTION
**Motivation**
ORCA removed BLT from its integrated fixtures, so we need to add BLT back using its own packages_alter so that it continues to be tested with ORCA.
