### PR TITLE
BLT-5231: Update default exception handling

### DIFF
--- a/settings/default.local.settings.php
+++ b/settings/default.local.settings.php
@@ -6,7 +6,6 @@
  */
 
 use Acquia\Blt\Robo\Common\EnvironmentDetector;
-use Drupal\Component\Assertion\Handle;
 
 $db_name = '${drupal.db.database}';
 
@@ -46,7 +45,7 @@ $settings['update_free_access'] = TRUE;
  * @see https://wiki.php.net/rfc/expectations
  */
 assert_options(ASSERT_ACTIVE, TRUE);
-Handle::register();
+assert_options(ASSERT_EXCEPTION, TRUE);
 
 /**
  * Show all error messages, with backtrace information.


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes [#5231](https://github.com/acquia/blt/issues/4726) relating to the CR here - https://www.drupal.org/node/3105918

**Proposed changes**
Removes use of deprecated class to prevent notices being thrown and breaking `install.php`.

**Alternatives considered**
n/a

**Testing steps**
Create a project using BLT and try visiting `install.php` - if no deprecation notice is shown then all is well.
