### PR TITLE
#4701: Add back PHP code sniffing in pre-commit hook

### DIFF
--- a/src/Robo/Commands/Internal/GitCommand.php
+++ b/src/Robo/Commands/Internal/GitCommand.php
@@ -63,6 +63,7 @@ class GitCommand extends BltTasks {
     $collection->addCode(
       function () use ($changed_files) {
         return $this->invokeCommands([
+          'validate:phpcs:staged' => [], 
           'validate:twig:lint:files' => ['file_list' => $changed_files],
           'validate:yaml:lint:files' => ['file_list' => $changed_files],
         ]);


### PR DESCRIPTION
PHP code sniffing was removed from the pre-commit hook in https://github.com/acquia/blt/commit/552ff157a6b6de3c11207ed505a4ea5ca7b7053e. This commit adds it back to the pre-commit hook. Unless there is a reason not to - it's unclear why it was removed, there is no issue referenced on the commit where it was removed.