### PR TITLE
ORCA-557: Enable Domo integration

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -20,6 +20,10 @@ jobs:
       ORCA_COVERALLS_ENABLE: ${{ matrix.coveralls-enable }}
       COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ORCA_PACKAGES_CONFIG_ALTER: ../blt/tests/packages_alter.yml
+      # Google env variables.
+      ORCA_GOOGLE_API_CLIENT_ID: ${{ secrets.ORCA_GOOGLE_API_CLIENT_ID }}
+      ORCA_GOOGLE_API_CLIENT_SECRET: ${{ secrets.ORCA_GOOGLE_API_CLIENT_SECRET }}
+      ORCA_GOOGLE_API_REFRESH_TOKEN: ${{ secrets.ORCA_GOOGLE_API_REFRESH_TOKEN }}
     strategy:
       matrix:
         orca-job:


### PR DESCRIPTION
Motivation
This is to add all the required credentials to enable ORCA to send test results to Domo.