### PR TITLE
Updated ah_other logic to prevent config split from being set on local.

### DIFF
--- a/src/Robo/Common/EnvironmentDetector.php
+++ b/src/Robo/Common/EnvironmentDetector.php
@@ -316,7 +316,7 @@ class EnvironmentDetector extends AcquiaDrupalEnvironmentDetector {
       'prod' => self::isProdEnv(),
       'ci' => self::isCiEnv(),
       'ode' => self::isAhOdeEnv(),
-      'ah_other' => self::isAhEnv() && !self::isDevEnv() && !self::isStageEnv() && !self::isAhOdeEnv() && !self::isProdEnv(),
+      'ah_other' => self::isAhEnv() && !self::isLocalEnv() && !self::isDevEnv() && !self::isStageEnv() && !self::isAhOdeEnv() && !self::isProdEnv(),
     ];
   }
 


### PR DESCRIPTION

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

When using lando for local development, an environment variable is set (**AH_SITE_ENVIRONMENT = LANDO**) denoting the usage of lando. This causes **isAhEnv** to return true. For most cases, this works just fine but the config split for ah_other gets enabled locally.


**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->
Include isLocalEnv() check for ah_other config split logic.

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
