### PR TITLE
Allow early setting of hash_salt

### DIFF
--- a/settings/misc.settings.php
+++ b/settings/misc.settings.php
@@ -22,7 +22,9 @@
  *   $settings['hash_salt'] = file_get_contents('/home/example/salt.txt');
  * @endcode
  */
-$settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
+if (empty($settings['hash_salt']) {
+  $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
+}
 
 /**
  * Deployment identifier.


### PR DESCRIPTION
**Motivation**
This would allow acquia#4291 so that a previously-set hash salt (for example, from the Acquia require line, or from the new "early settings" file) to be used instead of the BLT-defined one.

**Proposed changes**
Only set hash salt from the salt.txt file if $settings['hash_salt'] is empty (unset or empty string).

**Alternatives considered**
Acquia customers need to manually edit their settings.php to re-set a unique hash_salt because BLT "undoes" that unique-hashsalt-setting done in the acquia require line logic.

**Testing steps**
Set a hash_salt value in settings.php before the BLT require line, and then check with 

```
drush --uri=[example.com](http://example.com/) php-eval 'echo \Drupal\Core\Site\Settings::getHashSalt();'
```

that the hash_salt is respected instead of set to the salt.txt value.
