### PR TITLE
RCAT-684 | Enable D11 jobs

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -119,11 +119,11 @@ jobs:
   all-successful:
     if: always()
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [ build ]
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
-    - name: All checks successful
-      run: echo "🎉"
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+      - name: All checks successful
+        run: echo "🎉"

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -49,6 +49,18 @@ jobs:
         coveralls-enable: [ "FALSE" ]
         orca-version: [ "^4" ]
         include:
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.3"
+
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.3"
+
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.3"
+
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.3"
+
           - orca-job: INTEGRATED_TEST_ON_LATEST_LTS
             php-version: "8.2"
             coveralls-enable: "FALSE"
@@ -59,16 +71,6 @@ jobs:
 
           - orca-job: ISOLATED_TEST_ON_CURRENT
             php-version: "8.2"
-
-          # Testing Drupal 11 in php 8.3.
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.3"
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.3"
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.3"
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-            php-version: "8.3"
 
           # - orca-job: ISOLATED_TEST_ON_CURRENT
           #   php-version: "8.0"

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 0 * * *"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       ORCA_SUT_NAME: acquia/blt
       ORCA_SUT_BRANCH: main
@@ -45,7 +45,7 @@ jobs:
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
-        php-version: [ "8.1" ]
+        php-version: [ "8.1" , "8.3" ]
         coveralls-enable: [ "FALSE" ]
         orca-version: [ "^4" ]
         include:
@@ -59,18 +59,17 @@ jobs:
 
           - orca-job: ISOLATED_TEST_ON_CURRENT
             php-version: "8.2"
-          # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          #   php-version: "8.1"
-          #   coveralls-enable: "FALSE"
-          # - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          #   php-version: "8.1"
-          #   coveralls-enable: "FALSE"
-          # - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-          #   php-version: "8.1"
-          #   coveralls-enable: "FALSE"
-          # - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
-          #   php-version: "8.1"
-          #   coveralls-enable: "FALSE"
+
+          # Testing Drupal 11 in php 8.3.
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.3"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.3"
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.3"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.3"
+
           # - orca-job: ISOLATED_TEST_ON_CURRENT
           #   php-version: "8.0"
           #   coveralls-enable: "FALSE"


### PR DESCRIPTION
Motivation
Enables jobs to test D11 readiness [RCAT-684](https://acquia.atlassian.net/browse/RCAT-684)

Proposed changes
Following jobs are added for D11 with php8.3 -

- ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
- INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
- ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
- INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER