### PR TITLE
#4690 - Remove drush clear-cache drush from SyncCommand as drush doesn't have cache anymore

### DIFF
--- a/src/Robo/Commands/Drupal/SyncCommand.php
+++ b/src/Robo/Commands/Drupal/SyncCommand.php
@@ -162,7 +162,6 @@ class SyncCommand extends BltTasks {
 
     $task = $this->taskDrush()
       ->alias('')
-      ->drush('cache-clear drush')
       ->drush('sql-sync')
       ->arg($remote_alias)
       ->arg($local_alias)


### PR DESCRIPTION
**Motivation**
Fixes [#4690](https://github.com/acquia/blt/issues/4690)

**Proposed changes**
Removes the cache-clear drush from SyncCommand

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
Create a Drupal project
DO NOT install the database
Configure BLT aliases, etc
Run `blt sync:drupal:db`
